### PR TITLE
fix: rename marketplace from "ai" to "tonone-ai"

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,8 +1,8 @@
 {
-  "name": "ai",
+  "name": "tonone-ai",
   "description": "Engineering + Product Teams \u2014 23 Claude Code agents covering engineering and product functions",
   "owner": {
-    "name": "ai",
+    "name": "tonone-ai",
     "url": "https://tonone.ai"
   },
   "plugins": [


### PR DESCRIPTION
## Summary

`marketplace.json` declared `"name": "ai"`. Claude Code registered the marketplace as `ai`. The documented install command `claude plugin install tonone@tonone-ai` looked for marketplace `tonone-ai` — which didn't exist — returning "Plugin not found".

**Fix:** `"name": "ai"` → `"name": "tonone-ai"` in the top-level and owner fields of `marketplace.json`.

This is the second part of the two-issue root cause (first was the invalid path fields fixed in #29).

## Root cause summary

| Issue | File | Symptom | Fixed in |
|-------|------|---------|----------|
| Invalid `agents`/`skills` paths | `.claude-plugin/plugin.json` | Plugin excluded from index | #29 |
| Wrong marketplace name | `.claude-plugin/marketplace.json` | Marketplace lookup fails | this PR |

## Test plan
- [ ] Remove marketplace: `/plugin` or CLI equivalent
- [ ] Re-add: `claude plugin marketplace add tonone-ai/tonone`
- [ ] Should register as `tonone-ai` (not `ai`)
- [ ] `claude plugin install tonone@tonone-ai` should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)