### PR TITLE
fix: update plugin descriptions to reflect Engineering + Product team

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "tonone-ai",
-  "description": "Engineering Team - Claude Code agents that work as specialized engineers",
+  "description": "Engineering + Product Teams — 23 Claude Code agents covering engineering and product functions",
   "owner": {
     "name": "tonone-ai",
     "url": "https://tonone.ai"
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "tonone",
-      "description": "Elite engineering team — 1 lead + 14 specialists, 74 skills. All agents and skills in one install.",
+      "description": "Engineering + Product team — 23 agents, 2 teams. All agents and skills in one install.",
       "version": "0.4.1",
       "source": "./",
       "author": { "name": "tonone-ai", "url": "https://tonone.ai" },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tonone",
-  "description": "Elite engineering team — 1 lead + 14 specialists as Claude Code agents. Infrastructure, DevOps, backend, data, security, observability, frontend, ML/AI, mobile, embedded, knowledge, analytics, QA, and platform engineering.",
+  "description": "Engineering + Product team — 23 agents as Claude Code specialists. Infrastructure, DevOps, backend, security, ML/AI, mobile, UX, analytics, growth, strategy, and more.",
   "version": "0.4.1",
   "author": {
     "name": "tonone-ai",


### PR DESCRIPTION
## Summary

Removes stale marketing copy from the two plugin manifest files.

- **`plugin.json`** — description updated from "Elite engineering team — 1 lead + 14 specialists" to "Engineering + Product team — 23 agents as Claude Code specialists"
- **`marketplace.json`** — top-level description and `tonone` bundle entry updated to match

The old copy predated the Product Team v1 launch (#18) and no longer reflected the full 23-agent roster.

## Changes
- `.claude-plugin/plugin.json` — description rewrite (1 line)
- `.claude-plugin/marketplace.json` — 2 description rewrites

🤖 Generated with [Claude Code](https://claude.com/claude-code)