### PR TITLE
docs: sharpen README tagline + fix stale test (v0.6.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.5] — 2026-04-07
+
+### Changed
+
+- **README** — tagline sharpened to "One session. Two commands. Full team. Zero meetings."
+
+### Fixed
+
+- **test_structure.py** — updated naming assertion to match bare plugin name convention (no `tonone-` prefix) introduced in v0.6.4
+
 ## [0.6.4] — 2026-04-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tonone
 
-**Two commands. Full team.**
+**One session. Two commands. Full team. Zero meetings.**
 
 23 specialists just showed up. Engineering executes. Product decides. 125 skills across every discipline. MIT licensed, two commands to install.
 

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -141,7 +141,7 @@ def test_team_agents_match_agents_directory():
 
 def test_plugin_json_name_matches_agent_directory():
     """
-    plugin.json 'name' must follow the pattern 'tonone-<agentname>'.
+    plugin.json 'name' must match the agent directory name (bare, no prefix).
     Mismatches break the registry lookup by name.
     """
     for agent in AGENTS:
@@ -151,7 +151,7 @@ def test_plugin_json_name_matches_agent_directory():
         data = json.loads(p.read_text())
         if "name" not in data:
             continue
-        expected = f"tonone-{agent}"
+        expected = agent
         assert (
             data["name"] == expected
         ), f"{agent}/plugin.json: 'name' is '{data['name']}', expected '{expected}'"


### PR DESCRIPTION
## Summary

**README**
- Tagline updated: \"Two commands. Full team.\" → \"One session. Two commands. Full team. Zero meetings.\"

**Tests**
- Fixed `test_plugin_json_name_matches_agent_directory` — assertion was checking for `tonone-{agent}` prefix that was dropped in v0.6.4 (#28). Updated to match bare agent name convention.

## Pre-Landing Review

No issues found. 2-line diff, docs + test only.

## Test plan
- [x] All 10 structure tests pass (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)