### PR TITLE
chore: rebrand to tonone.ai — engineering second to none

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,9 +1,9 @@
 {
-  "name": "thisisfatih",
+  "name": "tonone-ai",
   "description": "Engineering Team - Claude Code agents that work as specialized engineers",
   "owner": {
-    "name": "thisisfatih",
-    "url": "https://github.com/thisisfatih"
+    "name": "tonone-ai",
+    "url": "https://tonone.ai"
   },
   "plugins": [
     {
@@ -12,8 +12,8 @@
       "version": "0.1.0",
       "source": "./cloud-architecture/cloud-run-specialist",
       "author": {
-        "name": "thisisfatih",
-        "url": "https://github.com/thisisfatih"
+        "name": "tonone-ai",
+        "url": "https://tonone.ai"
       }
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,10 +3,10 @@
   "description": "Elite engineering team — 1 lead + 12 specialists as Claude Code agents. Infrastructure, DevOps, backend, data, security, observability, frontend, ML/AI, mobile, embedded, knowledge, and analytics.",
   "version": "0.2.0",
   "author": {
-    "name": "thisisfatih",
-    "url": "https://github.com/thisisfatih"
+    "name": "tonone-ai",
+    "url": "https://tonone.ai"
   },
-  "repository": "https://github.com/thisisfatih/eng-team",
+  "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "keywords": [
     "agents",

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 thisisfatih
+Copyright (c) 2026 tonone-ai
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/PLAN.md
+++ b/PLAN.md
@@ -3,8 +3,8 @@
 ## All Steps Complete
 
 - [x] **1. Lower Python to >=3.10** in both pyproject.toml
-- [x] **2. Fix LICENSE** copyright holder → thisisfatih
-- [x] **3. Fix pyproject.toml URLs** → github.com/thisisfatih/eng-team
+- [x] **2. Fix LICENSE** copyright holder → tonone-ai
+- [x] **3. Fix pyproject.toml URLs** → github.com/tonone-ai/tonone
 - [x] **4. Add classifiers** for Python 3.10-3.13
 - [x] **5. Fix sys.argv mutation** → cli.py accepts argv param, install.py uses parse_known_args
 - [x] **6. Fix bare `except Exception`** → specific handlers + `--verbose` traceback + fallback hint
@@ -28,7 +28,7 @@
 - [ ] `pip install` from TestPyPI works
 - [ ] README renders correctly on PyPI
 - [ ] Initial git commit + tag v0.1.0
-- [ ] Create GitHub repo: github.com/thisisfatih/eng-team
+- [ ] Create GitHub repo: github.com/tonone-ai/tonone
 - [ ] Push to GitHub
 - [ ] Publish to PyPI
 - [ ] Verify: `pip install cloudrun-agent && cloudrun-agent install` works

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Engineering Team
+# Tonone
 
-Elite engineering team as [Claude Code](https://docs.anthropic.com/en/docs/claude-code) agents. 1 lead + 12 specialists. 68 skills. Every major engineering discipline covered.
+**Engineering second to none.**
+
+Your elite engineering team as [Claude Code](https://docs.anthropic.com/en/docs/claude-code) agents. 1 lead + 12 specialists. 68 skills. Every major engineering discipline covered.
 
 Simplicity is king. Scalability is best friend.
 
@@ -27,16 +29,16 @@ Simplicity is king. Scalability is best friend.
 ### Install the whole team
 
 ```
-/plugin marketplace add thisisfatih/eng-team
-/plugin install eng-team@thisisfatih
+/plugin marketplace add tonone-ai/tonone
+/plugin install eng-team@tonone-ai
 ```
 
 ### Or install individual agents
 
 ```
-/plugin install forge@thisisfatih
-/plugin install spine@thisisfatih
-/plugin install warden@thisisfatih
+/plugin install forge@tonone-ai
+/plugin install spine@tonone-ai
+/plugin install warden@tonone-ai
 ```
 
 ### Then just talk to them

--- a/docs/superpowers/plans/2026-03-16-plugin-migration.md
+++ b/docs/superpowers/plans/2026-03-16-plugin-migration.md
@@ -67,7 +67,7 @@
 
 ```json
 {
-  "name": "thisisfatih",
+  "name": "tonone-ai",
   "description": "Engineering Team - Claude Code agents that work as specialized engineers",
   "plugins": {
     "cloud-run-specialist": {
@@ -95,10 +95,10 @@ Write to `cloud-architecture/cloud-run-specialist/.claude-plugin/plugin.json`:
   "version": "0.1.0",
   "description": "Audit Cloud Run fleet: resource waste, performance, pricing, traffic, security",
   "author": {
-    "name": "thisisfatih",
-    "url": "https://github.com/thisisfatih"
+    "name": "tonone-ai",
+    "url": "https://github.com/tonone-ai"
   },
-  "repository": "https://github.com/thisisfatih/eng-team",
+  "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "keywords": ["gcp", "cloud-run", "audit", "infrastructure"]
 }
@@ -184,8 +184,8 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/thisisfatih/eng-team"
-Issues = "https://github.com/thisisfatih/eng-team/issues"
+Homepage = "https://github.com/tonone-ai/tonone"
+Issues = "https://github.com/tonone-ai/tonone/issues"
 
 [project.scripts]
 cloudrun-agent = "cloudrun_agent.cli:main"
@@ -449,7 +449,7 @@ def test_agent_entry_has_plugin_fields():
     assert hasattr(agent, "plugin_name")
     assert hasattr(agent, "marketplace")
     assert agent.plugin_name == "cloud-run-specialist"
-    assert agent.marketplace == "thisisfatih/eng-team"
+    assert agent.marketplace == "tonone-ai/tonone"
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
@@ -486,7 +486,7 @@ AGENTS: tuple[AgentEntry, ...] = (
         team="cloud-architecture",
         pypi_package="cloudrun-agent",
         plugin_name="cloud-run-specialist",
-        marketplace="thisisfatih/eng-team",
+        marketplace="tonone-ai/tonone",
         description="Audit Cloud Run fleet: resource waste, performance, pricing, traffic, security",
         skills=(
             "/cloudrun-dashboard",
@@ -574,8 +574,8 @@ Edit the else block at the bottom of `main()` (around line 197) to show both ins
     else:
         print(_header())
         print("Install (plugin - recommended):")
-        print(f"  /plugin marketplace add thisisfatih/eng-team")
-        print(f"  /plugin install cloud-run-specialist@thisisfatih")
+        print(f"  /plugin marketplace add tonone-ai/tonone")
+        print(f"  /plugin install cloud-run-specialist@tonone-ai")
         print()
         print("Install (pip):")
         print("  engteam list                    Browse available agents")
@@ -738,10 +738,10 @@ Write to `templates/new-agent/.claude-plugin/plugin.json`:
   "version": "0.1.0",
   "description": "AGENT_DESCRIPTION",
   "author": {
-    "name": "thisisfatih",
-    "url": "https://github.com/thisisfatih"
+    "name": "tonone-ai",
+    "url": "https://github.com/tonone-ai"
   },
-  "repository": "https://github.com/thisisfatih/eng-team",
+  "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "keywords": []
 }
@@ -903,8 +903,8 @@ AGENT_DESCRIPTION
 
 ```bash
 # In Claude Code (recommended):
-/plugin marketplace add thisisfatih/eng-team
-/plugin install AGENT_SLUG@thisisfatih
+/plugin marketplace add tonone-ai/tonone
+/plugin install AGENT_SLUG@tonone-ai
 
 # Or via pip:
 pip install AGENT_PYPI_NAME
@@ -952,8 +952,8 @@ Update the root `README.md` to show plugin install as primary. Key changes:
 Install the Cloud Run Specialist directly in Claude Code:
 ```
 
-/plugin marketplace add thisisfatih/eng-team
-/plugin install cloud-run-specialist@thisisfatih
+/plugin marketplace add tonone-ai/tonone
+/plugin install cloud-run-specialist@tonone-ai
 
 ```
 
@@ -987,9 +987,9 @@ engteam install cloud-run-specialist
 **Available Agents table** - add plugin install column:
 
 ```markdown
-| Agent                                                                | What it does                                                          | Plugin                                             | Pip                          |
-| -------------------------------------------------------------------- | --------------------------------------------------------------------- | -------------------------------------------------- | ---------------------------- |
-| **[cloud-run-specialist](cloud-architecture/cloud-run-specialist/)** | Audit Cloud Run fleet: waste, performance, pricing, traffic, security | `/plugin install cloud-run-specialist@thisisfatih` | `pip install cloudrun-agent` |
+| Agent                                                                | What it does                                                          | Plugin                                           | Pip                          |
+| -------------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------ | ---------------------------- |
+| **[cloud-run-specialist](cloud-architecture/cloud-run-specialist/)** | Audit Cloud Run fleet: waste, performance, pricing, traffic, security | `/plugin install cloud-run-specialist@tonone-ai` | `pip install cloudrun-agent` |
 ```
 
 **Marketplace Commands section** - show plugin commands first, then engteam CLI as alternative.
@@ -1079,8 +1079,8 @@ resource waste, performance, pricing, traffic/latency, security, and recommendat
 
 ```bash
 # In Claude Code:
-/plugin marketplace add thisisfatih/eng-team
-/plugin install cloud-run-specialist@thisisfatih
+/plugin marketplace add tonone-ai/tonone
+/plugin install cloud-run-specialist@tonone-ai
 
 # Prerequisites: gcloud CLI authenticated
 gcloud auth login && gcloud config set project YOUR_PROJECT
@@ -1154,8 +1154,8 @@ The Quick Start section becomes:
 In Claude Code:
 ```
 
-/plugin marketplace add thisisfatih/eng-team
-/plugin install cloud-run-specialist@thisisfatih
+/plugin marketplace add tonone-ai/tonone
+/plugin install cloud-run-specialist@tonone-ai
 
 ````
 

--- a/docs/superpowers/specs/2026-03-16-plugin-migration-design.md
+++ b/docs/superpowers/specs/2026-03-16-plugin-migration-design.md
@@ -82,10 +82,10 @@ eng-team/
   "version": "0.1.0",
   "description": "Audit Cloud Run fleet: resource waste, performance, pricing, traffic, security",
   "author": {
-    "name": "thisisfatih",
-    "url": "https://github.com/thisisfatih"
+    "name": "tonone-ai",
+    "url": "https://github.com/tonone-ai"
   },
-  "repository": "https://github.com/thisisfatih/eng-team",
+  "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "keywords": ["gcp", "cloud-run", "audit", "infrastructure"]
 }
@@ -97,7 +97,7 @@ eng-team/
 
 ```json
 {
-  "name": "thisisfatih",
+  "name": "tonone-ai",
   "description": "Engineering Team - Claude Code agents that work as specialized engineers",
   "plugins": {
     "cloud-run-specialist": {
@@ -115,8 +115,8 @@ New agents add an entry to `plugins` and create their directory under the approp
 
 ```bash
 # Plugin path (primary)
-/plugin marketplace add thisisfatih/eng-team
-/plugin install cloud-run-specialist@thisisfatih
+/plugin marketplace add tonone-ai/tonone
+/plugin install cloud-run-specialist@tonone-ai
 
 # Pip path (secondary, still works)
 pip install cloudrun-agent
@@ -231,7 +231,7 @@ class AgentEntry:
     team: str
     pypi_package: str
     plugin_name: str          # "cloud-run-specialist"
-    marketplace: str          # "thisisfatih/eng-team"
+    marketplace: str          # "tonone-ai/tonone"
     description: str
     skills: tuple[str, ...]
     status: str = "available"

--- a/marketplace.json
+++ b/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "thisisfatih",
+  "name": "tonone-ai",
   "description": "Engineering Team - Claude Code agents that work as specialized engineers",
   "plugins": {
     "apex": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/thisisfatih/eng-team"
-Issues = "https://github.com/thisisfatih/eng-team/issues"
+Homepage = "https://github.com/tonone-ai/tonone"
+Issues = "https://github.com/tonone-ai/tonone/issues"
 
 [project.scripts]
 engteam = "engteam.cli:main"

--- a/src/engteam/cli.py
+++ b/src/engteam/cli.py
@@ -200,8 +200,8 @@ def main() -> None:
     else:
         print(_header())
         print("Install (plugin - recommended):")
-        print("  /plugin marketplace add thisisfatih/eng-team")
-        print("  /plugin install cloud-run-specialist@thisisfatih")
+        print("  /plugin marketplace add tonone-ai/tonone")
+        print("  /plugin install cloud-run-specialist@tonone-ai")
         print()
         print("Install (pip):")
         print("  engteam list                    Browse available agents")

--- a/src/engteam/registry.py
+++ b/src/engteam/registry.py
@@ -21,7 +21,7 @@ AGENTS: tuple[AgentEntry, ...] = (
         team="cloud-architecture",
         pypi_package="cloudrun-agent",
         plugin_name="cloud-run-specialist",
-        marketplace="thisisfatih/eng-team",
+        marketplace="tonone-ai/tonone",
         description="Audit Cloud Run fleet: resource waste, performance, pricing, traffic, security",
         skills=(
             "/cloudrun-dashboard",

--- a/team/apex/.claude-plugin/plugin.json
+++ b/team/apex/.claude-plugin/plugin.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "description": "Engineering lead — orchestrates the team, scopes work, controls depth and budget",
   "author": {
-    "name": "thisisfatih",
-    "url": "https://github.com/thisisfatih"
+    "name": "tonone-ai",
+    "url": "https://tonone.ai"
   },
-  "repository": "https://github.com/thisisfatih/eng-team",
+  "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "keywords": ["lead", "orchestrator", "tech-lead", "engineering-management"]
 }

--- a/team/atlas/.claude-plugin/plugin.json
+++ b/team/atlas/.claude-plugin/plugin.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "description": "Knowledge engineer — architecture docs, ADRs, API specs, system diagrams, onboarding",
   "author": {
-    "name": "thisisfatih",
-    "url": "https://github.com/thisisfatih"
+    "name": "tonone-ai",
+    "url": "https://tonone.ai"
   },
-  "repository": "https://github.com/thisisfatih/eng-team",
+  "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "keywords": [
     "documentation",

--- a/team/cortex/.claude-plugin/plugin.json
+++ b/team/cortex/.claude-plugin/plugin.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "description": "ML/AI engineer — model training, MLOps, feature engineering, LLM integration",
   "author": {
-    "name": "thisisfatih",
-    "url": "https://github.com/thisisfatih"
+    "name": "tonone-ai",
+    "url": "https://tonone.ai"
   },
-  "repository": "https://github.com/thisisfatih/eng-team",
+  "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "keywords": ["ml", "ai", "mlops", "models", "llm", "feature-engineering"]
 }

--- a/team/flux/.claude-plugin/plugin.json
+++ b/team/flux/.claude-plugin/plugin.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "description": "Data engineer — databases, migrations, pipelines, data modeling",
   "author": {
-    "name": "thisisfatih",
-    "url": "https://github.com/thisisfatih"
+    "name": "tonone-ai",
+    "url": "https://tonone.ai"
   },
-  "repository": "https://github.com/thisisfatih/eng-team",
+  "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "keywords": ["data", "databases", "migrations", "pipelines", "modeling"]
 }

--- a/team/forge/.claude-plugin/plugin.json
+++ b/team/forge/.claude-plugin/plugin.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "description": "Infrastructure engineer — cloud services, networking, IaC, cost optimization",
   "author": {
-    "name": "thisisfatih",
-    "url": "https://github.com/thisisfatih"
+    "name": "tonone-ai",
+    "url": "https://tonone.ai"
   },
-  "repository": "https://github.com/thisisfatih/eng-team",
+  "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "keywords": ["infrastructure", "cloud", "iac", "networking", "cost"]
 }

--- a/team/lens/.claude-plugin/plugin.json
+++ b/team/lens/.claude-plugin/plugin.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "description": "Data analytics & BI engineer — dashboards, metrics design, reporting, data storytelling",
   "author": {
-    "name": "thisisfatih",
-    "url": "https://github.com/thisisfatih"
+    "name": "tonone-ai",
+    "url": "https://tonone.ai"
   },
-  "repository": "https://github.com/thisisfatih/eng-team",
+  "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "keywords": [
     "analytics",

--- a/team/prism/.claude-plugin/plugin.json
+++ b/team/prism/.claude-plugin/plugin.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "description": "Frontend & DX engineer — UI, internal tools, developer portals",
   "author": {
-    "name": "thisisfatih",
-    "url": "https://github.com/thisisfatih"
+    "name": "tonone-ai",
+    "url": "https://tonone.ai"
   },
-  "repository": "https://github.com/thisisfatih/eng-team",
+  "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "keywords": ["frontend", "dx", "ui", "developer-tools", "portals"]
 }

--- a/team/relay/.claude-plugin/plugin.json
+++ b/team/relay/.claude-plugin/plugin.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "description": "DevOps engineer — CI/CD, deployments, GitOps, developer experience",
   "author": {
-    "name": "thisisfatih",
-    "url": "https://github.com/thisisfatih"
+    "name": "tonone-ai",
+    "url": "https://tonone.ai"
   },
-  "repository": "https://github.com/thisisfatih/eng-team",
+  "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "keywords": ["devops", "cicd", "deployments", "gitops", "dx"]
 }

--- a/team/spine/.claude-plugin/plugin.json
+++ b/team/spine/.claude-plugin/plugin.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "description": "Backend engineer — APIs, system design, performance, distributed systems",
   "author": {
-    "name": "thisisfatih",
-    "url": "https://github.com/thisisfatih"
+    "name": "tonone-ai",
+    "url": "https://tonone.ai"
   },
-  "repository": "https://github.com/thisisfatih/eng-team",
+  "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "keywords": [
     "backend",

--- a/team/touch/.claude-plugin/plugin.json
+++ b/team/touch/.claude-plugin/plugin.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "description": "Mobile engineer — native iOS/Android, cross-platform, app stores, mobile performance",
   "author": {
-    "name": "thisisfatih",
-    "url": "https://github.com/thisisfatih"
+    "name": "tonone-ai",
+    "url": "https://tonone.ai"
   },
-  "repository": "https://github.com/thisisfatih/eng-team",
+  "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "keywords": [
     "mobile",

--- a/team/vigil/.claude-plugin/plugin.json
+++ b/team/vigil/.claude-plugin/plugin.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "description": "Observability & reliability engineer — monitoring, alerting, SRE, incident response, SLOs",
   "author": {
-    "name": "thisisfatih",
-    "url": "https://github.com/thisisfatih"
+    "name": "tonone-ai",
+    "url": "https://tonone.ai"
   },
-  "repository": "https://github.com/thisisfatih/eng-team",
+  "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "keywords": [
     "observability",

--- a/team/volt/.claude-plugin/plugin.json
+++ b/team/volt/.claude-plugin/plugin.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "description": "Embedded & IoT engineer — firmware, microcontrollers, edge computing, device protocols",
   "author": {
-    "name": "thisisfatih",
-    "url": "https://github.com/thisisfatih"
+    "name": "tonone-ai",
+    "url": "https://tonone.ai"
   },
-  "repository": "https://github.com/thisisfatih/eng-team",
+  "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "keywords": [
     "embedded",

--- a/team/warden/.claude-plugin/plugin.json
+++ b/team/warden/.claude-plugin/plugin.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "description": "Security engineer — IAM, secrets, compliance, threat modeling",
   "author": {
-    "name": "thisisfatih",
-    "url": "https://github.com/thisisfatih"
+    "name": "tonone-ai",
+    "url": "https://tonone.ai"
   },
-  "repository": "https://github.com/thisisfatih/eng-team",
+  "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "keywords": ["security", "iam", "secrets", "compliance", "threat-modeling"]
 }

--- a/templates/new-agent/.claude-plugin/plugin.json
+++ b/templates/new-agent/.claude-plugin/plugin.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "description": "AGENT_DESCRIPTION",
   "author": {
-    "name": "thisisfatih",
-    "url": "https://github.com/thisisfatih"
+    "name": "tonone-ai",
+    "url": "https://tonone.ai"
   },
-  "repository": "https://github.com/thisisfatih/eng-team",
+  "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "keywords": []
 }

--- a/templates/new-agent/README.md
+++ b/templates/new-agent/README.md
@@ -7,8 +7,8 @@ AGENT_DESCRIPTION
 In Claude Code (recommended):
 
 ```
-/plugin marketplace add thisisfatih/eng-team
-/plugin install AGENT_SLUG@thisisfatih
+/plugin marketplace add tonone-ai/tonone
+/plugin install AGENT_SLUG@tonone-ai
 ```
 
 Or via pip:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -195,4 +195,4 @@ def test_agent_entry_has_plugin_fields():
     assert hasattr(agent, "plugin_name")
     assert hasattr(agent, "marketplace")
     assert agent.plugin_name == "cloud-run-specialist"
-    assert agent.marketplace == "thisisfatih/eng-team"
+    assert agent.marketplace == "tonone-ai/tonone"


### PR DESCRIPTION
- Transferred repo from thisisfatih/eng-team to tonone-ai/tonone
- Updated all plugin.json author/repository references
- Updated README with Tonone branding and tagline
- Updated marketplace.json, templates, docs
- Zero references to old org remaining