### PR TITLE
fix: bundle plugin installs + README install docs (v0.6.4)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tonone",
   "description": "Engineering + Product team — 23 agents as Claude Code specialists. Infrastructure, DevOps, backend, security, ML/AI, mobile, UX, analytics, growth, strategy, and more.",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "author": {
     "name": "tonone-ai",
     "url": "https://tonone.ai"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.4] — 2026-04-06
+
+### Fixed
+
+- **bundle manifests** — removed invalid `"agents"` and `"skills"` string fields from all three bundle plugin.json files; Claude Code auto-discovers these directories and the string format caused a validation error on install
+- **README** — Quick Start now shows both CLI (`claude plugin`) and in-session (`/plugin`) installation pathways; code fences labelled with language identifiers
+
 ## [0.6.3] — 2026-04-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -53,14 +53,23 @@ That's Tonone. Not twenty-three copies of the same generalist. Twenty-three spec
 
 **Prerequisites:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code) v1.0+
 
+From your terminal:
+
+```bash
+claude plugin marketplace add tonone-ai/tonone
+claude plugin install tonone@tonone-ai
 ```
+
+Or inside an active Claude Code session:
+
+```text
 /plugin marketplace add tonone-ai/tonone
 /plugin install tonone@tonone-ai
 ```
 
 Your team is ready:
 
-```
+```text
 > /apex-plan Build a real-time analytics platform for our IoT fleet
 > /helm-brief Define the next product sprint
 > /forge-infra Set up cloud infrastructure for a new SaaS product
@@ -82,7 +91,7 @@ codex
 
 Codex reads `AGENTS.md` automatically. Invoke agents and skills by describing what you want:
 
-```
+```text
 > Read agents/forge.md and act as Forge — audit this infrastructure
 > Read agents/apex.md — plan this project with S/M/L options
 > Follow the workflow in skills/warden-audit/SKILL.md
@@ -116,7 +125,7 @@ Every engineering agent adapts to what you're already using:
 
 **Apex** leads the engineering team. Tell it what you're building:
 
-```
+```text
 You: "Build user authentication for our SaaS"
 
 Apex: I see 3 ways to approach this:
@@ -139,7 +148,7 @@ Apex: I see 3 ways to approach this:
 
 Inherited a codebase? Apex runs parallel reconnaissance across all specialists:
 
-```
+```text
 > /apex-takeover
 
 Phase 1 — Recon (parallel):

--- a/bundle/engineering-team/.claude-plugin/plugin.json
+++ b/bundle/engineering-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tonone-engineering-team",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Engineering team — 15 agents: Apex, Forge, Relay, Spine, Flux, Warden, Vigil, Prism, Cortex, Touch, Volt, Atlas, Lens, Proof, Pave",
   "author": {
     "name": "tonone-ai",

--- a/bundle/engineering-team/.claude-plugin/plugin.json
+++ b/bundle/engineering-team/.claude-plugin/plugin.json
@@ -8,7 +8,5 @@
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["agents", "engineering-team", "bundle"],
-  "agents": "../agents/",
-  "skills": "../skills/"
+  "keywords": ["agents", "engineering-team", "bundle"]
 }

--- a/bundle/full-team/.claude-plugin/plugin.json
+++ b/bundle/full-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tonone-full-team",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Full tonone team — all 23 agents (Engineering + Product) with all 125 skills",
   "author": {
     "name": "tonone-ai",

--- a/bundle/full-team/.claude-plugin/plugin.json
+++ b/bundle/full-team/.claude-plugin/plugin.json
@@ -14,7 +14,5 @@
     "engineering-team",
     "product-team",
     "bundle"
-  ],
-  "agents": "../agents/",
-  "skills": "../skills/"
+  ]
 }

--- a/bundle/product-team/.claude-plugin/plugin.json
+++ b/bundle/product-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tonone-product-team",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Product team — 8 agents: Helm, Echo, Lumen, Draft, Form, Crest, Pitch, Surge",
   "author": {
     "name": "tonone-ai",

--- a/bundle/product-team/.claude-plugin/plugin.json
+++ b/bundle/product-team/.claude-plugin/plugin.json
@@ -8,7 +8,5 @@
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["agents", "product-team", "bundle"],
-  "agents": "../agents/",
-  "skills": "../skills/"
+  "keywords": ["agents", "product-team", "bundle"]
 }


### PR DESCRIPTION
## Summary

**Bundle manifest fix** — all three bundle plugins (`engineering-team`, `product-team`, `full-team`) were failing to install with \`agents: Invalid input, skills: Invalid input\` because plugin.json declared those fields as strings (\`\"../agents/\"\`). Claude Code's validator rejects string values — it expects these fields to be absent and auto-discovers \`agents/\` and \`skills/\` directories from the plugin root. Removed from all three manifests.

**README Quick Start** — now shows both installation pathways:
- Terminal CLI: \`claude plugin marketplace add\` / \`claude plugin install\`
- In-session: \`/plugin marketplace add\` / \`/plugin install\`

Also fixed unlabelled code fences (markdownlint warnings).

## Pre-Landing Review
No issues found. Pure config + docs change, no application logic.

## Test Coverage
No testable code paths changed — manifest and markdown only.

## Plan Completion
No plan file detected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)