### PR TITLE
fix: declare agents + skills paths in all plugin manifests (v0.6.3)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tonone",
   "description": "Engineering + Product team — 23 agents as Claude Code specialists. Infrastructure, DevOps, backend, security, ML/AI, mobile, UX, analytics, growth, strategy, and more.",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "author": {
     "name": "tonone-ai",
     "url": "https://tonone.ai"
@@ -23,5 +23,7 @@
     "analytics",
     "testing",
     "platform"
-  ]
+  ],
+  "agents": "../agents/",
+  "skills": "../skills/"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.3] — 2026-04-06
+
+### Fixed
+
+- **plugin.json** — all four plugin manifests (root + 3 bundles) now declare `"agents"` and `"skills"` paths so agents like `/apex`, `/forge`, etc. are discoverable after installation
+
 ## [0.6.2] — 2026-04-06
 
 ### Added

--- a/bundle/engineering-team/.claude-plugin/plugin.json
+++ b/bundle/engineering-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tonone-engineering-team",
-  "version": "0.6.1",
+  "version": "0.6.3",
   "description": "Engineering team — 15 agents: Apex, Forge, Relay, Spine, Flux, Warden, Vigil, Prism, Cortex, Touch, Volt, Atlas, Lens, Proof, Pave",
   "author": {
     "name": "tonone-ai",
@@ -8,5 +8,7 @@
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["agents", "engineering-team", "bundle"]
+  "keywords": ["agents", "engineering-team", "bundle"],
+  "agents": "../agents/",
+  "skills": "../skills/"
 }

--- a/bundle/full-team/.claude-plugin/plugin.json
+++ b/bundle/full-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tonone-full-team",
-  "version": "0.6.1",
+  "version": "0.6.3",
   "description": "Full tonone team — all 23 agents (Engineering + Product) with all 125 skills",
   "author": {
     "name": "tonone-ai",
@@ -14,5 +14,7 @@
     "engineering-team",
     "product-team",
     "bundle"
-  ]
+  ],
+  "agents": "../agents/",
+  "skills": "../skills/"
 }

--- a/bundle/product-team/.claude-plugin/plugin.json
+++ b/bundle/product-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tonone-product-team",
-  "version": "0.6.1",
+  "version": "0.6.3",
   "description": "Product team — 8 agents: Helm, Echo, Lumen, Draft, Form, Crest, Pitch, Surge",
   "author": {
     "name": "tonone-ai",
@@ -8,5 +8,7 @@
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["agents", "product-team", "bundle"]
+  "keywords": ["agents", "product-team", "bundle"],
+  "agents": "../agents/",
+  "skills": "../skills/"
 }


### PR DESCRIPTION
## Summary

**Root cause:** After `/plugin install tonone@tonone-ai`, agents like `/apex`, `/forge`, `/relay` were invisible because all four `plugin.json` manifests had no `"agents"` or `"skills"` fields. Claude Code resolves plugin paths relative to `.claude-plugin/plugin.json`, so without explicit declarations it couldn't discover the agent/skill directories.

**Fix:** Added `"agents": "../agents/"` and `"skills": "../skills/"` to all four manifests:
- `.claude-plugin/plugin.json` (root `tonone` plugin)
- `bundle/full-team/.claude-plugin/plugin.json`
- `bundle/engineering-team/.claude-plugin/plugin.json`
- `bundle/product-team/.claude-plugin/plugin.json`

Also bumped version to 0.6.3 and added CHANGELOG entry.

## Pre-Landing Review

No issues found. Pure JSON config additions with no logic surface.

## Test plan
- [x] All structure tests pass (10/10)
- [x] Paths resolve correctly: `.claude-plugin/` → `../agents/` = repo-root `agents/`
- [x] Bundle dirs already have their own `agents/` and `skills/` symlink trees

🤖 Generated with [Claude Code](https://claude.com/claude-code)