### PR TITLE
docs: refine tagline and add Why This Exists section

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -34,7 +34,7 @@ lint:
     - prettier@3.8.1
     - ruff@0.15.8
     - taplo@0.10.0
-    - trufflehog@3.93.8
+    - trufflehog@3.94.1
     - yamllint@1.38.0
 actions:
   enabled:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Engineering Team
 
-Elite engineering team as Claude Code agents. 1 lead + 12 specialists. Simplicity is king. Scalability is best friend.
+Elite engineering team as Claude Code agents. 1 lead + 12 specialists. Simple by default. Scalable by design.
 
 ## The Team
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,23 @@
 
 Your elite engineering team as [Claude Code](https://docs.anthropic.com/en/docs/claude-code) agents. 1 lead + 12 specialists. 64 skills. Every major engineering discipline covered.
 
-Simplicity is king. Scalability is best friend.
+Simple by default. Scalable by design.
+
+## Why This Exists
+
+Right now, every engineer gets a generalized AI assistant. Everyone prompts separately, gets separate outputs, then copies results into Slack threads for the next person to feed back into AI. It's a relay race where every handoff loses context.
+
+**That's the wrong unit of automation.** Instead of giving each person an AI assistant, give the whole department an AI team. Specialists that talk to each other, share context, and run the show end to end — infrastructure to deployment to monitoring — without the copy-paste relay.
+
+That's Tonone. Not thirteen copies of the same generalist. Thirteen specialists, each owning one domain, coordinated by a lead who knows when to call who and at what depth.
+
+### The Mindset
+
+**Complexity is debt.** Every unnecessary abstraction, every over-engineered solution, every "just in case" feature — it all accrues interest. It slows you down today and buries you tomorrow.
+
+**Scalability compounds.** When you build simple, correct foundations, they carry more weight over time without breaking. Simple systems are easier to debug, easier to extend, and easier to hand off.
+
+No boilerplate generators. No tutorial-grade scaffolds. Production-ready output that respects your codebase, your stack, and your time.
 
 ## The Team
 


### PR DESCRIPTION
## Summary
- Updated tagline to "Simple by default. Scalable by design."
- Added "Why This Exists" section to README — positions Tonone as department-level AI team vs individual generalist assistants
- Added "The Mindset" subsection with the "complexity is debt, scalability compounds" philosophy

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm tagline is consistent between README.md and CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)