### PR TITLE
feat: wire up bundle plugins — installing full-team/engineering-team/product-team now works

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "tonone",
       "description": "Engineering + Product team \u2014 23 agents, 2 teams. All agents and skills in one install.",
-      "version": "0.5.1",
+      "version": "0.6.1",
       "source": "./",
       "author": {
         "name": "tonone-ai",
@@ -20,7 +20,7 @@
     {
       "name": "engineering-team",
       "description": "Install all 15 Engineering Team agents at once",
-      "version": "0.4.1",
+      "version": "0.6.1",
       "source": "./bundle/engineering-team",
       "author": {
         "name": "tonone-ai",
@@ -31,7 +31,7 @@
     {
       "name": "product-team",
       "description": "Install all 8 Product Team agents at once",
-      "version": "0.1.0",
+      "version": "0.6.1",
       "source": "./bundle/product-team",
       "author": {
         "name": "tonone-ai",
@@ -41,8 +41,8 @@
     },
     {
       "name": "full-team",
-      "description": "Install all 23 tonone agents at once \u2014 Engineering Team + Product Team",
-      "version": "0.1.0",
+      "description": "Install all 23 tonone agents at once — Engineering Team + Product Team",
+      "version": "0.6.1",
       "source": "./bundle/full-team",
       "author": {
         "name": "tonone-ai",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tonone",
   "description": "Engineering + Product team — 23 agents as Claude Code specialists. Infrastructure, DevOps, backend, security, ML/AI, mobile, UX, analytics, growth, strategy, and more.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": {
     "name": "tonone-ai",
     "url": "https://tonone.ai"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Job 1: Structure tests
+  # Validates that every agent and skill has all required files in the right
+  # places. This is the highest-value gate: a missing plugin.json or SKILL.md
+  # silently breaks install for every user who pulls that agent or skill.
+  # ---------------------------------------------------------------------------
+  validate-structure:
+    name: Validate structure
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install pytest
+        run: pip install pytest
+      - name: Run structure tests
+        run: python -m pytest tests/test_structure.py -v
+
+  # ---------------------------------------------------------------------------
+  # Job 2: Shell script linting
+  # All setup.sh files are linted at WARNING severity. Errors in setup scripts
+  # silently fail for end users who run them — shellcheck catches the common
+  # pitfalls (unquoted vars, pipefail gaps) before they reach anyone.
+  # ---------------------------------------------------------------------------
+  lint-shell:
+    name: Lint shell scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: sudo apt-get install -y shellcheck
+      - name: Run shellcheck
+        run: find . -name "setup.sh" -not -path "./.git/*" | xargs shellcheck -S warning
+
+  # ---------------------------------------------------------------------------
+  # Job 3: Agent tests (matrix) — DISABLED
+  #
+  # All 23 agent test directories currently contain only an empty __init__.py
+  # stub. Running a matrix job over them would produce 23 green "0 tests
+  # collected" runs — misleading signal that wastes CI minutes.
+  #
+  # Activate this job when an agent gains real Python functionality:
+  # 1. Add the agent name to the matrix list below.
+  # 2. Ensure team/<agent>/scripts/ has a pyproject.toml with test deps and at
+  #    least one test_*.py file with substantive tests.
+  #
+  # Template (uncomment and populate matrix.agent when ready):
+  #
+  # agent-tests:
+  #   name: "Agent tests"
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       agent: []  # e.g. [forge, relay, spine]
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-python@v5
+  #       with:
+  #         python-version: "3.11"
+  #     - name: Install uv
+  #       run: pip install uv
+  #     - name: Run agent tests
+  #       working-directory: team/${{ matrix.agent }}/scripts
+  #       run: |
+  #         uv sync --quiet
+  #         uv run pytest ../tests/ -v
+  # ---------------------------------------------------------------------------

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,98 @@
+# tonone — Engineering + Product Team
+
+> **Primary platform:** Claude Code. This file provides Codex CLI compatibility.
+> For Claude Code setup, see `CLAUDE.md`.
+
+Two AI teams. 23 agents total. Engineering executes. Product decides what to build and why.
+
+## Engineering Team — 15 agents
+
+| Agent      | Hat                         | Owns                                                          |
+| ---------- | --------------------------- | ------------------------------------------------------------- |
+| **Apex**   | Engineering Lead            | Orchestrates the team, scopes work, controls depth and budget |
+| **Forge**  | Infrastructure              | Cloud services, networking, IaC, cost optimization            |
+| **Relay**  | DevOps                      | CI/CD, deployments, GitOps, developer experience              |
+| **Spine**  | Backend                     | APIs, system design, performance, distributed systems         |
+| **Flux**   | Data                        | Databases, migrations, pipelines, data modeling               |
+| **Warden** | Security                    | IAM, secrets, compliance, threat modeling                     |
+| **Vigil**  | Observability + Reliability | Monitoring, alerting, SRE, incident response, SLOs            |
+| **Prism**  | Frontend/DX                 | UI, internal tools, developer portals                         |
+| **Cortex** | ML/AI                       | Model training, MLOps, feature engineering, LLM integration   |
+| **Touch**  | Mobile                      | Native iOS/Android, cross-platform, app stores                |
+| **Volt**   | Embedded/IoT                | Firmware, microcontrollers, edge computing, protocols         |
+| **Atlas**  | Knowledge Engineering       | Architecture docs, ADRs, API specs, system diagrams           |
+| **Lens**   | Data Analytics & BI         | Dashboards, metrics design, reporting, data storytelling      |
+| **Proof**  | QA & Testing                | Test strategy, E2E suites, integration testing, flaky triage  |
+| **Pave**   | Platform Engineering        | Developer experience, golden paths, service catalogs          |
+
+## Product Team — 8 agents
+
+| Agent     | Hat               | Owns                                                            |
+| --------- | ----------------- | --------------------------------------------------------------- |
+| **Helm**  | Head of Product   | Orchestrates the product team, writes briefs, hands off to Apex |
+| **Echo**  | User Research     | User interviews, personas, Jobs-to-Be-Done, feedback synthesis  |
+| **Lumen** | Product Analytics | Metrics frameworks, funnel analysis, OKRs, A/B test design      |
+| **Draft** | UX Design         | User flows, information architecture, wireframes                |
+| **Form**  | Visual Design     | Brand identity, color systems, typography, design system        |
+| **Crest** | Product Strategy  | Roadmap planning, prioritization, competitive analysis          |
+| **Pitch** | Product Marketing | Positioning, messaging, value prop, GTM, launch copy            |
+| **Surge** | Growth            | Acquisition channels, activation funnels, retention playbooks   |
+
+## Helm↔Apex Interface
+
+Helm hands off to Apex using a 6-field product brief schema. See `agents/apex.md` → `## Helm Handoff` for the full contract.
+
+## Structure
+
+```
+tonone/
+├── agents/           ← agent definitions (read these to embody an agent)
+│   ├── apex.md
+│   ├── forge.md
+│   └── ...           (23 files)
+├── skills/           ← skill workflows (read these to follow a skill)
+│   ├── apex-plan/SKILL.md
+│   ├── forge-audit/SKILL.md
+│   └── ...           (125 directories)
+├── team/             ← source of truth per agent (canonical skills, hooks, scripts)
+├── docs/             ← naming guide, architecture, output kit
+└── templates/        ← scaffolding for new agents
+```
+
+Note: `.claude-plugin/` directories are Claude Code-specific and can be ignored in Codex.
+
+## Using Agents in Codex
+
+Agents are plain Markdown system prompts in `agents/<name>.md`. To work with a specific agent:
+
+1. Read the agent definition: `agents/<name>.md`
+2. Adopt that agent's role, priorities, and output style for the session
+3. Use Codex's standard tools (shell, file read/write) as the agent would
+
+Example: to work as Forge, read `agents/forge.md` and respond as the infrastructure specialist.
+
+## Using Skills in Codex
+
+Skills are workflow documents in `skills/<skill-name>/SKILL.md`. They have no special invocation — just read and follow them:
+
+1. Find the relevant skill: `skills/` lists all 125 workflows
+2. Read the skill file to understand the steps
+3. Execute the workflow using Codex's tools
+
+Example: to run the forge audit workflow, read `skills/forge-audit/SKILL.md` and follow the steps.
+
+To find the right skill for a task, check the skill frontmatter `description` field — it explains when to use each skill.
+
+## Conventions
+
+- Agent names: single word, 1-2 syllables, evocative of the domain
+- Skills: `{agentname}-{action}` naming pattern (e.g., `forge-audit`, `spine-review`)
+- All agent output follows the output kit (`docs/output-kit.md`): 40-line max, box-drawing skeleton, unified severity indicators
+- Edit agent definitions in `team/<agent>/agents/`, not the root `agents/` copies
+
+## Adding a New Agent
+
+1. Copy `templates/new-agent/` to `team/<agent-name>/`
+2. Replace placeholders in plugin.json, agent def, skills
+3. Copy agent def to root `agents/` directory
+4. See `docs/naming-guide.md` for naming conventions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.2] — 2026-04-06
+
+### Added
+
+- **AGENTS.md** — Codex CLI compatibility layer: team roster, directory guide, and instructions for using agents and skills without the Claude Code plugin system
+- **README** — Codex CLI quick start section (clone, `codex`, invoke agents by reading markdown directly)
+- **docs/architecture.md** — platform support table documenting Claude Code (primary) vs Codex CLI (secondary)
+
 ## [0.6.1] — 2026-04-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -59,18 +59,16 @@ No boilerplate generators. No tutorial-grade scaffolds. Production-ready output 
 
 ## Quick Start
 
-### Prerequisites
+### Claude Code (primary)
 
-- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed (v1.0+)
-
-### Install
+**Prerequisites:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code) v1.0+
 
 ```
 /plugin marketplace add tonone-ai/tonone
 /plugin install tonone@tonone-ai
 ```
 
-### Then just talk to them
+Then just talk to them:
 
 ```
 > /apex-plan Build a real-time analytics platform for our IoT fleet
@@ -81,6 +79,26 @@ No boilerplate generators. No tutorial-grade scaffolds. Production-ready output 
 > /echo-interview Run a user research session
 > /crest-roadmap Build a product roadmap
 ```
+
+### Codex CLI (secondary)
+
+**Prerequisites:** [Codex CLI](https://github.com/openai/codex) installed
+
+```bash
+git clone https://github.com/tonone-ai/tonone
+cd tonone
+codex
+```
+
+Codex reads `AGENTS.md` automatically. Invoke agents and skills by describing what you want:
+
+```
+> Read agents/forge.md and act as Forge — audit this infrastructure
+> Read agents/apex.md — plan this project with S/M/L options
+> Follow the workflow in skills/warden-audit/SKILL.md
+```
+
+Skills are markdown workflow documents in `skills/<name>/SKILL.md`. Read them and follow the steps — no slash commands needed.
 
 ## What You Get
 

--- a/bundle/engineering-team/.claude-plugin/plugin.json
+++ b/bundle/engineering-team/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
-  "name": "engineering-team",
-  "version": "0.1.0",
-  "description": "Install all 15 Engineering Team agents at once",
+  "name": "tonone-engineering-team",
+  "version": "0.6.1",
+  "description": "Engineering team — 15 agents: Apex, Forge, Relay, Spine, Flux, Warden, Vigil, Prism, Cortex, Touch, Volt, Atlas, Lens, Proof, Pave",
   "author": {
     "name": "tonone-ai",
     "url": "https://tonone.ai"
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["bundle", "installer", "engineering-team", "all-agents"]
+  "keywords": ["agents", "engineering-team", "bundle"]
 }

--- a/bundle/engineering-team/agents/apex.md
+++ b/bundle/engineering-team/agents/apex.md
@@ -1,0 +1,1 @@
+../../../agents/apex.md

--- a/bundle/engineering-team/agents/atlas.md
+++ b/bundle/engineering-team/agents/atlas.md
@@ -1,0 +1,1 @@
+../../../agents/atlas.md

--- a/bundle/engineering-team/agents/cortex.md
+++ b/bundle/engineering-team/agents/cortex.md
@@ -1,0 +1,1 @@
+../../../agents/cortex.md

--- a/bundle/engineering-team/agents/flux.md
+++ b/bundle/engineering-team/agents/flux.md
@@ -1,0 +1,1 @@
+../../../agents/flux.md

--- a/bundle/engineering-team/agents/forge.md
+++ b/bundle/engineering-team/agents/forge.md
@@ -1,0 +1,1 @@
+../../../agents/forge.md

--- a/bundle/engineering-team/agents/lens.md
+++ b/bundle/engineering-team/agents/lens.md
@@ -1,0 +1,1 @@
+../../../agents/lens.md

--- a/bundle/engineering-team/agents/pave.md
+++ b/bundle/engineering-team/agents/pave.md
@@ -1,0 +1,1 @@
+../../../agents/pave.md

--- a/bundle/engineering-team/agents/prism.md
+++ b/bundle/engineering-team/agents/prism.md
@@ -1,0 +1,1 @@
+../../../agents/prism.md

--- a/bundle/engineering-team/agents/proof.md
+++ b/bundle/engineering-team/agents/proof.md
@@ -1,0 +1,1 @@
+../../../agents/proof.md

--- a/bundle/engineering-team/agents/relay.md
+++ b/bundle/engineering-team/agents/relay.md
@@ -1,0 +1,1 @@
+../../../agents/relay.md

--- a/bundle/engineering-team/agents/spine.md
+++ b/bundle/engineering-team/agents/spine.md
@@ -1,0 +1,1 @@
+../../../agents/spine.md

--- a/bundle/engineering-team/agents/touch.md
+++ b/bundle/engineering-team/agents/touch.md
@@ -1,0 +1,1 @@
+../../../agents/touch.md

--- a/bundle/engineering-team/agents/vigil.md
+++ b/bundle/engineering-team/agents/vigil.md
@@ -1,0 +1,1 @@
+../../../agents/vigil.md

--- a/bundle/engineering-team/agents/volt.md
+++ b/bundle/engineering-team/agents/volt.md
@@ -1,0 +1,1 @@
+../../../agents/volt.md

--- a/bundle/engineering-team/agents/warden.md
+++ b/bundle/engineering-team/agents/warden.md
@@ -1,0 +1,1 @@
+../../../agents/warden.md

--- a/bundle/engineering-team/skills/apex-plan
+++ b/bundle/engineering-team/skills/apex-plan
@@ -1,0 +1,1 @@
+../../../skills/apex-plan

--- a/bundle/engineering-team/skills/apex-recon
+++ b/bundle/engineering-team/skills/apex-recon
@@ -1,0 +1,1 @@
+../../../skills/apex-recon

--- a/bundle/engineering-team/skills/apex-review
+++ b/bundle/engineering-team/skills/apex-review
@@ -1,0 +1,1 @@
+../../../skills/apex-review

--- a/bundle/engineering-team/skills/apex-status
+++ b/bundle/engineering-team/skills/apex-status
@@ -1,0 +1,1 @@
+../../../skills/apex-status

--- a/bundle/engineering-team/skills/apex-takeover
+++ b/bundle/engineering-team/skills/apex-takeover
@@ -1,0 +1,1 @@
+../../../skills/apex-takeover

--- a/bundle/engineering-team/skills/atlas-adr
+++ b/bundle/engineering-team/skills/atlas-adr
@@ -1,0 +1,1 @@
+../../../skills/atlas-adr

--- a/bundle/engineering-team/skills/atlas-changelog
+++ b/bundle/engineering-team/skills/atlas-changelog
@@ -1,0 +1,1 @@
+../../../skills/atlas-changelog

--- a/bundle/engineering-team/skills/atlas-map
+++ b/bundle/engineering-team/skills/atlas-map
@@ -1,0 +1,1 @@
+../../../skills/atlas-map

--- a/bundle/engineering-team/skills/atlas-onboard
+++ b/bundle/engineering-team/skills/atlas-onboard
@@ -1,0 +1,1 @@
+../../../skills/atlas-onboard

--- a/bundle/engineering-team/skills/atlas-present
+++ b/bundle/engineering-team/skills/atlas-present
@@ -1,0 +1,1 @@
+../../../skills/atlas-present

--- a/bundle/engineering-team/skills/atlas-recon
+++ b/bundle/engineering-team/skills/atlas-recon
@@ -1,0 +1,1 @@
+../../../skills/atlas-recon

--- a/bundle/engineering-team/skills/atlas-report
+++ b/bundle/engineering-team/skills/atlas-report
@@ -1,0 +1,1 @@
+../../../skills/atlas-report

--- a/bundle/engineering-team/skills/cortex-eval
+++ b/bundle/engineering-team/skills/cortex-eval
@@ -1,0 +1,1 @@
+../../../skills/cortex-eval

--- a/bundle/engineering-team/skills/cortex-integrate
+++ b/bundle/engineering-team/skills/cortex-integrate
@@ -1,0 +1,1 @@
+../../../skills/cortex-integrate

--- a/bundle/engineering-team/skills/cortex-model
+++ b/bundle/engineering-team/skills/cortex-model
@@ -1,0 +1,1 @@
+../../../skills/cortex-model

--- a/bundle/engineering-team/skills/cortex-prompt
+++ b/bundle/engineering-team/skills/cortex-prompt
@@ -1,0 +1,1 @@
+../../../skills/cortex-prompt

--- a/bundle/engineering-team/skills/cortex-recon
+++ b/bundle/engineering-team/skills/cortex-recon
@@ -1,0 +1,1 @@
+../../../skills/cortex-recon

--- a/bundle/engineering-team/skills/flux-health
+++ b/bundle/engineering-team/skills/flux-health
@@ -1,0 +1,1 @@
+../../../skills/flux-health

--- a/bundle/engineering-team/skills/flux-migrate
+++ b/bundle/engineering-team/skills/flux-migrate
@@ -1,0 +1,1 @@
+../../../skills/flux-migrate

--- a/bundle/engineering-team/skills/flux-pipeline
+++ b/bundle/engineering-team/skills/flux-pipeline
@@ -1,0 +1,1 @@
+../../../skills/flux-pipeline

--- a/bundle/engineering-team/skills/flux-query
+++ b/bundle/engineering-team/skills/flux-query
@@ -1,0 +1,1 @@
+../../../skills/flux-query

--- a/bundle/engineering-team/skills/flux-recon
+++ b/bundle/engineering-team/skills/flux-recon
@@ -1,0 +1,1 @@
+../../../skills/flux-recon

--- a/bundle/engineering-team/skills/flux-schema
+++ b/bundle/engineering-team/skills/flux-schema
@@ -1,0 +1,1 @@
+../../../skills/flux-schema

--- a/bundle/engineering-team/skills/forge-audit
+++ b/bundle/engineering-team/skills/forge-audit
@@ -1,0 +1,1 @@
+../../../skills/forge-audit

--- a/bundle/engineering-team/skills/forge-cost
+++ b/bundle/engineering-team/skills/forge-cost
@@ -1,0 +1,1 @@
+../../../skills/forge-cost

--- a/bundle/engineering-team/skills/forge-diagnose
+++ b/bundle/engineering-team/skills/forge-diagnose
@@ -1,0 +1,1 @@
+../../../skills/forge-diagnose

--- a/bundle/engineering-team/skills/forge-infra
+++ b/bundle/engineering-team/skills/forge-infra
@@ -1,0 +1,1 @@
+../../../skills/forge-infra

--- a/bundle/engineering-team/skills/forge-network
+++ b/bundle/engineering-team/skills/forge-network
@@ -1,0 +1,1 @@
+../../../skills/forge-network

--- a/bundle/engineering-team/skills/forge-recon
+++ b/bundle/engineering-team/skills/forge-recon
@@ -1,0 +1,1 @@
+../../../skills/forge-recon

--- a/bundle/engineering-team/skills/lens-audit
+++ b/bundle/engineering-team/skills/lens-audit
@@ -1,0 +1,1 @@
+../../../skills/lens-audit

--- a/bundle/engineering-team/skills/lens-dashboard
+++ b/bundle/engineering-team/skills/lens-dashboard
@@ -1,0 +1,1 @@
+../../../skills/lens-dashboard

--- a/bundle/engineering-team/skills/lens-metrics
+++ b/bundle/engineering-team/skills/lens-metrics
@@ -1,0 +1,1 @@
+../../../skills/lens-metrics

--- a/bundle/engineering-team/skills/lens-recon
+++ b/bundle/engineering-team/skills/lens-recon
@@ -1,0 +1,1 @@
+../../../skills/lens-recon

--- a/bundle/engineering-team/skills/lens-report
+++ b/bundle/engineering-team/skills/lens-report
@@ -1,0 +1,1 @@
+../../../skills/lens-report

--- a/bundle/engineering-team/skills/pave-audit
+++ b/bundle/engineering-team/skills/pave-audit
@@ -1,0 +1,1 @@
+../../../skills/pave-audit

--- a/bundle/engineering-team/skills/pave-catalog
+++ b/bundle/engineering-team/skills/pave-catalog
@@ -1,0 +1,1 @@
+../../../skills/pave-catalog

--- a/bundle/engineering-team/skills/pave-env
+++ b/bundle/engineering-team/skills/pave-env
@@ -1,0 +1,1 @@
+../../../skills/pave-env

--- a/bundle/engineering-team/skills/pave-golden
+++ b/bundle/engineering-team/skills/pave-golden
@@ -1,0 +1,1 @@
+../../../skills/pave-golden

--- a/bundle/engineering-team/skills/pave-recon
+++ b/bundle/engineering-team/skills/pave-recon
@@ -1,0 +1,1 @@
+../../../skills/pave-recon

--- a/bundle/engineering-team/skills/prism-audit
+++ b/bundle/engineering-team/skills/prism-audit
@@ -1,0 +1,1 @@
+../../../skills/prism-audit

--- a/bundle/engineering-team/skills/prism-component
+++ b/bundle/engineering-team/skills/prism-component
@@ -1,0 +1,1 @@
+../../../skills/prism-component

--- a/bundle/engineering-team/skills/prism-dashboard
+++ b/bundle/engineering-team/skills/prism-dashboard
@@ -1,0 +1,1 @@
+../../../skills/prism-dashboard

--- a/bundle/engineering-team/skills/prism-recon
+++ b/bundle/engineering-team/skills/prism-recon
@@ -1,0 +1,1 @@
+../../../skills/prism-recon

--- a/bundle/engineering-team/skills/prism-ui
+++ b/bundle/engineering-team/skills/prism-ui
@@ -1,0 +1,1 @@
+../../../skills/prism-ui

--- a/bundle/engineering-team/skills/proof-api
+++ b/bundle/engineering-team/skills/proof-api
@@ -1,0 +1,1 @@
+../../../skills/proof-api

--- a/bundle/engineering-team/skills/proof-audit
+++ b/bundle/engineering-team/skills/proof-audit
@@ -1,0 +1,1 @@
+../../../skills/proof-audit

--- a/bundle/engineering-team/skills/proof-e2e
+++ b/bundle/engineering-team/skills/proof-e2e
@@ -1,0 +1,1 @@
+../../../skills/proof-e2e

--- a/bundle/engineering-team/skills/proof-recon
+++ b/bundle/engineering-team/skills/proof-recon
@@ -1,0 +1,1 @@
+../../../skills/proof-recon

--- a/bundle/engineering-team/skills/proof-strategy
+++ b/bundle/engineering-team/skills/proof-strategy
@@ -1,0 +1,1 @@
+../../../skills/proof-strategy

--- a/bundle/engineering-team/skills/relay-audit
+++ b/bundle/engineering-team/skills/relay-audit
@@ -1,0 +1,1 @@
+../../../skills/relay-audit

--- a/bundle/engineering-team/skills/relay-deploy
+++ b/bundle/engineering-team/skills/relay-deploy
@@ -1,0 +1,1 @@
+../../../skills/relay-deploy

--- a/bundle/engineering-team/skills/relay-docker
+++ b/bundle/engineering-team/skills/relay-docker
@@ -1,0 +1,1 @@
+../../../skills/relay-docker

--- a/bundle/engineering-team/skills/relay-pipeline
+++ b/bundle/engineering-team/skills/relay-pipeline
@@ -1,0 +1,1 @@
+../../../skills/relay-pipeline

--- a/bundle/engineering-team/skills/relay-recon
+++ b/bundle/engineering-team/skills/relay-recon
@@ -1,0 +1,1 @@
+../../../skills/relay-recon

--- a/bundle/engineering-team/skills/spine-api
+++ b/bundle/engineering-team/skills/spine-api
@@ -1,0 +1,1 @@
+../../../skills/spine-api

--- a/bundle/engineering-team/skills/spine-design
+++ b/bundle/engineering-team/skills/spine-design
@@ -1,0 +1,1 @@
+../../../skills/spine-design

--- a/bundle/engineering-team/skills/spine-perf
+++ b/bundle/engineering-team/skills/spine-perf
@@ -1,0 +1,1 @@
+../../../skills/spine-perf

--- a/bundle/engineering-team/skills/spine-recon
+++ b/bundle/engineering-team/skills/spine-recon
@@ -1,0 +1,1 @@
+../../../skills/spine-recon

--- a/bundle/engineering-team/skills/spine-review
+++ b/bundle/engineering-team/skills/spine-review
@@ -1,0 +1,1 @@
+../../../skills/spine-review

--- a/bundle/engineering-team/skills/spine-service
+++ b/bundle/engineering-team/skills/spine-service
@@ -1,0 +1,1 @@
+../../../skills/spine-service

--- a/bundle/engineering-team/skills/touch-app
+++ b/bundle/engineering-team/skills/touch-app
@@ -1,0 +1,1 @@
+../../../skills/touch-app

--- a/bundle/engineering-team/skills/touch-audit
+++ b/bundle/engineering-team/skills/touch-audit
@@ -1,0 +1,1 @@
+../../../skills/touch-audit

--- a/bundle/engineering-team/skills/touch-feature
+++ b/bundle/engineering-team/skills/touch-feature
@@ -1,0 +1,1 @@
+../../../skills/touch-feature

--- a/bundle/engineering-team/skills/touch-recon
+++ b/bundle/engineering-team/skills/touch-recon
@@ -1,0 +1,1 @@
+../../../skills/touch-recon

--- a/bundle/engineering-team/skills/touch-release
+++ b/bundle/engineering-team/skills/touch-release
@@ -1,0 +1,1 @@
+../../../skills/touch-release

--- a/bundle/engineering-team/skills/vigil-alert
+++ b/bundle/engineering-team/skills/vigil-alert
@@ -1,0 +1,1 @@
+../../../skills/vigil-alert

--- a/bundle/engineering-team/skills/vigil-check
+++ b/bundle/engineering-team/skills/vigil-check
@@ -1,0 +1,1 @@
+../../../skills/vigil-check

--- a/bundle/engineering-team/skills/vigil-incident
+++ b/bundle/engineering-team/skills/vigil-incident
@@ -1,0 +1,1 @@
+../../../skills/vigil-incident

--- a/bundle/engineering-team/skills/vigil-instrument
+++ b/bundle/engineering-team/skills/vigil-instrument
@@ -1,0 +1,1 @@
+../../../skills/vigil-instrument

--- a/bundle/engineering-team/skills/vigil-recon
+++ b/bundle/engineering-team/skills/vigil-recon
@@ -1,0 +1,1 @@
+../../../skills/vigil-recon

--- a/bundle/engineering-team/skills/volt-driver
+++ b/bundle/engineering-team/skills/volt-driver
@@ -1,0 +1,1 @@
+../../../skills/volt-driver

--- a/bundle/engineering-team/skills/volt-firmware
+++ b/bundle/engineering-team/skills/volt-firmware
@@ -1,0 +1,1 @@
+../../../skills/volt-firmware

--- a/bundle/engineering-team/skills/volt-ota
+++ b/bundle/engineering-team/skills/volt-ota
@@ -1,0 +1,1 @@
+../../../skills/volt-ota

--- a/bundle/engineering-team/skills/volt-power
+++ b/bundle/engineering-team/skills/volt-power
@@ -1,0 +1,1 @@
+../../../skills/volt-power

--- a/bundle/engineering-team/skills/volt-recon
+++ b/bundle/engineering-team/skills/volt-recon
@@ -1,0 +1,1 @@
+../../../skills/volt-recon

--- a/bundle/engineering-team/skills/warden-audit
+++ b/bundle/engineering-team/skills/warden-audit
@@ -1,0 +1,1 @@
+../../../skills/warden-audit

--- a/bundle/engineering-team/skills/warden-harden
+++ b/bundle/engineering-team/skills/warden-harden
@@ -1,0 +1,1 @@
+../../../skills/warden-harden

--- a/bundle/engineering-team/skills/warden-iam
+++ b/bundle/engineering-team/skills/warden-iam
@@ -1,0 +1,1 @@
+../../../skills/warden-iam

--- a/bundle/engineering-team/skills/warden-recon
+++ b/bundle/engineering-team/skills/warden-recon
@@ -1,0 +1,1 @@
+../../../skills/warden-recon

--- a/bundle/engineering-team/skills/warden-threat
+++ b/bundle/engineering-team/skills/warden-threat
@@ -1,0 +1,1 @@
+../../../skills/warden-threat

--- a/bundle/full-team/.claude-plugin/plugin.json
+++ b/bundle/full-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tonone-full-team",
-  "version": "0.6.2",
+  "version": "0.6.1",
   "description": "Full tonone team — all 23 agents (Engineering + Product) with all 125 skills",
   "author": {
     "name": "tonone-ai",

--- a/bundle/full-team/.claude-plugin/plugin.json
+++ b/bundle/full-team/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "full-team",
-  "version": "0.1.0",
-  "description": "Install all 23 tonone agents at once — Engineering Team + Product Team",
+  "name": "tonone-full-team",
+  "version": "0.6.2",
+  "description": "Full tonone team — all 23 agents (Engineering + Product) with all 125 skills",
   "author": {
     "name": "tonone-ai",
     "url": "https://tonone.ai"
@@ -9,11 +9,10 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "keywords": [
-    "bundle",
-    "installer",
+    "agents",
     "full-team",
-    "all-agents",
     "engineering-team",
-    "product-team"
+    "product-team",
+    "bundle"
   ]
 }

--- a/bundle/full-team/agents/apex.md
+++ b/bundle/full-team/agents/apex.md
@@ -1,0 +1,1 @@
+../../../agents/apex.md

--- a/bundle/full-team/agents/atlas.md
+++ b/bundle/full-team/agents/atlas.md
@@ -1,0 +1,1 @@
+../../../agents/atlas.md

--- a/bundle/full-team/agents/cortex.md
+++ b/bundle/full-team/agents/cortex.md
@@ -1,0 +1,1 @@
+../../../agents/cortex.md

--- a/bundle/full-team/agents/crest.md
+++ b/bundle/full-team/agents/crest.md
@@ -1,0 +1,1 @@
+../../../agents/crest.md

--- a/bundle/full-team/agents/draft.md
+++ b/bundle/full-team/agents/draft.md
@@ -1,0 +1,1 @@
+../../../agents/draft.md

--- a/bundle/full-team/agents/echo.md
+++ b/bundle/full-team/agents/echo.md
@@ -1,0 +1,1 @@
+../../../agents/echo.md

--- a/bundle/full-team/agents/flux.md
+++ b/bundle/full-team/agents/flux.md
@@ -1,0 +1,1 @@
+../../../agents/flux.md

--- a/bundle/full-team/agents/forge.md
+++ b/bundle/full-team/agents/forge.md
@@ -1,0 +1,1 @@
+../../../agents/forge.md

--- a/bundle/full-team/agents/form.md
+++ b/bundle/full-team/agents/form.md
@@ -1,0 +1,1 @@
+../../../agents/form.md

--- a/bundle/full-team/agents/helm.md
+++ b/bundle/full-team/agents/helm.md
@@ -1,0 +1,1 @@
+../../../agents/helm.md

--- a/bundle/full-team/agents/lens.md
+++ b/bundle/full-team/agents/lens.md
@@ -1,0 +1,1 @@
+../../../agents/lens.md

--- a/bundle/full-team/agents/lumen.md
+++ b/bundle/full-team/agents/lumen.md
@@ -1,0 +1,1 @@
+../../../agents/lumen.md

--- a/bundle/full-team/agents/pave.md
+++ b/bundle/full-team/agents/pave.md
@@ -1,0 +1,1 @@
+../../../agents/pave.md

--- a/bundle/full-team/agents/pitch.md
+++ b/bundle/full-team/agents/pitch.md
@@ -1,0 +1,1 @@
+../../../agents/pitch.md

--- a/bundle/full-team/agents/prism.md
+++ b/bundle/full-team/agents/prism.md
@@ -1,0 +1,1 @@
+../../../agents/prism.md

--- a/bundle/full-team/agents/proof.md
+++ b/bundle/full-team/agents/proof.md
@@ -1,0 +1,1 @@
+../../../agents/proof.md

--- a/bundle/full-team/agents/relay.md
+++ b/bundle/full-team/agents/relay.md
@@ -1,0 +1,1 @@
+../../../agents/relay.md

--- a/bundle/full-team/agents/spine.md
+++ b/bundle/full-team/agents/spine.md
@@ -1,0 +1,1 @@
+../../../agents/spine.md

--- a/bundle/full-team/agents/surge.md
+++ b/bundle/full-team/agents/surge.md
@@ -1,0 +1,1 @@
+../../../agents/surge.md

--- a/bundle/full-team/agents/touch.md
+++ b/bundle/full-team/agents/touch.md
@@ -1,0 +1,1 @@
+../../../agents/touch.md

--- a/bundle/full-team/agents/vigil.md
+++ b/bundle/full-team/agents/vigil.md
@@ -1,0 +1,1 @@
+../../../agents/vigil.md

--- a/bundle/full-team/agents/volt.md
+++ b/bundle/full-team/agents/volt.md
@@ -1,0 +1,1 @@
+../../../agents/volt.md

--- a/bundle/full-team/agents/warden.md
+++ b/bundle/full-team/agents/warden.md
@@ -1,0 +1,1 @@
+../../../agents/warden.md

--- a/bundle/full-team/skills/apex-plan
+++ b/bundle/full-team/skills/apex-plan
@@ -1,0 +1,1 @@
+../../../skills/apex-plan

--- a/bundle/full-team/skills/apex-recon
+++ b/bundle/full-team/skills/apex-recon
@@ -1,0 +1,1 @@
+../../../skills/apex-recon

--- a/bundle/full-team/skills/apex-review
+++ b/bundle/full-team/skills/apex-review
@@ -1,0 +1,1 @@
+../../../skills/apex-review

--- a/bundle/full-team/skills/apex-status
+++ b/bundle/full-team/skills/apex-status
@@ -1,0 +1,1 @@
+../../../skills/apex-status

--- a/bundle/full-team/skills/apex-takeover
+++ b/bundle/full-team/skills/apex-takeover
@@ -1,0 +1,1 @@
+../../../skills/apex-takeover

--- a/bundle/full-team/skills/atlas-adr
+++ b/bundle/full-team/skills/atlas-adr
@@ -1,0 +1,1 @@
+../../../skills/atlas-adr

--- a/bundle/full-team/skills/atlas-changelog
+++ b/bundle/full-team/skills/atlas-changelog
@@ -1,0 +1,1 @@
+../../../skills/atlas-changelog

--- a/bundle/full-team/skills/atlas-map
+++ b/bundle/full-team/skills/atlas-map
@@ -1,0 +1,1 @@
+../../../skills/atlas-map

--- a/bundle/full-team/skills/atlas-onboard
+++ b/bundle/full-team/skills/atlas-onboard
@@ -1,0 +1,1 @@
+../../../skills/atlas-onboard

--- a/bundle/full-team/skills/atlas-present
+++ b/bundle/full-team/skills/atlas-present
@@ -1,0 +1,1 @@
+../../../skills/atlas-present

--- a/bundle/full-team/skills/atlas-recon
+++ b/bundle/full-team/skills/atlas-recon
@@ -1,0 +1,1 @@
+../../../skills/atlas-recon

--- a/bundle/full-team/skills/atlas-report
+++ b/bundle/full-team/skills/atlas-report
@@ -1,0 +1,1 @@
+../../../skills/atlas-report

--- a/bundle/full-team/skills/cortex-eval
+++ b/bundle/full-team/skills/cortex-eval
@@ -1,0 +1,1 @@
+../../../skills/cortex-eval

--- a/bundle/full-team/skills/cortex-integrate
+++ b/bundle/full-team/skills/cortex-integrate
@@ -1,0 +1,1 @@
+../../../skills/cortex-integrate

--- a/bundle/full-team/skills/cortex-model
+++ b/bundle/full-team/skills/cortex-model
@@ -1,0 +1,1 @@
+../../../skills/cortex-model

--- a/bundle/full-team/skills/cortex-prompt
+++ b/bundle/full-team/skills/cortex-prompt
@@ -1,0 +1,1 @@
+../../../skills/cortex-prompt

--- a/bundle/full-team/skills/cortex-recon
+++ b/bundle/full-team/skills/cortex-recon
@@ -1,0 +1,1 @@
+../../../skills/cortex-recon

--- a/bundle/full-team/skills/crest-compete
+++ b/bundle/full-team/skills/crest-compete
@@ -1,0 +1,1 @@
+../../../skills/crest-compete

--- a/bundle/full-team/skills/crest-narrative
+++ b/bundle/full-team/skills/crest-narrative
@@ -1,0 +1,1 @@
+../../../skills/crest-narrative

--- a/bundle/full-team/skills/crest-okr
+++ b/bundle/full-team/skills/crest-okr
@@ -1,0 +1,1 @@
+../../../skills/crest-okr

--- a/bundle/full-team/skills/crest-recon
+++ b/bundle/full-team/skills/crest-recon
@@ -1,0 +1,1 @@
+../../../skills/crest-recon

--- a/bundle/full-team/skills/crest-roadmap
+++ b/bundle/full-team/skills/crest-roadmap
@@ -1,0 +1,1 @@
+../../../skills/crest-roadmap

--- a/bundle/full-team/skills/draft-flow
+++ b/bundle/full-team/skills/draft-flow
@@ -1,0 +1,1 @@
+../../../skills/draft-flow

--- a/bundle/full-team/skills/draft-ia
+++ b/bundle/full-team/skills/draft-ia
@@ -1,0 +1,1 @@
+../../../skills/draft-ia

--- a/bundle/full-team/skills/draft-recon
+++ b/bundle/full-team/skills/draft-recon
@@ -1,0 +1,1 @@
+../../../skills/draft-recon

--- a/bundle/full-team/skills/draft-review
+++ b/bundle/full-team/skills/draft-review
@@ -1,0 +1,1 @@
+../../../skills/draft-review

--- a/bundle/full-team/skills/draft-wireframe
+++ b/bundle/full-team/skills/draft-wireframe
@@ -1,0 +1,1 @@
+../../../skills/draft-wireframe

--- a/bundle/full-team/skills/echo-feedback
+++ b/bundle/full-team/skills/echo-feedback
@@ -1,0 +1,1 @@
+../../../skills/echo-feedback

--- a/bundle/full-team/skills/echo-interview
+++ b/bundle/full-team/skills/echo-interview
@@ -1,0 +1,1 @@
+../../../skills/echo-interview

--- a/bundle/full-team/skills/echo-jobs
+++ b/bundle/full-team/skills/echo-jobs
@@ -1,0 +1,1 @@
+../../../skills/echo-jobs

--- a/bundle/full-team/skills/echo-recon
+++ b/bundle/full-team/skills/echo-recon
@@ -1,0 +1,1 @@
+../../../skills/echo-recon

--- a/bundle/full-team/skills/echo-segment
+++ b/bundle/full-team/skills/echo-segment
@@ -1,0 +1,1 @@
+../../../skills/echo-segment

--- a/bundle/full-team/skills/flux-health
+++ b/bundle/full-team/skills/flux-health
@@ -1,0 +1,1 @@
+../../../skills/flux-health

--- a/bundle/full-team/skills/flux-migrate
+++ b/bundle/full-team/skills/flux-migrate
@@ -1,0 +1,1 @@
+../../../skills/flux-migrate

--- a/bundle/full-team/skills/flux-pipeline
+++ b/bundle/full-team/skills/flux-pipeline
@@ -1,0 +1,1 @@
+../../../skills/flux-pipeline

--- a/bundle/full-team/skills/flux-query
+++ b/bundle/full-team/skills/flux-query
@@ -1,0 +1,1 @@
+../../../skills/flux-query

--- a/bundle/full-team/skills/flux-recon
+++ b/bundle/full-team/skills/flux-recon
@@ -1,0 +1,1 @@
+../../../skills/flux-recon

--- a/bundle/full-team/skills/flux-schema
+++ b/bundle/full-team/skills/flux-schema
@@ -1,0 +1,1 @@
+../../../skills/flux-schema

--- a/bundle/full-team/skills/forge-audit
+++ b/bundle/full-team/skills/forge-audit
@@ -1,0 +1,1 @@
+../../../skills/forge-audit

--- a/bundle/full-team/skills/forge-cost
+++ b/bundle/full-team/skills/forge-cost
@@ -1,0 +1,1 @@
+../../../skills/forge-cost

--- a/bundle/full-team/skills/forge-diagnose
+++ b/bundle/full-team/skills/forge-diagnose
@@ -1,0 +1,1 @@
+../../../skills/forge-diagnose

--- a/bundle/full-team/skills/forge-infra
+++ b/bundle/full-team/skills/forge-infra
@@ -1,0 +1,1 @@
+../../../skills/forge-infra

--- a/bundle/full-team/skills/forge-network
+++ b/bundle/full-team/skills/forge-network
@@ -1,0 +1,1 @@
+../../../skills/forge-network

--- a/bundle/full-team/skills/forge-recon
+++ b/bundle/full-team/skills/forge-recon
@@ -1,0 +1,1 @@
+../../../skills/forge-recon

--- a/bundle/full-team/skills/form-audit
+++ b/bundle/full-team/skills/form-audit
@@ -1,0 +1,1 @@
+../../../skills/form-audit

--- a/bundle/full-team/skills/form-brand
+++ b/bundle/full-team/skills/form-brand
@@ -1,0 +1,1 @@
+../../../skills/form-brand

--- a/bundle/full-team/skills/form-component
+++ b/bundle/full-team/skills/form-component
@@ -1,0 +1,1 @@
+../../../skills/form-component

--- a/bundle/full-team/skills/form-deck
+++ b/bundle/full-team/skills/form-deck
@@ -1,0 +1,1 @@
+../../../skills/form-deck

--- a/bundle/full-team/skills/form-email
+++ b/bundle/full-team/skills/form-email
@@ -1,0 +1,1 @@
+../../../skills/form-email

--- a/bundle/full-team/skills/form-logo
+++ b/bundle/full-team/skills/form-logo
@@ -1,0 +1,1 @@
+../../../skills/form-logo

--- a/bundle/full-team/skills/form-mobile
+++ b/bundle/full-team/skills/form-mobile
@@ -1,0 +1,1 @@
+../../../skills/form-mobile

--- a/bundle/full-team/skills/form-social
+++ b/bundle/full-team/skills/form-social
@@ -1,0 +1,1 @@
+../../../skills/form-social

--- a/bundle/full-team/skills/form-tokens
+++ b/bundle/full-team/skills/form-tokens
@@ -1,0 +1,1 @@
+../../../skills/form-tokens

--- a/bundle/full-team/skills/form-web
+++ b/bundle/full-team/skills/form-web
@@ -1,0 +1,1 @@
+../../../skills/form-web

--- a/bundle/full-team/skills/helm-arbiter
+++ b/bundle/full-team/skills/helm-arbiter
@@ -1,0 +1,1 @@
+../../../skills/helm-arbiter

--- a/bundle/full-team/skills/helm-brief
+++ b/bundle/full-team/skills/helm-brief
@@ -1,0 +1,1 @@
+../../../skills/helm-brief

--- a/bundle/full-team/skills/helm-handoff
+++ b/bundle/full-team/skills/helm-handoff
@@ -1,0 +1,1 @@
+../../../skills/helm-handoff

--- a/bundle/full-team/skills/helm-plan
+++ b/bundle/full-team/skills/helm-plan
@@ -1,0 +1,1 @@
+../../../skills/helm-plan

--- a/bundle/full-team/skills/helm-recon
+++ b/bundle/full-team/skills/helm-recon
@@ -1,0 +1,1 @@
+../../../skills/helm-recon

--- a/bundle/full-team/skills/lens-audit
+++ b/bundle/full-team/skills/lens-audit
@@ -1,0 +1,1 @@
+../../../skills/lens-audit

--- a/bundle/full-team/skills/lens-dashboard
+++ b/bundle/full-team/skills/lens-dashboard
@@ -1,0 +1,1 @@
+../../../skills/lens-dashboard

--- a/bundle/full-team/skills/lens-metrics
+++ b/bundle/full-team/skills/lens-metrics
@@ -1,0 +1,1 @@
+../../../skills/lens-metrics

--- a/bundle/full-team/skills/lens-recon
+++ b/bundle/full-team/skills/lens-recon
@@ -1,0 +1,1 @@
+../../../skills/lens-recon

--- a/bundle/full-team/skills/lens-report
+++ b/bundle/full-team/skills/lens-report
@@ -1,0 +1,1 @@
+../../../skills/lens-report

--- a/bundle/full-team/skills/lumen-abtest
+++ b/bundle/full-team/skills/lumen-abtest
@@ -1,0 +1,1 @@
+../../../skills/lumen-abtest

--- a/bundle/full-team/skills/lumen-funnel
+++ b/bundle/full-team/skills/lumen-funnel
@@ -1,0 +1,1 @@
+../../../skills/lumen-funnel

--- a/bundle/full-team/skills/lumen-instrument
+++ b/bundle/full-team/skills/lumen-instrument
@@ -1,0 +1,1 @@
+../../../skills/lumen-instrument

--- a/bundle/full-team/skills/lumen-metrics
+++ b/bundle/full-team/skills/lumen-metrics
@@ -1,0 +1,1 @@
+../../../skills/lumen-metrics

--- a/bundle/full-team/skills/lumen-recon
+++ b/bundle/full-team/skills/lumen-recon
@@ -1,0 +1,1 @@
+../../../skills/lumen-recon

--- a/bundle/full-team/skills/pave-audit
+++ b/bundle/full-team/skills/pave-audit
@@ -1,0 +1,1 @@
+../../../skills/pave-audit

--- a/bundle/full-team/skills/pave-catalog
+++ b/bundle/full-team/skills/pave-catalog
@@ -1,0 +1,1 @@
+../../../skills/pave-catalog

--- a/bundle/full-team/skills/pave-env
+++ b/bundle/full-team/skills/pave-env
@@ -1,0 +1,1 @@
+../../../skills/pave-env

--- a/bundle/full-team/skills/pave-golden
+++ b/bundle/full-team/skills/pave-golden
@@ -1,0 +1,1 @@
+../../../skills/pave-golden

--- a/bundle/full-team/skills/pave-recon
+++ b/bundle/full-team/skills/pave-recon
@@ -1,0 +1,1 @@
+../../../skills/pave-recon

--- a/bundle/full-team/skills/pitch-copy
+++ b/bundle/full-team/skills/pitch-copy
@@ -1,0 +1,1 @@
+../../../skills/pitch-copy

--- a/bundle/full-team/skills/pitch-launch
+++ b/bundle/full-team/skills/pitch-launch
@@ -1,0 +1,1 @@
+../../../skills/pitch-launch

--- a/bundle/full-team/skills/pitch-message
+++ b/bundle/full-team/skills/pitch-message
@@ -1,0 +1,1 @@
+../../../skills/pitch-message

--- a/bundle/full-team/skills/pitch-position
+++ b/bundle/full-team/skills/pitch-position
@@ -1,0 +1,1 @@
+../../../skills/pitch-position

--- a/bundle/full-team/skills/pitch-recon
+++ b/bundle/full-team/skills/pitch-recon
@@ -1,0 +1,1 @@
+../../../skills/pitch-recon

--- a/bundle/full-team/skills/prism-audit
+++ b/bundle/full-team/skills/prism-audit
@@ -1,0 +1,1 @@
+../../../skills/prism-audit

--- a/bundle/full-team/skills/prism-component
+++ b/bundle/full-team/skills/prism-component
@@ -1,0 +1,1 @@
+../../../skills/prism-component

--- a/bundle/full-team/skills/prism-dashboard
+++ b/bundle/full-team/skills/prism-dashboard
@@ -1,0 +1,1 @@
+../../../skills/prism-dashboard

--- a/bundle/full-team/skills/prism-recon
+++ b/bundle/full-team/skills/prism-recon
@@ -1,0 +1,1 @@
+../../../skills/prism-recon

--- a/bundle/full-team/skills/prism-ui
+++ b/bundle/full-team/skills/prism-ui
@@ -1,0 +1,1 @@
+../../../skills/prism-ui

--- a/bundle/full-team/skills/proof-api
+++ b/bundle/full-team/skills/proof-api
@@ -1,0 +1,1 @@
+../../../skills/proof-api

--- a/bundle/full-team/skills/proof-audit
+++ b/bundle/full-team/skills/proof-audit
@@ -1,0 +1,1 @@
+../../../skills/proof-audit

--- a/bundle/full-team/skills/proof-e2e
+++ b/bundle/full-team/skills/proof-e2e
@@ -1,0 +1,1 @@
+../../../skills/proof-e2e

--- a/bundle/full-team/skills/proof-recon
+++ b/bundle/full-team/skills/proof-recon
@@ -1,0 +1,1 @@
+../../../skills/proof-recon

--- a/bundle/full-team/skills/proof-strategy
+++ b/bundle/full-team/skills/proof-strategy
@@ -1,0 +1,1 @@
+../../../skills/proof-strategy

--- a/bundle/full-team/skills/relay-audit
+++ b/bundle/full-team/skills/relay-audit
@@ -1,0 +1,1 @@
+../../../skills/relay-audit

--- a/bundle/full-team/skills/relay-deploy
+++ b/bundle/full-team/skills/relay-deploy
@@ -1,0 +1,1 @@
+../../../skills/relay-deploy

--- a/bundle/full-team/skills/relay-docker
+++ b/bundle/full-team/skills/relay-docker
@@ -1,0 +1,1 @@
+../../../skills/relay-docker

--- a/bundle/full-team/skills/relay-pipeline
+++ b/bundle/full-team/skills/relay-pipeline
@@ -1,0 +1,1 @@
+../../../skills/relay-pipeline

--- a/bundle/full-team/skills/relay-recon
+++ b/bundle/full-team/skills/relay-recon
@@ -1,0 +1,1 @@
+../../../skills/relay-recon

--- a/bundle/full-team/skills/spine-api
+++ b/bundle/full-team/skills/spine-api
@@ -1,0 +1,1 @@
+../../../skills/spine-api

--- a/bundle/full-team/skills/spine-design
+++ b/bundle/full-team/skills/spine-design
@@ -1,0 +1,1 @@
+../../../skills/spine-design

--- a/bundle/full-team/skills/spine-perf
+++ b/bundle/full-team/skills/spine-perf
@@ -1,0 +1,1 @@
+../../../skills/spine-perf

--- a/bundle/full-team/skills/spine-recon
+++ b/bundle/full-team/skills/spine-recon
@@ -1,0 +1,1 @@
+../../../skills/spine-recon

--- a/bundle/full-team/skills/spine-review
+++ b/bundle/full-team/skills/spine-review
@@ -1,0 +1,1 @@
+../../../skills/spine-review

--- a/bundle/full-team/skills/spine-service
+++ b/bundle/full-team/skills/spine-service
@@ -1,0 +1,1 @@
+../../../skills/spine-service

--- a/bundle/full-team/skills/surge-activation
+++ b/bundle/full-team/skills/surge-activation
@@ -1,0 +1,1 @@
+../../../skills/surge-activation

--- a/bundle/full-team/skills/surge-experiment
+++ b/bundle/full-team/skills/surge-experiment
@@ -1,0 +1,1 @@
+../../../skills/surge-experiment

--- a/bundle/full-team/skills/surge-plg
+++ b/bundle/full-team/skills/surge-plg
@@ -1,0 +1,1 @@
+../../../skills/surge-plg

--- a/bundle/full-team/skills/surge-recon
+++ b/bundle/full-team/skills/surge-recon
@@ -1,0 +1,1 @@
+../../../skills/surge-recon

--- a/bundle/full-team/skills/surge-retention
+++ b/bundle/full-team/skills/surge-retention
@@ -1,0 +1,1 @@
+../../../skills/surge-retention

--- a/bundle/full-team/skills/touch-app
+++ b/bundle/full-team/skills/touch-app
@@ -1,0 +1,1 @@
+../../../skills/touch-app

--- a/bundle/full-team/skills/touch-audit
+++ b/bundle/full-team/skills/touch-audit
@@ -1,0 +1,1 @@
+../../../skills/touch-audit

--- a/bundle/full-team/skills/touch-feature
+++ b/bundle/full-team/skills/touch-feature
@@ -1,0 +1,1 @@
+../../../skills/touch-feature

--- a/bundle/full-team/skills/touch-recon
+++ b/bundle/full-team/skills/touch-recon
@@ -1,0 +1,1 @@
+../../../skills/touch-recon

--- a/bundle/full-team/skills/touch-release
+++ b/bundle/full-team/skills/touch-release
@@ -1,0 +1,1 @@
+../../../skills/touch-release

--- a/bundle/full-team/skills/vigil-alert
+++ b/bundle/full-team/skills/vigil-alert
@@ -1,0 +1,1 @@
+../../../skills/vigil-alert

--- a/bundle/full-team/skills/vigil-check
+++ b/bundle/full-team/skills/vigil-check
@@ -1,0 +1,1 @@
+../../../skills/vigil-check

--- a/bundle/full-team/skills/vigil-incident
+++ b/bundle/full-team/skills/vigil-incident
@@ -1,0 +1,1 @@
+../../../skills/vigil-incident

--- a/bundle/full-team/skills/vigil-instrument
+++ b/bundle/full-team/skills/vigil-instrument
@@ -1,0 +1,1 @@
+../../../skills/vigil-instrument

--- a/bundle/full-team/skills/vigil-recon
+++ b/bundle/full-team/skills/vigil-recon
@@ -1,0 +1,1 @@
+../../../skills/vigil-recon

--- a/bundle/full-team/skills/volt-driver
+++ b/bundle/full-team/skills/volt-driver
@@ -1,0 +1,1 @@
+../../../skills/volt-driver

--- a/bundle/full-team/skills/volt-firmware
+++ b/bundle/full-team/skills/volt-firmware
@@ -1,0 +1,1 @@
+../../../skills/volt-firmware

--- a/bundle/full-team/skills/volt-ota
+++ b/bundle/full-team/skills/volt-ota
@@ -1,0 +1,1 @@
+../../../skills/volt-ota

--- a/bundle/full-team/skills/volt-power
+++ b/bundle/full-team/skills/volt-power
@@ -1,0 +1,1 @@
+../../../skills/volt-power

--- a/bundle/full-team/skills/volt-recon
+++ b/bundle/full-team/skills/volt-recon
@@ -1,0 +1,1 @@
+../../../skills/volt-recon

--- a/bundle/full-team/skills/warden-audit
+++ b/bundle/full-team/skills/warden-audit
@@ -1,0 +1,1 @@
+../../../skills/warden-audit

--- a/bundle/full-team/skills/warden-harden
+++ b/bundle/full-team/skills/warden-harden
@@ -1,0 +1,1 @@
+../../../skills/warden-harden

--- a/bundle/full-team/skills/warden-iam
+++ b/bundle/full-team/skills/warden-iam
@@ -1,0 +1,1 @@
+../../../skills/warden-iam

--- a/bundle/full-team/skills/warden-recon
+++ b/bundle/full-team/skills/warden-recon
@@ -1,0 +1,1 @@
+../../../skills/warden-recon

--- a/bundle/full-team/skills/warden-threat
+++ b/bundle/full-team/skills/warden-threat
@@ -1,0 +1,1 @@
+../../../skills/warden-threat

--- a/bundle/product-team/.claude-plugin/plugin.json
+++ b/bundle/product-team/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
-  "name": "product-team",
-  "version": "0.1.0",
-  "description": "Install all 8 Product Team agents at once",
+  "name": "tonone-product-team",
+  "version": "0.6.1",
+  "description": "Product team — 8 agents: Helm, Echo, Lumen, Draft, Form, Crest, Pitch, Surge",
   "author": {
     "name": "tonone-ai",
     "url": "https://tonone.ai"
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["bundle", "installer", "product-team", "all-agents"]
+  "keywords": ["agents", "product-team", "bundle"]
 }

--- a/bundle/product-team/agents/crest.md
+++ b/bundle/product-team/agents/crest.md
@@ -1,0 +1,1 @@
+../../../agents/crest.md

--- a/bundle/product-team/agents/draft.md
+++ b/bundle/product-team/agents/draft.md
@@ -1,0 +1,1 @@
+../../../agents/draft.md

--- a/bundle/product-team/agents/echo.md
+++ b/bundle/product-team/agents/echo.md
@@ -1,0 +1,1 @@
+../../../agents/echo.md

--- a/bundle/product-team/agents/form.md
+++ b/bundle/product-team/agents/form.md
@@ -1,0 +1,1 @@
+../../../agents/form.md

--- a/bundle/product-team/agents/helm.md
+++ b/bundle/product-team/agents/helm.md
@@ -1,0 +1,1 @@
+../../../agents/helm.md

--- a/bundle/product-team/agents/lumen.md
+++ b/bundle/product-team/agents/lumen.md
@@ -1,0 +1,1 @@
+../../../agents/lumen.md

--- a/bundle/product-team/agents/pitch.md
+++ b/bundle/product-team/agents/pitch.md
@@ -1,0 +1,1 @@
+../../../agents/pitch.md

--- a/bundle/product-team/agents/surge.md
+++ b/bundle/product-team/agents/surge.md
@@ -1,0 +1,1 @@
+../../../agents/surge.md

--- a/bundle/product-team/skills/crest-compete
+++ b/bundle/product-team/skills/crest-compete
@@ -1,0 +1,1 @@
+../../../skills/crest-compete

--- a/bundle/product-team/skills/crest-narrative
+++ b/bundle/product-team/skills/crest-narrative
@@ -1,0 +1,1 @@
+../../../skills/crest-narrative

--- a/bundle/product-team/skills/crest-okr
+++ b/bundle/product-team/skills/crest-okr
@@ -1,0 +1,1 @@
+../../../skills/crest-okr

--- a/bundle/product-team/skills/crest-recon
+++ b/bundle/product-team/skills/crest-recon
@@ -1,0 +1,1 @@
+../../../skills/crest-recon

--- a/bundle/product-team/skills/crest-roadmap
+++ b/bundle/product-team/skills/crest-roadmap
@@ -1,0 +1,1 @@
+../../../skills/crest-roadmap

--- a/bundle/product-team/skills/draft-flow
+++ b/bundle/product-team/skills/draft-flow
@@ -1,0 +1,1 @@
+../../../skills/draft-flow

--- a/bundle/product-team/skills/draft-ia
+++ b/bundle/product-team/skills/draft-ia
@@ -1,0 +1,1 @@
+../../../skills/draft-ia

--- a/bundle/product-team/skills/draft-recon
+++ b/bundle/product-team/skills/draft-recon
@@ -1,0 +1,1 @@
+../../../skills/draft-recon

--- a/bundle/product-team/skills/draft-review
+++ b/bundle/product-team/skills/draft-review
@@ -1,0 +1,1 @@
+../../../skills/draft-review

--- a/bundle/product-team/skills/draft-wireframe
+++ b/bundle/product-team/skills/draft-wireframe
@@ -1,0 +1,1 @@
+../../../skills/draft-wireframe

--- a/bundle/product-team/skills/echo-feedback
+++ b/bundle/product-team/skills/echo-feedback
@@ -1,0 +1,1 @@
+../../../skills/echo-feedback

--- a/bundle/product-team/skills/echo-interview
+++ b/bundle/product-team/skills/echo-interview
@@ -1,0 +1,1 @@
+../../../skills/echo-interview

--- a/bundle/product-team/skills/echo-jobs
+++ b/bundle/product-team/skills/echo-jobs
@@ -1,0 +1,1 @@
+../../../skills/echo-jobs

--- a/bundle/product-team/skills/echo-recon
+++ b/bundle/product-team/skills/echo-recon
@@ -1,0 +1,1 @@
+../../../skills/echo-recon

--- a/bundle/product-team/skills/echo-segment
+++ b/bundle/product-team/skills/echo-segment
@@ -1,0 +1,1 @@
+../../../skills/echo-segment

--- a/bundle/product-team/skills/form-audit
+++ b/bundle/product-team/skills/form-audit
@@ -1,0 +1,1 @@
+../../../skills/form-audit

--- a/bundle/product-team/skills/form-brand
+++ b/bundle/product-team/skills/form-brand
@@ -1,0 +1,1 @@
+../../../skills/form-brand

--- a/bundle/product-team/skills/form-component
+++ b/bundle/product-team/skills/form-component
@@ -1,0 +1,1 @@
+../../../skills/form-component

--- a/bundle/product-team/skills/form-deck
+++ b/bundle/product-team/skills/form-deck
@@ -1,0 +1,1 @@
+../../../skills/form-deck

--- a/bundle/product-team/skills/form-email
+++ b/bundle/product-team/skills/form-email
@@ -1,0 +1,1 @@
+../../../skills/form-email

--- a/bundle/product-team/skills/form-logo
+++ b/bundle/product-team/skills/form-logo
@@ -1,0 +1,1 @@
+../../../skills/form-logo

--- a/bundle/product-team/skills/form-mobile
+++ b/bundle/product-team/skills/form-mobile
@@ -1,0 +1,1 @@
+../../../skills/form-mobile

--- a/bundle/product-team/skills/form-social
+++ b/bundle/product-team/skills/form-social
@@ -1,0 +1,1 @@
+../../../skills/form-social

--- a/bundle/product-team/skills/form-tokens
+++ b/bundle/product-team/skills/form-tokens
@@ -1,0 +1,1 @@
+../../../skills/form-tokens

--- a/bundle/product-team/skills/form-web
+++ b/bundle/product-team/skills/form-web
@@ -1,0 +1,1 @@
+../../../skills/form-web

--- a/bundle/product-team/skills/helm-arbiter
+++ b/bundle/product-team/skills/helm-arbiter
@@ -1,0 +1,1 @@
+../../../skills/helm-arbiter

--- a/bundle/product-team/skills/helm-brief
+++ b/bundle/product-team/skills/helm-brief
@@ -1,0 +1,1 @@
+../../../skills/helm-brief

--- a/bundle/product-team/skills/helm-handoff
+++ b/bundle/product-team/skills/helm-handoff
@@ -1,0 +1,1 @@
+../../../skills/helm-handoff

--- a/bundle/product-team/skills/helm-plan
+++ b/bundle/product-team/skills/helm-plan
@@ -1,0 +1,1 @@
+../../../skills/helm-plan

--- a/bundle/product-team/skills/helm-recon
+++ b/bundle/product-team/skills/helm-recon
@@ -1,0 +1,1 @@
+../../../skills/helm-recon

--- a/bundle/product-team/skills/lumen-abtest
+++ b/bundle/product-team/skills/lumen-abtest
@@ -1,0 +1,1 @@
+../../../skills/lumen-abtest

--- a/bundle/product-team/skills/lumen-funnel
+++ b/bundle/product-team/skills/lumen-funnel
@@ -1,0 +1,1 @@
+../../../skills/lumen-funnel

--- a/bundle/product-team/skills/lumen-instrument
+++ b/bundle/product-team/skills/lumen-instrument
@@ -1,0 +1,1 @@
+../../../skills/lumen-instrument

--- a/bundle/product-team/skills/lumen-metrics
+++ b/bundle/product-team/skills/lumen-metrics
@@ -1,0 +1,1 @@
+../../../skills/lumen-metrics

--- a/bundle/product-team/skills/lumen-recon
+++ b/bundle/product-team/skills/lumen-recon
@@ -1,0 +1,1 @@
+../../../skills/lumen-recon

--- a/bundle/product-team/skills/pitch-copy
+++ b/bundle/product-team/skills/pitch-copy
@@ -1,0 +1,1 @@
+../../../skills/pitch-copy

--- a/bundle/product-team/skills/pitch-launch
+++ b/bundle/product-team/skills/pitch-launch
@@ -1,0 +1,1 @@
+../../../skills/pitch-launch

--- a/bundle/product-team/skills/pitch-message
+++ b/bundle/product-team/skills/pitch-message
@@ -1,0 +1,1 @@
+../../../skills/pitch-message

--- a/bundle/product-team/skills/pitch-position
+++ b/bundle/product-team/skills/pitch-position
@@ -1,0 +1,1 @@
+../../../skills/pitch-position

--- a/bundle/product-team/skills/pitch-recon
+++ b/bundle/product-team/skills/pitch-recon
@@ -1,0 +1,1 @@
+../../../skills/pitch-recon

--- a/bundle/product-team/skills/surge-activation
+++ b/bundle/product-team/skills/surge-activation
@@ -1,0 +1,1 @@
+../../../skills/surge-activation

--- a/bundle/product-team/skills/surge-experiment
+++ b/bundle/product-team/skills/surge-experiment
@@ -1,0 +1,1 @@
+../../../skills/surge-experiment

--- a/bundle/product-team/skills/surge-plg
+++ b/bundle/product-team/skills/surge-plg
@@ -1,0 +1,1 @@
+../../../skills/surge-plg

--- a/bundle/product-team/skills/surge-recon
+++ b/bundle/product-team/skills/surge-recon
@@ -1,0 +1,1 @@
+../../../skills/surge-recon

--- a/bundle/product-team/skills/surge-retention
+++ b/bundle/product-team/skills/surge-retention
@@ -1,0 +1,1 @@
+../../../skills/surge-retention

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,6 +6,15 @@ How Tonone is structured and why.
 
 Tonone is a Claude Code plugin that installs 23 agents and 125 skills across two teams: Engineering (15 agents) and Product (8 agents). Everything is prompt-based — agents are Markdown system prompts, skills are Markdown workflow definitions. No runtime code is required.
 
+## Platform Support
+
+| Platform    | Support   | Config file | Skills                                 |
+| ----------- | --------- | ----------- | -------------------------------------- |
+| Claude Code | Primary   | `CLAUDE.md` | Slash commands via plugin system       |
+| Codex CLI   | Secondary | `AGENTS.md` | Read `skills/<name>/SKILL.md` directly |
+
+Claude Code is the intended platform. Codex users read `AGENTS.md` for team context, then manually read agent definitions (`agents/<name>.md`) and skill workflows (`skills/<name>/SKILL.md`) — the content is identical, only the invocation mechanism differs.
+
 ```
 User runs /forge-audit
   → Claude Code loads the skill prompt from skills/forge-audit/SKILL.md

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -1,0 +1,157 @@
+"""
+Structure tests for the tonone repo.
+
+Risk map:
+- Agent definitions missing → HIGH impact (broken install, silent gaps at public release)
+- plugin.json schema violations → HIGH impact (plugin registry won't parse)
+- setup.sh missing → MEDIUM impact (agent unusable without manual workaround)
+- Skill SKILL.md missing/thin → HIGH impact (skill won't load in Claude)
+- marketplace.json out of sync → MEDIUM impact (wrong install count in registry)
+
+These are integration-level structure tests — they exercise the real filesystem,
+not mocked paths, so they catch renames, deletions, and partial scaffolds.
+"""
+
+import json
+from pathlib import Path
+
+REPO = Path(__file__).parent.parent
+AGENTS = sorted([d.name for d in (REPO / "team").iterdir() if d.is_dir()])
+
+
+# ---------------------------------------------------------------------------
+# Agent structure
+# ---------------------------------------------------------------------------
+
+
+def test_all_agents_have_plugin_json():
+    """Every agent must have a .claude-plugin/plugin.json for the plugin registry."""
+    for agent in AGENTS:
+        p = REPO / "team" / agent / ".claude-plugin" / "plugin.json"
+        assert p.exists(), f"{agent}: missing .claude-plugin/plugin.json"
+
+
+def test_all_agents_have_agent_definition():
+    """Every agent must have a canonical definition in agents/<agent>.md."""
+    for agent in AGENTS:
+        p = REPO / "agents" / f"{agent}.md"
+        assert p.exists(), f"{agent}: missing agents/{agent}.md"
+
+
+def test_all_agents_have_setup_script():
+    """Every agent must have a scripts/setup.sh for local environment setup."""
+    for agent in AGENTS:
+        p = REPO / "team" / agent / "scripts" / "setup.sh"
+        assert p.exists(), f"{agent}: missing scripts/setup.sh"
+
+
+def test_plugin_json_required_fields():
+    """plugin.json must contain name, version, and description — registry parses these."""
+    for agent in AGENTS:
+        p = REPO / "team" / agent / ".claude-plugin" / "plugin.json"
+        if not p.exists():
+            continue
+        data = json.loads(p.read_text())
+        for field in ["name", "version", "description"]:
+            assert field in data, f"{agent}/plugin.json: missing '{field}'"
+
+
+def test_agent_definitions_not_empty():
+    """Agent definitions must be substantive (>= 50 lines) — not placeholder stubs."""
+    for agent_file in sorted((REPO / "agents").glob("*.md")):
+        lines = len(agent_file.read_text().splitlines())
+        assert (
+            lines >= 50
+        ), f"agents/{agent_file.name}: only {lines} lines (suspiciously thin)"
+
+
+# ---------------------------------------------------------------------------
+# Skills
+# ---------------------------------------------------------------------------
+
+
+def test_all_skills_have_skill_md():
+    """Every skill directory must contain a SKILL.md — without it the skill won't load."""
+    skills_dir = REPO / "skills"
+    for skill_dir in sorted(skills_dir.iterdir()):
+        if skill_dir.is_dir():
+            skill_file = skill_dir / "SKILL.md"
+            assert skill_file.exists(), f"skills/{skill_dir.name}: missing SKILL.md"
+
+
+def test_skills_have_minimum_content():
+    """SKILL.md files must have at least 10 lines — catches empty scaffolded stubs."""
+    skills_dir = REPO / "skills"
+    for skill_dir in sorted(skills_dir.iterdir()):
+        skill_file = skill_dir / "SKILL.md"
+        if skill_file.exists():
+            lines = len(skill_file.read_text().splitlines())
+            assert (
+                lines >= 10
+            ), f"skills/{skill_dir.name}/SKILL.md: only {lines} lines (suspiciously thin)"
+
+
+# ---------------------------------------------------------------------------
+# Marketplace manifest
+# ---------------------------------------------------------------------------
+
+
+def test_marketplace_json_skill_count():
+    """
+    If marketplace.json has a 'skills' array, it must match the actual count of
+    skill directories. A mismatch means the manifest was not updated after adding
+    or removing skills.
+
+    Note: the current marketplace.json uses a 'plugins' array (bundle registry),
+    not a 'skills' array — so this test is a no-op today and activates automatically
+    if a skills index is added later.
+    """
+    manifest_path = REPO / ".claude-plugin" / "marketplace.json"
+    if not manifest_path.exists():
+        return  # no manifest at all — skip
+    manifest = json.loads(manifest_path.read_text())
+    if "skills" not in manifest:
+        return  # manifest exists but has no skills index — skip
+    actual_skills = len([d for d in (REPO / "skills").iterdir() if d.is_dir()])
+    listed_skills = len(manifest["skills"])
+    assert (
+        listed_skills == actual_skills
+    ), f"marketplace.json lists {listed_skills} skills but skills/ has {actual_skills} dirs"
+
+
+# ---------------------------------------------------------------------------
+# Internal consistency
+# ---------------------------------------------------------------------------
+
+
+def test_team_agents_match_agents_directory():
+    """
+    Every agent in team/ must have a matching file in agents/, and vice versa.
+    This catches the case where an agent is added to one location but not the other.
+    """
+    team_agents = set(AGENTS)
+    agents_dir_names = {f.stem for f in (REPO / "agents").glob("*.md")}
+    only_in_team = team_agents - agents_dir_names
+    only_in_agents_dir = agents_dir_names - team_agents
+    assert not only_in_team, f"In team/ but missing agents/*.md: {sorted(only_in_team)}"
+    assert (
+        not only_in_agents_dir
+    ), f"In agents/ but missing team/ dir: {sorted(only_in_agents_dir)}"
+
+
+def test_plugin_json_name_matches_agent_directory():
+    """
+    plugin.json 'name' must follow the pattern 'tonone-<agentname>'.
+    Mismatches break the registry lookup by name.
+    """
+    for agent in AGENTS:
+        p = REPO / "team" / agent / ".claude-plugin" / "plugin.json"
+        if not p.exists():
+            continue
+        data = json.loads(p.read_text())
+        if "name" not in data:
+            continue
+        expected = f"tonone-{agent}"
+        assert (
+            data["name"] == expected
+        ), f"{agent}/plugin.json: 'name' is '{data['name']}', expected '{expected}'"


### PR DESCRIPTION
## Summary

**Bundle plugin fix — the critical missing piece before public release.**

Installing \`tonone\`, \`full-team\`, \`engineering-team\`, or \`product-team\` previously delivered nothing useful — bundles were empty shells with no agents or skills. This PR fixes that.

**What changed:**

- **Bundle wiring**: Each bundle now has a \`.claude-plugin/plugin.json\` and \`agents/\` + \`skills/\` directories populated via symlinks to the canonical sources:
  - \`full-team\`: 23 agents, 125 skills
  - \`engineering-team\`: 15 agents, 80 skills
  - \`product-team\`: 8 agents, 45 skills
- **Marketplace versions**: All three bundle entries aligned to v0.6.1
- **Symlink approach**: Agents live in \`agents/\`, skills in \`skills/\` — bundles are views into those. Updating a skill automatically reflects across all bundles.

## Test Coverage

All 10 structure tests pass. Tests verify agent definitions, plugin.json fields, SKILL.md presence, and marketplace sync.

## Pre-Landing Review

No issues found. Config-only change — symlinks to existing files, no logic.

## Design Review

No frontend files changed — skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)