### PR TITLE
docs: copy audit -- sharper positioning across README, AGENTS, CONTRIBUTING

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,8 @@
 # tonone — Engineering + Product Team
 
-> **Primary platform:** Claude Code. This file provides Codex CLI compatibility.
-> For Claude Code setup, see `CLAUDE.md`.
+> Codex users: start here. Claude Code users: see `CLAUDE.md`.
 
-Two AI teams. 23 agents total. Engineering executes. Product decides what to build and why.
+23 specialists just showed up. Engineering executes. Product decides.
 
 ## Engineering Team — 15 agents
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,8 @@
 # Contributing to Tonone
 
-Thanks for your interest in contributing. This guide covers the main ways to help.
+Everything is Markdown. Fork it, improve it, open a PR.
+
+Tonone is pure Markdown -- agents are system prompts, skills are workflow docs. No build step, no venv to activate, no framework to learn. If you can edit text, you can ship an improvement.
 
 ## Getting Started
 
@@ -8,8 +10,6 @@ Thanks for your interest in contributing. This guide covers the main ways to hel
 git clone https://github.com/tonone-ai/tonone.git
 cd tonone
 ```
-
-No build step required — Tonone is a Claude Code plugin made of Markdown agent definitions and skill prompts.
 
 To test your changes, install your local clone in Claude Code:
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,16 @@
 # Tonone
 
-**Engineering + product, second to none.**
+**Two commands. Full team.**
 
-Your elite AI team as [Claude Code](https://docs.anthropic.com/en/docs/claude-code) agents. 2 leads + 21 specialists. 125 skills. Every major engineering and product discipline covered.
-
-Simple by default. Scalable by design.
+23 specialists just showed up. Engineering executes. Product decides. 125 skills across every discipline. MIT licensed, two commands to install.
 
 ## Why This Exists
 
 Right now, everyone gets a generalized AI assistant. Engineers, product managers, designers, strategists — all prompting separately, getting separate outputs, then copying results into Slack threads for the next person to feed back into AI. It's a relay race where every handoff loses context.
 
-**That's the wrong unit of automation.** Instead of giving each person an AI assistant, give the whole company an AI team. Specialists that talk to each other, share context, and run the show end to end — from user research to infrastructure to deployment — without the copy-paste relay.
+**The team is the unit. Not the assistant.** Instead of giving each person an AI assistant, give the whole company an AI team. Specialists that talk to each other, share context, and run the show end to end — from user research to infrastructure to deployment — without the copy-paste relay.
 
-That's Tonone. Not twenty-three copies of the same generalist. Twenty-three specialists, each owning one domain, coordinated by leads who know when to call who and at what depth.
-
-### The Mindset
-
-**Complexity is debt.** Every unnecessary abstraction, every over-engineered solution, every "just in case" feature — it all accrues interest. It slows you down today and buries you tomorrow.
-
-**Scalability compounds.** When you build simple, correct foundations, they carry more weight over time without breaking. Simple systems are easier to debug, easier to extend, and easier to hand off.
-
-No boilerplate generators. No tutorial-grade scaffolds. Production-ready output that respects your codebase, your stack, and your time.
+That's Tonone. Not twenty-three copies of the same generalist. Twenty-three specialists, each owning one domain, coordinated by leads who know when to call who and at what depth. Production-ready output. No tutorials. No boilerplate.
 
 ## The Team
 
@@ -68,7 +58,7 @@ No boilerplate generators. No tutorial-grade scaffolds. Production-ready output 
 /plugin install tonone@tonone-ai
 ```
 
-Then just talk to them:
+Your team is ready:
 
 ```
 > /apex-plan Build a real-time analytics platform for our IoT fleet
@@ -80,7 +70,7 @@ Then just talk to them:
 > /crest-roadmap Build a product roadmap
 ```
 
-### Codex CLI (secondary)
+### Codex CLI
 
 **Prerequisites:** [Codex CLI](https://github.com/openai/codex) installed
 
@@ -102,7 +92,7 @@ Skills are markdown workflow documents in `skills/<name>/SKILL.md`. Read them an
 
 ## What You Get
 
-Every agent can **build**, **review**, and **recon**:
+Every specialist ships in three modes:
 
 | Mode       | What It Means                                         | Example Skills                                                  |
 | ---------- | ----------------------------------------------------- | --------------------------------------------------------------- |
@@ -110,9 +100,9 @@ Every agent can **build**, **review**, and **recon**:
 | **Review** | Audit and fix existing systems                        | `/warden-audit`, `/relay-audit`, `/prism-audit`, `/vigil-check` |
 | **Recon**  | Survey a domain for system takeover                   | `/forge-recon`, `/spine-recon`, `/flux-recon`, `/apex-takeover` |
 
-### Platform-Aware
+### They detect your stack
 
-Every engineering agent detects your stack and adapts:
+Every engineering agent adapts to what you're already using:
 
 - **Cloud:** GCP, AWS, Azure, Cloudflare, Vercel, Fly.io, Hetzner, DigitalOcean
 - **CI/CD:** GitHub Actions, GitLab CI, Cloud Build, CircleCI, Bitbucket Pipelines
@@ -124,7 +114,7 @@ Every engineering agent detects your stack and adapts:
 
 ### The Leads
 
-**Apex** is the engineering lead. Give it a task, it figures out who to involve and at what depth:
+**Apex** leads the engineering team. Tell it what you're building:
 
 ```
 You: "Build user authentication for our SaaS"
@@ -382,4 +372,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) to get started — improve skills, propos
 
 ## License
 
-MIT — see [LICENSE](LICENSE)
+MIT. Fork it. Ship it. Use it anywhere. [LICENSE](LICENSE)


### PR DESCRIPTION
## Summary

Full copy audit pass applying the \"Two commands. Full team.\" positioning to all user-facing surfaces.

**README.md**
- Tagline: \"Two commands. Full team.\" -- passes the 5-second stranger test
- Opening: benefit-led, cuts \"elite\" filler adjective, surfaces MIT upfront
- Why This Exists: tightened pivot line to \"The team is the unit. Not the assistant.\"
- Cut \"The Mindset\" section (philosophy leak) -- one keeper line moved inline
- Cut \"Simple by default. Scalable by design.\" (floating, no positioning value)
- Quick Start: \"Your team is ready:\" instead of \"Then just talk to them:\"
- Codex section: removed \"(secondary)\" label
- What You Get: \"Every specialist ships in three modes:\"
- Platform heading: \"They detect your stack\" + \"adapts to what you're already using\"
- Apex intro: direct -- \"Tell it what you're building:\"
- License: \"MIT. Fork it. Ship it. Use it anywhere.\"

**AGENTS.md**
- Opening note: \"Codex users: start here. Claude Code users: see CLAUDE.md.\"
- Second line: benefit-led -- \"23 specialists just showed up. Engineering executes. Product decides.\"

**CONTRIBUTING.md**
- Lead with the WOW: \"Everything is Markdown. Fork it, improve it, open a PR.\"
- Surfaces the no-build-step fact prominently in the opener

## Test plan
- [ ] README renders correctly on GitHub
- [ ] AGENTS.md Codex note is clear and welcoming
- [ ] CONTRIBUTING.md opener sets the right tone for new contributors

🤖 Generated with [Claude Code](https://claude.com/claude-code)