### PR TITLE
fix: marketplace compliance — skill frontmatter, YAML fixes, agent tools

### DIFF
--- a/agents/apex.md
+++ b/agents/apex.md
@@ -1,13 +1,6 @@
 ---
 name: apex
 description: Engineering lead — orchestrates the team, scopes work, controls depth and budget
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
-  - Agent
 model: opus
 ---
 

--- a/agents/atlas.md
+++ b/agents/atlas.md
@@ -1,12 +1,6 @@
 ---
 name: atlas
 description: Knowledge engineer — architecture docs, ADRs, API specs, system diagrams, onboarding
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/agents/cortex.md
+++ b/agents/cortex.md
@@ -1,12 +1,6 @@
 ---
 name: cortex
 description: ML/AI engineer — LLM integration, prompt engineering, RAG, evals, and AI feature design for production
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/agents/crest.md
+++ b/agents/crest.md
@@ -1,12 +1,6 @@
 ---
 name: crest
 description: Product strategist — diagnosis-first strategy, roadmap sequencing, competitive positioning, and market decisions
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/agents/draft.md
+++ b/agents/draft.md
@@ -1,12 +1,6 @@
 ---
 name: draft
 description: UX designer — user flows, information architecture, wireframes, and interaction design
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/agents/echo.md
+++ b/agents/echo.md
@@ -1,12 +1,6 @@
 ---
 name: echo
 description: User researcher — interviews, personas, Jobs-to-Be-Done, and customer feedback synthesis
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/agents/flux.md
+++ b/agents/flux.md
@@ -1,12 +1,6 @@
 ---
 name: flux
 description: Data engineer — databases, migrations, pipelines, data modeling
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/agents/forge.md
+++ b/agents/forge.md
@@ -1,12 +1,6 @@
 ---
 name: forge
 description: Infrastructure engineer — cloud services, networking, IaC, cost optimization
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/agents/form.md
+++ b/agents/form.md
@@ -1,12 +1,6 @@
 ---
 name: form
 description: Visual designer — brand identity, color systems, typography, UI design, and design systems
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/agents/helm.md
+++ b/agents/helm.md
@@ -1,13 +1,6 @@
 ---
 name: helm
 description: Head of Product — product strategy, requirements, and engineering handoff via the Helm↔Apex interface
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
-  - Agent
 model: sonnet
 ---
 

--- a/agents/lens.md
+++ b/agents/lens.md
@@ -1,12 +1,6 @@
 ---
 name: lens
 description: Data analytics & BI engineer — dashboards, metrics design, reporting, data storytelling
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/agents/lumen.md
+++ b/agents/lumen.md
@@ -1,12 +1,6 @@
 ---
 name: lumen
 description: Product analyst — metrics architecture, funnel analysis, A/B test design, retention, and growth measurement
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/agents/pave.md
+++ b/agents/pave.md
@@ -1,12 +1,6 @@
 ---
 name: pave
 description: Platform engineer — developer experience, golden paths, service catalogs, environment management, internal tooling. Builds what removes friction for the team that exists.
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/agents/pitch.md
+++ b/agents/pitch.md
@@ -1,12 +1,6 @@
 ---
 name: pitch
 description: Product marketer — positioning, messaging, value proposition, GTM strategy, and launch copy
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/agents/prism.md
+++ b/agents/prism.md
@@ -1,12 +1,6 @@
 ---
 name: prism
 description: Frontend & DX engineer — translates Form's design system into production UI components, pages, and internal tools
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/agents/proof.md
+++ b/agents/proof.md
@@ -1,12 +1,6 @@
 ---
 name: proof
 description: QA & testing engineer — test strategy, E2E suites, integration testing, test infrastructure, flaky test triage
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/agents/relay.md
+++ b/agents/relay.md
@@ -1,12 +1,6 @@
 ---
 name: relay
 description: DevOps engineer — CI/CD, deployments, GitOps, developer experience
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/agents/spine.md
+++ b/agents/spine.md
@@ -1,12 +1,6 @@
 ---
 name: spine
 description: Backend engineer — APIs, system design, performance, distributed systems
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/agents/surge.md
+++ b/agents/surge.md
@@ -1,12 +1,6 @@
 ---
 name: surge
 description: Growth engineer — acquisition channels, activation funnels, retention playbooks, and PLG strategy
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/agents/touch.md
+++ b/agents/touch.md
@@ -1,12 +1,6 @@
 ---
 name: touch
 description: Mobile engineer — native iOS/Android, cross-platform, app stores, mobile performance
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/agents/vigil.md
+++ b/agents/vigil.md
@@ -1,12 +1,6 @@
 ---
 name: vigil
 description: Observability & reliability engineer — SLOs, alerting, instrumentation, incident response. Writes configs and runbooks, doesn't produce roadmaps.
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/agents/volt.md
+++ b/agents/volt.md
@@ -1,12 +1,6 @@
 ---
 name: volt
 description: Embedded & IoT engineer — firmware architecture, microcontrollers, OTA updates, edge computing, device protocols
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/agents/warden.md
+++ b/agents/warden.md
@@ -1,12 +1,6 @@
 ---
 name: warden
 description: Security engineer — IAM, secrets, threat modeling, hardening, auth, and supply chain security
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/skills/apex-plan/SKILL.md
+++ b/skills/apex-plan/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: apex-plan
 description: Plan and scope a project — discovery, challenge assumptions, present S/M/L options with token and cost estimates. Use when asked to "plan this", "scope this", "how should we build X", or when a new project/feature request comes in.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Apex Plan

--- a/skills/apex-recon/SKILL.md
+++ b/skills/apex-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: apex-recon
 description: Engineering lead reconnaissance — inventory the project before planning. Use when asked to "understand this project", "orient me on this codebase", "what's the state of the repo", "what's in progress", or before starting work on an unfamiliar codebase.
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Engineering Reconnaissance

--- a/skills/apex-review/SKILL.md
+++ b/skills/apex-review/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: apex-review
 description: Cross-cutting review of recent work — catches gaps between specialists. Use when asked to "review what we built", "check the work", "pre-launch review", or after completing a significant chunk of work.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Apex Review

--- a/skills/apex-status/SKILL.md
+++ b/skills/apex-status/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: apex-status
 description: CTO-level project status from git and codebase state. Use when asked "where are we", "project status", "what's done", or at the start of a work session.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Apex Status

--- a/skills/apex-takeover/SKILL.md
+++ b/skills/apex-takeover/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: apex-takeover
 description: System takeover — take ownership of an existing codebase or inherited system. Use when "we acquired this", "previous team left", "take over this system", "inherited this codebase".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Apex Takeover

--- a/skills/atlas-adr/SKILL.md
+++ b/skills/atlas-adr/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: atlas-adr
 description: Write an Architecture Decision Record — document what was decided, why, what alternatives were considered, and what trade-offs were accepted. Use when asked to "write an ADR", "document this decision", or "why did we choose X".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Write an Architecture Decision Record

--- a/skills/atlas-changelog/SKILL.md
+++ b/skills/atlas-changelog/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: atlas-changelog
 description: Maintain per-repo and cross-repo changelogs — append structured entries after agent work. Use when asked to "log this change", "update changelog", "what changed", "change history".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Maintain Changelog

--- a/skills/atlas-map/SKILL.md
+++ b/skills/atlas-map/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: atlas-map
 description: Map the system architecture — read the codebase, identify services and connections, output a C4-level architecture map as Mermaid diagrams with component descriptions. Use when asked to "map the architecture", "system diagram", "how does this work", or "architecture overview".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Map the System Architecture

--- a/skills/atlas-onboard/SKILL.md
+++ b/skills/atlas-onboard/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: atlas-onboard
 description: Generate onboarding documentation — what this project does, how to set up locally, where things live, key decisions, how to deploy. Written for day-one engineers who know nothing. Use when asked for "onboarding docs", "new engineer guide", "how to get started", or "developer setup".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Generate Onboarding Documentation

--- a/skills/atlas-present/SKILL.md
+++ b/skills/atlas-present/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: atlas-present
 description: Generate a polished HTML presentation page and Obsidian Canvas for big releases — new products, takeovers, major migrations. Non-technical audience. Use when asked to "present this", "release announcement", "show what we built", or "stakeholder update".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Release Presentation

--- a/skills/atlas-recon/SKILL.md
+++ b/skills/atlas-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: atlas-recon
 description: Documentation reconnaissance for takeover — find all docs, assess accuracy, freshness, coverage, and discoverability, and identify critical knowledge gaps. Use when asked "what docs exist", "documentation assessment", or "knowledge gaps".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Documentation Reconnaissance

--- a/skills/atlas-report/SKILL.md
+++ b/skills/atlas-report/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: atlas-report
 description: Render agent findings as a styled HTML report in the browser. Use when asked for "full report", "detailed report", "show in browser", or when CLI output exceeds the 40-line budget.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Render HTML Report

--- a/skills/cortex-eval/SKILL.md
+++ b/skills/cortex-eval/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: cortex-eval
 description: Evaluate model performance — check for accuracy drops, data drift, and error patterns. Use when asked about "model accuracy dropped", "evaluate the model", "check for drift", or "model performance".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Evaluate Model Performance

--- a/skills/cortex-integrate/SKILL.md
+++ b/skills/cortex-integrate/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: cortex-integrate
 description: Design and implement an AI feature integration — model selection, architecture pattern, system prompt, data flow, error handling, cost estimate. Use when asked to "add AI to this", "LLM integration", "add Claude/GPT", or "AI-powered feature".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # AI Feature Integration

--- a/skills/cortex-model/SKILL.md
+++ b/skills/cortex-model/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: cortex-model
 description: Build an ML pipeline — from data to trained model to serving endpoint. Use when asked to "build ML model", "train a model", "prediction pipeline", "classification", or "regression".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build an ML Pipeline

--- a/skills/cortex-prompt/SKILL.md
+++ b/skills/cortex-prompt/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: cortex-prompt
 description: Build a production-ready prompt package — system prompt, few-shot examples, output format, edge case handling, eval criteria. Use when asked to "prompt engineering", "build a prompt", "write a system prompt", or "improve this prompt".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build a Production-Ready Prompt

--- a/skills/cortex-recon/SKILL.md
+++ b/skills/cortex-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: cortex-recon
 description: ML reconnaissance — inventory all models, pipelines, data sources, and monitoring. Use when asked "what ML do we have", "model inventory", or "ML assessment".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # ML Reconnaissance

--- a/skills/crest-compete/SKILL.md
+++ b/skills/crest-compete/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: crest-compete
 description: Competitive analysis ending in a clear positioning call — where to play, how to win. Use when asked to "analyze competitors", "competitive landscape", "how do we compare to X", "competitive positioning", "where should we play", "find our white space", or "who else does this".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Competitive Analysis

--- a/skills/crest-narrative/SKILL.md
+++ b/skills/crest-narrative/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: crest-narrative
 description: Strategic narrative — write a standalone strategy memo that frames product direction, bets, and rationale for a planning horizon. Use when asked to "write a strategy doc", "product vision", "strategic narrative", "company strategy memo", "planning memo", or "explain our product direction".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Strategic Narrative

--- a/skills/crest-okr/SKILL.md
+++ b/skills/crest-okr/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: crest-okr
 description: OKR design — create objectives and key results with a North Star metric, input metrics tree, and cadence. Use when asked to "set OKRs", "define our objectives", "what should we measure this quarter", "design our OKR framework", "build a metrics tree", or "what's our North Star".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # OKR Design

--- a/skills/crest-recon/SKILL.md
+++ b/skills/crest-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: crest-recon
 description: Strategic context reconnaissance — read existing roadmaps, OKRs, competitive docs, and briefs to establish context before planning. Use when asked to "understand our strategy", "what's the current roadmap", "what OKRs do we have", "strategic context", or before starting any prioritization or roadmap work.
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Strategic Reconnaissance

--- a/skills/crest-roadmap/SKILL.md
+++ b/skills/crest-roadmap/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: crest-roadmap
 description: Build a product roadmap with sequenced bets and explicit tradeoffs. Use when asked to "build a roadmap", "prioritize the backlog strategically", "what do we build next quarter", "sequence our bets", "what should we focus on", or "product strategy for the next N months".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Crest Roadmap

--- a/skills/draft-flow/SKILL.md
+++ b/skills/draft-flow/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: draft-flow
-description: Use when asked to design a user flow, map how a user moves through a feature, create a wireframe or flow diagram, or document interaction design for a product brief. Examples: "design the flow for X", "map out the user journey", "create a wireframe for this feature", "how should the UX work for this".
+description: |
+  Use when asked to design a user flow, map how a user moves through a feature, create a wireframe or flow diagram, or document interaction design for a product brief. Examples: "design the flow for X", "map out the user journey", "create a wireframe for this feature", "how should the UX work for this".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Draft Flow

--- a/skills/draft-ia/SKILL.md
+++ b/skills/draft-ia/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: draft-ia
 description: Information architecture — design navigation structure, content hierarchy, sitemap, and taxonomy for a product or feature set. Use when asked to "organize the navigation", "information architecture", "how should content be structured", "sitemap", "nav redesign", "where should X live", or "content hierarchy".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Information Architecture

--- a/skills/draft-recon/SKILL.md
+++ b/skills/draft-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: draft-recon
 description: UI and UX reconnaissance — scan existing frontend routes, components, navigation, and flows to understand the current UX state before designing. Use when asked to "understand the current UI", "what UX patterns exist", "map the navigation", "what screens exist", or before starting any flow or wireframe work.
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # UX Reconnaissance

--- a/skills/draft-review/SKILL.md
+++ b/skills/draft-review/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: draft-review
 description: Usability review — evaluate an existing flow or UI against usability heuristics, flag friction points, and recommend fixes. Use when asked to "review the UX", "usability audit", "what's wrong with this flow", "UX feedback", "critique this design", or "why are users dropping off here".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Usability Review

--- a/skills/draft-wireframe/SKILL.md
+++ b/skills/draft-wireframe/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: draft-wireframe
 description: Text and Mermaid wireframes — produce screen-level layouts with content hierarchy, component placement, and interaction annotations. Use when asked to "wireframe this", "sketch the UI", "layout for this screen", "lo-fi mockup", "screen design", or "what should this page look like".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Wireframe

--- a/skills/echo-feedback/SKILL.md
+++ b/skills/echo-feedback/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: echo-feedback
 description: Feedback synthesis — cluster support tickets, NPS verbatims, app store reviews, and churn surveys by theme, separate signal from noise, and produce an actionable insight report. Use when asked to "synthesize this feedback", "analyze support tickets", "what are users complaining about", "NPS analysis", "churn feedback synthesis", or "what's the feedback telling us".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Feedback Synthesis

--- a/skills/echo-interview/SKILL.md
+++ b/skills/echo-interview/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: echo-interview
 description: Run a user interview — produce an interview guide and synthesize the output into an actionable insight report. Use when asked to "run a user interview", "synthesize these interview notes", "what do users actually want", "build a persona from this feedback", "find the JTBD in these transcripts", or "analyze this interview data".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Echo Interview

--- a/skills/echo-jobs/SKILL.md
+++ b/skills/echo-jobs/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: echo-jobs
 description: Jobs-to-Be-Done analysis — given a product, user descriptions, transcripts, or tickets, produce a JTBD job map with switching forces analysis and opportunity ranking. Use when asked to "find the JTBD", "what jobs are users hiring us for", "job mapping", "what are users really trying to do", "JTBD framework", or "why are users switching".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Jobs-to-Be-Done Analysis

--- a/skills/echo-recon/SKILL.md
+++ b/skills/echo-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: echo-recon
 description: User research reconnaissance — survey existing personas, research docs, interview notes, and feedback artifacts to establish what is already known about users. Use when asked to "what research exists", "review existing personas", "what do we know about our users", or before starting new research or synthesis work.
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Research Reconnaissance

--- a/skills/echo-segment/SKILL.md
+++ b/skills/echo-segment/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: echo-segment
 description: User segmentation and persona creation from mixed data sources — analytics, CRM, support tickets, reviews, or any combination. Use when asked to "build personas", "who are our users", "segment our users", "create user profiles", "define user archetypes", or "who is the target user".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # User Segmentation and Personas

--- a/skills/flux-health/SKILL.md
+++ b/skills/flux-health/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: flux-health
 description: Data quality and pipeline health check — freshness, schema drift, null rates, orphaned records, pipeline status. Use when asked about "data quality check", "pipeline health", "is our data fresh", or "schema drift".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Data Quality and Pipeline Health

--- a/skills/flux-migrate/SKILL.md
+++ b/skills/flux-migrate/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: flux-migrate
 description: Build zero-downtime database migrations — forward SQL, rollback SQL, deployment sequence. Use when asked to "write migration", "schema change", "add column", "rename table", "drop column", or "migrate safely".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build Zero-Downtime Migration

--- a/skills/flux-pipeline/SKILL.md
+++ b/skills/flux-pipeline/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: flux-pipeline
 description: Build a data pipeline — ETL/ELT with extraction, transformation, loading, error handling, and scheduling. Use when asked to "build ETL", "data pipeline", "move data from X to Y", or "sync data".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build a Data Pipeline

--- a/skills/flux-query/SKILL.md
+++ b/skills/flux-query/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: flux-query
 description: Optimize slow database queries — analyze execution plans, add indexes, rewrite queries. Use when asked about "slow query", "optimize SQL", "query performance", or "explain this query".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Optimize Slow Queries

--- a/skills/flux-recon/SKILL.md
+++ b/skills/flux-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: flux-recon
 description: Database reconnaissance — full inventory of schema, migrations, data volume, backups, connection pooling, and query patterns. Use when asked to "assess this database", "understand the schema", or "database health check".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Database Reconnaissance

--- a/skills/flux-schema/SKILL.md
+++ b/skills/flux-schema/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: flux-schema
 description: Design and build database schema — tables, columns, types, indexes, constraints, relationships. Given a domain description, output the schema and write the files. Use when asked to "design schema", "database design", "create tables", or "data model".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Design and Build Database Schema

--- a/skills/forge-audit/SKILL.md
+++ b/skills/forge-audit/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: forge-audit
 description: Audit existing infrastructure for security issues, waste, and misconfigurations. Use when asked to "audit my infra", "check cloud setup", "infra review", "are we wasting money", "security check on infra", or "review my terraform".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Audit Existing Infrastructure

--- a/skills/forge-cost/SKILL.md
+++ b/skills/forge-cost/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: forge-cost
 description: Audit cloud infrastructure costs and produce a concrete optimization plan with specific changes and estimated savings. Use when asked to "how much is this costing", "reduce cloud spend", "cost optimization", "are we overpaying", "cloud bill", or "budget for this infra".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Cost Audit and Optimization Plan

--- a/skills/forge-diagnose/SKILL.md
+++ b/skills/forge-diagnose/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: forge-diagnose
 description: Diagnose runtime infrastructure issues — cold starts, timeouts, scaling problems, network failures. Use when asked about "infra is slow", "cold starts", "network issues", "why is this timing out", "scaling problem", "latency spikes", or "service is down".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Diagnose Runtime Infrastructure Issues

--- a/skills/forge-infra/SKILL.md
+++ b/skills/forge-infra/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: forge-infra
 description: Build production-grade infrastructure as code for a service or project. Use when asked to "set up infra", "provision infrastructure", "create cloud resources", "IaC for this project", "terraform for this", or "deploy this service".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build Infrastructure as Code

--- a/skills/forge-network/SKILL.md
+++ b/skills/forge-network/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: forge-network
 description: Design and build networking infrastructure — VPCs, subnets, DNS, load balancers, firewall rules. Use when asked to "set up networking", "VPC design", "configure DNS", "load balancer setup", "network architecture", or "firewall rules".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Design and Build Networking

--- a/skills/forge-recon/SKILL.md
+++ b/skills/forge-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: forge-recon
 description: Infrastructure reconnaissance — inventory all cloud resources, map connections, flag risks. Use when asked to "inventory our infra", "what infrastructure do we have", "map our cloud resources", "infra discovery", or "what's running in our cloud".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Infrastructure Reconnaissance

--- a/skills/form-audit/SKILL.md
+++ b/skills/form-audit/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: form-audit
-description: Use when asked to audit UI for visual quality, check design consistency, review brand alignment, evaluate design system compliance, or find visual issues before a launch. Examples: "audit our UI", "check visual consistency", "review the design for issues", "is our UI on-brand", "find visual bugs", "design QA before launch".
+description: |
+  Use when asked to audit UI for visual quality, check design consistency, review brand alignment, evaluate design system compliance, or find visual issues before a launch. Examples: "audit our UI", "check visual consistency", "review the design for issues", "is our UI on-brand", "find visual bugs", "design QA before launch".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Form Audit

--- a/skills/form-brand/SKILL.md
+++ b/skills/form-brand/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: form-brand
-description: Use when asked to create a brand identity, define visual design direction, generate a color palette or type system, build a style guide, or establish the look and feel for a product. Examples: "create a brand for X", "define the visual identity", "what colors should we use", "build a style guide", "design system foundations".
+description: |
+  Use when asked to create a brand identity, define visual design direction, generate a color palette or type system, build a style guide, or establish the look and feel for a product. Examples: "create a brand for X", "define the visual identity", "what colors should we use", "build a style guide", "design system foundations".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Form Brand

--- a/skills/form-component/SKILL.md
+++ b/skills/form-component/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: form-component
-description: Use when asked to design a UI component, specify a button, input, card, modal, badge, or any interactive element. Examples: "design a button component", "spec out the input field", "define the card component states", "create a component spec for Prism", "what should the dropdown look like".
+description: |
+  Use when asked to design a UI component, specify a button, input, card, modal, badge, or any interactive element. Examples: "design a button component", "spec out the input field", "define the card component states", "create a component spec for Prism", "what should the dropdown look like".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Form Component

--- a/skills/form-deck/SKILL.md
+++ b/skills/form-deck/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: form-deck
-description: Use when asked to design a pitch deck, presentation, or slide set. Examples: "design a pitch deck", "create a sales deck", "make a conference presentation", "build an investor deck", "help me present this to the board", "create slides for X".
+description: |
+  Use when asked to design a pitch deck, presentation, or slide set. Examples: "design a pitch deck", "create a sales deck", "make a conference presentation", "build an investor deck", "help me present this to the board", "create slides for X".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Form Deck

--- a/skills/form-email/SKILL.md
+++ b/skills/form-email/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: form-email
-description: Use when asked to design an email template, newsletter, drip campaign email, transactional email, or any HTML email asset. Examples: "design a welcome email", "create a newsletter template", "make an onboarding email sequence", "design a password reset email", "build an email campaign".
+description: |
+  Use when asked to design an email template, newsletter, drip campaign email, transactional email, or any HTML email asset. Examples: "design a welcome email", "create a newsletter template", "make an onboarding email sequence", "design a password reset email", "build an email campaign".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Form Email

--- a/skills/form-logo/SKILL.md
+++ b/skills/form-logo/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: form-logo
-description: Use when asked to create a logo, design a brand mark, generate a logo concept, or produce any logo asset. Examples: "create a logo for X", "design a brand mark", "make me a logo", "generate logo concepts", "logo for our product".
+description: |
+  Use when asked to create a logo, design a brand mark, generate a logo concept, or produce any logo asset. Examples: "create a logo for X", "design a brand mark", "make me a logo", "generate logo concepts", "logo for our product".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Form Logo

--- a/skills/form-mobile/SKILL.md
+++ b/skills/form-mobile/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: form-mobile
-description: Use when asked to design iOS or Android mobile app screens, create mobile UI, spec mobile flows, or produce screen designs for a native app. Examples: "design the onboarding screens", "spec the checkout flow for iOS", "design a home screen for Android", "create mobile UI for this feature".
+description: |
+  Use when asked to design iOS or Android mobile app screens, create mobile UI, spec mobile flows, or produce screen designs for a native app. Examples: "design the onboarding screens", "spec the checkout flow for iOS", "design a home screen for Android", "create mobile UI for this feature".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Form Mobile

--- a/skills/form-social/SKILL.md
+++ b/skills/form-social/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: form-social
-description: Use when asked to design social media graphics, ad creatives, or marketing assets. Examples: "design a LinkedIn post for our launch", "create ad creatives for our campaign", "make an Instagram story", "design a Twitter card", "create a banner ad", "social assets for the product announcement".
+description: |
+  Use when asked to design social media graphics, ad creatives, or marketing assets. Examples: "design a LinkedIn post for our launch", "create ad creatives for our campaign", "make an Instagram story", "design a Twitter card", "create a banner ad", "social assets for the product announcement".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Form Social

--- a/skills/form-tokens/SKILL.md
+++ b/skills/form-tokens/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: form-tokens
-description: Use when asked to define a design token system, create tokens, document tokens, set up CSS custom properties, build a Tailwind token config, establish a spacing scale, define color semantics, or bridge design decisions to code. Examples: "set up design tokens", "define our token system", "create CSS variables for the design system", "document our color tokens", "establish a spacing scale".
+description: |
+  Use when asked to define a design token system, create tokens, document tokens, set up CSS custom properties, build a Tailwind token config, establish a spacing scale, define color semantics, or bridge design decisions to code. Examples: "set up design tokens", "define our token system", "create CSS variables for the design system", "document our color tokens", "establish a spacing scale".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Form Tokens

--- a/skills/form-web/SKILL.md
+++ b/skills/form-web/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: form-web
-description: Use when asked to design a landing page, marketing website, or any web presence intended to convert or inform. Examples: "design a landing page for X", "create a marketing site", "we need a homepage", "design our website", "build a page for our launch".
+description: |
+  Use when asked to design a landing page, marketing website, or any web presence intended to convert or inform. Examples: "design a landing page for X", "create a marketing site", "we need a homepage", "design our website", "build a page for our launch".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Form Web

--- a/skills/helm-arbiter/SKILL.md
+++ b/skills/helm-arbiter/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: helm-arbiter
 description: Scope arbitration — resolve disagreements between product and engineering on what is in or out of scope, with a decision log and escalation path. Use when asked to "resolve this scope disagreement", "arbitrate between product and eng", "scope is creeping", "we can't agree on what's in scope", or "help us decide what to cut".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Scope Arbitration

--- a/skills/helm-brief/SKILL.md
+++ b/skills/helm-brief/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: helm-brief
-description: Use when asked to write a product brief, turn a feature idea into a spec, define requirements for something to build, or clarify what a product should do and why. Examples: "write a brief for X", "turn this idea into a spec", "what should we build here", "help me define requirements".
+description: |
+  Use when asked to write a product brief, turn a feature idea into a spec, define requirements for something to build, or clarify what a product should do and why. Examples: "write a brief for X", "turn this idea into a spec", "what should we build here", "help me define requirements".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Helm Brief

--- a/skills/helm-handoff/SKILL.md
+++ b/skills/helm-handoff/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: helm-handoff
-description: Use when a product brief is finalized and ready to hand off to the engineering team, or when asked to send a brief to Apex, kick off engineering work, or start development on a product spec. Examples: "hand this off to engineering", "send brief to Apex", "start building this", "kick off dev on this spec".
+description: |
+  Use when a product brief is finalized and ready to hand off to the engineering team, or when asked to send a brief to Apex, kick off engineering work, or start development on a product spec. Examples: "hand this off to engineering", "send brief to Apex", "start building this", "kick off dev on this spec".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Helm Handoff

--- a/skills/helm-plan/SKILL.md
+++ b/skills/helm-plan/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: helm-plan
-description: Use when asked to build a product roadmap, prioritize a backlog, decide what to build next, or sequence a list of feature ideas. Examples: "what should we build next", "prioritize this backlog", "make a roadmap", "RICE score these features".
+description: |
+  Use when asked to build a product roadmap, prioritize a backlog, decide what to build next, or sequence a list of feature ideas. Examples: "what should we build next", "prioritize this backlog", "make a roadmap", "RICE score these features".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Helm Plan

--- a/skills/helm-recon/SKILL.md
+++ b/skills/helm-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: helm-recon
 description: Product landscape reconnaissance — survey existing briefs, research, strategy, and team output before writing new briefs or dispatching specialists. Use when asked to "understand the product state", "what briefs exist", "what has the team produced", "orient me on this product", or before starting a new product initiative.
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Product Reconnaissance

--- a/skills/lens-audit/SKILL.md
+++ b/skills/lens-audit/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: lens-audit
 description: Review existing analytics — find all dashboards and reports, check who uses them, whether metrics are defined, and whether they drive decisions. Recommend what to keep, kill, or add. Use when asked "are our dashboards useful", "analytics review", or "metrics audit".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Audit Existing Analytics

--- a/skills/lens-dashboard/SKILL.md
+++ b/skills/lens-dashboard/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: lens-dashboard
 description: Design and spec an analytical dashboard — define the question each chart answers, write the SQL queries, spec the layout and refresh cadence. Produces a complete dashboard spec ready to implement. Use when asked to "build a dashboard", "analytics dashboard", "BI dashboard", "weekly product health", or "visualize this data".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build Analytical Dashboard

--- a/skills/lens-metrics/SKILL.md
+++ b/skills/lens-metrics/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: lens-metrics
 description: Produce a complete metrics definition doc — metric name, formula, data source, segmentation, SQL or event tracking spec, and what good/bad looks like. Given a product area, outputs the full metrics spec. Use when asked to "define KPIs", "metrics framework", "what should we measure", "north star metric", or "instrument this feature".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Define and Implement Metrics

--- a/skills/lens-recon/SKILL.md
+++ b/skills/lens-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: lens-recon
 description: Analytics reconnaissance for takeover — find all analytics tools, inventory what's tracked and dashboarded, assess data freshness and metric definitions, and present a coverage map. Use when asked "what analytics exist", "BI assessment", or "what do we track".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Analytics Reconnaissance

--- a/skills/lens-report/SKILL.md
+++ b/skills/lens-report/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: lens-report
 description: Build a reporting pipeline — scheduled reports with SQL queries, delivery via Slack or email, threshold alerts, and historical comparison. Use when asked for "automated reports", "scheduled report", "email digest", or "Slack alerts for metrics".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build Reporting Pipeline

--- a/skills/lumen-abtest/SKILL.md
+++ b/skills/lumen-abtest/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: lumen-abtest
 description: A/B test design — produce an experiment spec with hypothesis, primary metric, MDE, sample size, run time, and decision rule. Also determines when NOT to A/B test and what to do instead. Use when asked to "design an A/B test", "should we test this", "experiment design", "how do we know if this works", "what's the sample size", or "set up an experiment".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Lumen A/B Test

--- a/skills/lumen-funnel/SKILL.md
+++ b/skills/lumen-funnel/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: lumen-funnel
-description: Use when asked to analyze a funnel, find where users drop off, diagnose low conversion or activation rates, design a metrics framework, set up OKRs, or measure whether a feature is working. Examples: "analyze our funnel", "why is activation low", "where are users dropping off", "design OKRs for this quarter", "is this feature working", "set up metrics for this launch".
+description: |
+  Use when asked to analyze a funnel, find where users drop off, diagnose low conversion or activation rates, design a metrics framework, set up OKRs, or measure whether a feature is working. Examples: "analyze our funnel", "why is activation low", "where are users dropping off", "design OKRs for this quarter", "is this feature working", "set up metrics for this launch".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Lumen Funnel

--- a/skills/lumen-instrument/SKILL.md
+++ b/skills/lumen-instrument/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: lumen-instrument
 description: Instrumentation plan — design event taxonomy, property schema, and tracking plan for analytics tools. Use when asked to "what should we track", "instrumentation plan", "set up analytics events", "analytics event schema", "tracking plan", or "instrument this feature".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Instrumentation Plan

--- a/skills/lumen-metrics/SKILL.md
+++ b/skills/lumen-metrics/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: lumen-metrics
 description: Metrics architecture — produce a complete metrics plan given a product description. North Star, input metrics tree, instrumentation spec, action triggers, and counter-metrics. Use when asked to "design a metrics framework", "what should we measure", "build a metrics system", "define our KPIs", "what are our success metrics", "metrics strategy", or "what do we track".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Lumen Metrics

--- a/skills/lumen-recon/SKILL.md
+++ b/skills/lumen-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: lumen-recon
 description: Analytics reconnaissance — scan existing event tracking, metric definitions, dashboards, and analytics configuration to understand what is currently being measured. Use when asked to "what are we tracking", "audit our analytics", "what metrics exist", "analytics inventory", or before designing new metrics or instrumentation.
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Analytics Reconnaissance

--- a/skills/pave-audit/SKILL.md
+++ b/skills/pave-audit/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: pave-audit
 description: Audit developer experience — measure onboarding time, build speed, deployment friction, and developer satisfaction. Use when asked to "DX audit", "developer experience review", "why is development slow", "onboarding assessment", or "DORA metrics".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Developer Experience Audit

--- a/skills/pave-catalog/SKILL.md
+++ b/skills/pave-catalog/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: pave-catalog
 description: Build a service catalog — schema, starter entries, and governance model. Produces what information to capture per service, how it's maintained, and where it lives. Use when asked to "service catalog", "what services do we have", "catalog our services", "service inventory", or "who owns what".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Service Catalog

--- a/skills/pave-env/SKILL.md
+++ b/skills/pave-env/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: pave-env
 description: Set up local development environments — devcontainers, Docker Compose, one-command setup, dev/prod parity. Use when asked to "set up dev environment", "devcontainer", "docker compose for dev", "local development setup", or "one command to run".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Development Environment

--- a/skills/pave-golden/SKILL.md
+++ b/skills/pave-golden/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: pave-golden
 description: Define a golden path — the opinionated, supported way to do a common developer task (create a new service, set up an environment, deploy a feature). Produces concrete steps, templates, and tooling. Use when asked to "golden path", "create project template", "scaffold a new service", "how should we create services", or "standardize our setup".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Golden Path Definition

--- a/skills/pave-recon/SKILL.md
+++ b/skills/pave-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: pave-recon
 description: Platform reconnaissance — inventory all developer tooling, environments, build systems, and developer workflows for project takeover. Use when asked to "understand the dev setup", "developer tooling assessment", "platform assessment", or "how do developers work here".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Platform Reconnaissance

--- a/skills/pitch-copy/SKILL.md
+++ b/skills/pitch-copy/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: pitch-copy
 description: Landing page and marketing copy — write hero section, problem/solution blocks, proof points, and CTAs. Use when asked to "write landing page copy", "write the homepage", "marketing copy for this feature", "product page copy", "write the hero section", or "write copy for [surface]".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Marketing Copy

--- a/skills/pitch-launch/SKILL.md
+++ b/skills/pitch-launch/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: pitch-launch
 description: Produce an actual launch plan with announcement copy, channel sequence, and day-1 checklist. Use when asked to "plan a launch", "GTM strategy", "how do we announce this", "launch plan for [feature]", "go-to-market", "write our Product Hunt post", or "how do we get people to notice this".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Pitch Launch

--- a/skills/pitch-message/SKILL.md
+++ b/skills/pitch-message/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: pitch-message
 description: Messaging framework — produce a full headline, subheadline, proof points, and CTA hierarchy for use across all surfaces. Use when asked to "write our messaging", "messaging framework", "what should our headline say", "copy hierarchy", "tagline and messaging", or "how do we talk about the product".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Messaging Framework

--- a/skills/pitch-position/SKILL.md
+++ b/skills/pitch-position/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: pitch-position
 description: Produce a complete positioning document using the Dunford framework — competitive alternatives, unique attributes, value, best-fit customer, market category, positioning statement, and tagline. Use when asked to "write our positioning", "define our value prop", "positioning statement", "what market are we in", "how do we position against X", "what's our tagline", or "write our messaging foundation".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Pitch Position

--- a/skills/pitch-recon/SKILL.md
+++ b/skills/pitch-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: pitch-recon
 description: Marketing and messaging reconnaissance — read existing landing pages, copy, positioning docs, and marketing materials to understand the current messaging state. Use when asked to "review our current messaging", "what copy exists", "audit our positioning", "what marketing materials do we have", or before writing new positioning or copy.
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Marketing Reconnaissance

--- a/skills/prism-audit/SKILL.md
+++ b/skills/prism-audit/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: prism-audit
 description: Frontend audit — bundle size, dependencies, accessibility, performance, component quality. Use when asked for "frontend review", "performance audit", "accessibility check", or "bundle size".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Frontend Audit

--- a/skills/prism-component/SKILL.md
+++ b/skills/prism-component/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: prism-component
 description: Implement a reusable, accessible, typed component from a design spec. Use when asked to "create a component", "build a widget", "implement this design", or "reusable UI element".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Implement a Component

--- a/skills/prism-dashboard/SKILL.md
+++ b/skills/prism-dashboard/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: prism-dashboard
 description: Build an internal dashboard with data tables, filters, detail views, and CRUD. Use when asked to build an "admin panel", "internal dashboard", "back office", or "data dashboard UI".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build an Internal Dashboard

--- a/skills/prism-recon/SKILL.md
+++ b/skills/prism-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: prism-recon
 description: Frontend reconnaissance — map the component tree, routing, state management, build config, and assess quality. Use when asked to "understand this frontend", "frontend assessment", or "what's the UI built with".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Frontend Reconnaissance

--- a/skills/prism-ui/SKILL.md
+++ b/skills/prism-ui/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: prism-ui
 description: Implement a complete UI screen or feature from a Form visual spec. Use when asked to "build a page", "implement this screen", "build the frontend for this feature", or "create this UI".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Implement a UI Screen or Feature

--- a/skills/proof-api/SKILL.md
+++ b/skills/proof-api/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: proof-api
 description: Build API test suites — endpoint testing, contract testing, load testing for REST/GraphQL/gRPC APIs. Use when asked to "test this API", "API tests", "endpoint testing", "contract tests", or "load test".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # API Test Suite

--- a/skills/proof-audit/SKILL.md
+++ b/skills/proof-audit/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: proof-audit
 description: Audit test suite health — find flaky tests, slow tests, coverage gaps, and testing anti-patterns. Use when asked to "audit tests", "fix flaky tests", "why are tests slow", "test health", or "improve test suite".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Test Suite Audit

--- a/skills/proof-e2e/SKILL.md
+++ b/skills/proof-e2e/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: proof-e2e
 description: Build E2E test specs for critical user journeys — Playwright or Cypress, page objects, setup/teardown, CI config. Use when asked to "write E2E tests", "end-to-end testing", "browser tests", "UI tests", or "Playwright tests".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # E2E Test Suite

--- a/skills/proof-recon/SKILL.md
+++ b/skills/proof-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: proof-recon
 description: Testing reconnaissance — inventory all tests, frameworks, coverage, CI integration, and assess testing maturity for project takeover. Use when asked to "understand the tests", "testing assessment", "what's tested", or "test inventory".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Testing Reconnaissance

--- a/skills/proof-strategy/SKILL.md
+++ b/skills/proof-strategy/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: proof-strategy
 description: Produce a test strategy for a project or feature — risk map, test type decisions, coverage targets, CI config. Use when asked to "create test strategy", "what should we test", "testing plan", or "improve test coverage".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Test Strategy

--- a/skills/relay-audit/SKILL.md
+++ b/skills/relay-audit/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: relay-audit
 description: Audit an existing CI/CD pipeline for slowness, security issues, and reliability gaps. Use when asked to "audit pipeline", "why is CI slow", "pipeline review", or "deployment review".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Audit Existing Pipeline

--- a/skills/relay-deploy/SKILL.md
+++ b/skills/relay-deploy/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: relay-deploy
 description: Set up a complete deployment configuration — Dockerfile, deployment manifest, environment config, and rollback procedure. Use when asked about "deployment setup", "how do I deploy this", "deployment strategy", or "rollback plan".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Set Up Deployment Configuration

--- a/skills/relay-docker/SKILL.md
+++ b/skills/relay-docker/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: relay-docker
 description: Build production-ready Dockerfiles with multi-stage builds, security hardening, and docker-compose for local dev. Use when asked to "create Dockerfile", "optimize container", or "dockerize this".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build Production Dockerfiles

--- a/skills/relay-pipeline/SKILL.md
+++ b/skills/relay-pipeline/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: relay-pipeline
 description: Build a full CI/CD pipeline from scratch. Use when asked to "set up CI/CD", "create pipeline", or "automate deploys".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build CI/CD Pipeline

--- a/skills/relay-recon/SKILL.md
+++ b/skills/relay-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: relay-recon
 description: Map the full CI/CD pipeline — triggers, build, test, deploy flow — with risk assessment. Use when asked "how does this deploy", "map the pipeline", or "understand CI/CD".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Pipeline Reconnaissance

--- a/skills/spine-api/SKILL.md
+++ b/skills/spine-api/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: spine-api
 description: Design and spec an API — endpoints, request/response shapes, error codes, auth pattern, pagination. Applies Stripe's consistency principles. Use when asked to "design an API", "build API endpoints", "create REST API", or "API for this feature".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Design and Build an API

--- a/skills/spine-design/SKILL.md
+++ b/skills/spine-design/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: spine-design
 description: Produce a system design doc — components, data flow, decisions made, tradeoffs, failure modes. Not a list of options. An actual design with calls made. Use when asked for "system design for", "architect this", "how should we build", or "design the backend".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # System Design

--- a/skills/spine-perf/SKILL.md
+++ b/skills/spine-perf/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: spine-perf
 description: Find and fix performance bottlenecks — N+1 queries, missing indexes, sync bottlenecks, caching gaps. Use when asked "why is this slow", "performance issue", "optimize this endpoint", or "N+1 queries".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Find and Fix Performance Bottlenecks

--- a/skills/spine-recon/SKILL.md
+++ b/skills/spine-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: spine-recon
 description: Backend reconnaissance — map all routes, middleware, models, dependencies, auth, and assess code quality for project takeover. Use when asked to "understand this backend", "map the API", or "assess code quality".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Backend Reconnaissance

--- a/skills/spine-review/SKILL.md
+++ b/skills/spine-review/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: spine-review
 description: API and backend code review — REST conventions, auth, validation, error handling, pagination, rate limiting, test coverage. Use when asked to "review this API", "code review", "review backend", or "pre-launch backend check".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # API and Code Review

--- a/skills/spine-service/SKILL.md
+++ b/skills/spine-service/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: spine-service
 description: Build a new production-ready service from scratch — config management, health checks, graceful shutdown, structured logging. Use when asked to "new service", "scaffold a backend", "bootstrap service", or "create microservice".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build a New Service

--- a/skills/surge-activation/SKILL.md
+++ b/skills/surge-activation/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: surge-activation
-description: Use when asked to improve activation, map the growth funnel, identify growth levers, design a referral program, build a retention playbook, develop a PLG strategy, or find where to invest in growth. Examples: "how do we grow faster", "improve our activation rate", "design a referral program", "build a retention playbook", "what are our best growth levers", "map our growth funnel".
+description: |
+  Use when asked to improve activation, map the growth funnel, identify growth levers, design a referral program, build a retention playbook, develop a PLG strategy, or find where to invest in growth. Examples: "how do we grow faster", "improve our activation rate", "design a referral program", "build a retention playbook", "what are our best growth levers", "map our growth funnel".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Surge Activation

--- a/skills/surge-experiment/SKILL.md
+++ b/skills/surge-experiment/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: surge-experiment
 description: Growth experiment design — structure a growth hypothesis, define metric, baseline, expected lift, and kill condition for a single experiment. Use when asked to "design a growth experiment", "test this growth idea", "experiment framework", "how do we test if this works", or "growth hypothesis".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Growth Experiment Design

--- a/skills/surge-plg/SKILL.md
+++ b/skills/surge-plg/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: surge-plg
 description: PLG motion design — free tier definition, activation sequence, expansion trigger points, viral mechanic assessment. Given a product, output the PLG architecture and make the calls. Use when asked to "PLG strategy", "freemium model", "product-led growth plan", "self-serve motion", "how do we add a free tier", "upgrade triggers", or "viral loop design".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # PLG Motion Design

--- a/skills/surge-recon/SKILL.md
+++ b/skills/surge-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: surge-recon
 description: Growth state reconnaissance — scan existing onboarding flows, acquisition channels, conversion funnels, and growth experiment logs to understand current growth state. Use when asked to "what's our growth state", "audit the funnel", "what growth experiments have we run", "acquisition channel inventory", or before designing new growth experiments.
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Growth Reconnaissance

--- a/skills/surge-retention/SKILL.md
+++ b/skills/surge-retention/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: surge-retention
 description: Retention diagnosis + intervention plan — analyze the retention curve, identify the primary drop-off point, and produce a specific intervention plan with expected impact. Use when asked to "improve retention", "why are users churning", "build a retention playbook", "reduce churn", "win-back campaign", or "users aren't coming back".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Retention Diagnosis + Intervention Plan

--- a/skills/touch-app/SKILL.md
+++ b/skills/touch-app/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: touch-app
 description: Produce a complete mobile app architecture design — platform choice, navigation structure, state management, data layer, key screens. Use when asked to "build a mobile app", "new app", "create iOS/Android app", "app architecture", or "cross-platform app".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Mobile App Architecture Design

--- a/skills/touch-audit/SKILL.md
+++ b/skills/touch-audit/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: touch-audit
 description: Mobile audit — app size, startup time, crash reporting, store compliance, accessibility, offline behavior. Use when asked for "mobile review", "app store readiness", "mobile performance", or "crash analysis".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Mobile Audit

--- a/skills/touch-feature/SKILL.md
+++ b/skills/touch-feature/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: touch-feature
 description: Produce a mobile feature spec — user story, technical approach, component breakdown, platform-specific considerations, edge cases. Use when asked to "add a screen", "spec this feature", "mobile feature", "new tab", "push notifications", or "deep link".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Mobile Feature Spec

--- a/skills/touch-recon/SKILL.md
+++ b/skills/touch-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: touch-recon
 description: Mobile reconnaissance — understand the app's tech stack, architecture, dependencies, and health for takeover. Use when asked to "understand this app", "mobile assessment", or "app health".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Mobile Reconnaissance

--- a/skills/touch-release/SKILL.md
+++ b/skills/touch-release/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: touch-release
 description: Set up mobile release pipeline — Fastlane, code signing, CI, beta distribution, versioning. Use when asked about "app store setup", "release pipeline", "fastlane", "beta distribution", or "signing".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Set Up Mobile Release Pipeline

--- a/skills/vigil-alert/SKILL.md
+++ b/skills/vigil-alert/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: vigil-alert
 description: Write SLO-based alert rules with burn rate thresholds and paired runbooks. Outputs actual alert configs, not a strategy doc. Use when asked to "set up alerts", "create runbooks", "define SLOs", or "alerting strategy".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build Alert Rules and Runbooks

--- a/skills/vigil-check/SKILL.md
+++ b/skills/vigil-check/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: vigil-check
 description: Verify observability posture — audit monitoring coverage, find blind spots, prioritize gaps. Use when asked "is monitoring sufficient", "observability review", "are we covered", or "pre-launch monitoring check".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Verify Observability Posture

--- a/skills/vigil-incident/SKILL.md
+++ b/skills/vigil-incident/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: vigil-incident
 description: Incident response — diagnose production issues, find root cause, propose fix with rollback. Use when asked about "something is broken", "production issue", "why is this down", "incident", or "debug production".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Incident Response

--- a/skills/vigil-instrument/SKILL.md
+++ b/skills/vigil-instrument/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: vigil-instrument
 description: Instrument a service with OpenTelemetry — RED metrics, structured logs, distributed tracing, and health checks. Outputs actual code and config, not a plan. Use when asked to "add monitoring", "instrument this", "add logging", "set up tracing", or "observability".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Instrument a Service

--- a/skills/vigil-recon/SKILL.md
+++ b/skills/vigil-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: vigil-recon
 description: Observability reconnaissance — inventory what monitoring exists, map coverage, highlight blind spots. Use when asked "what monitoring exists", "observability assessment", or "what can we see".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Observability Reconnaissance

--- a/skills/volt-driver/SKILL.md
+++ b/skills/volt-driver/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: volt-driver
 description: Build a device driver or protocol handler — I2C sensors, BLE services, MQTT clients, SPI peripherals with interrupt-driven I/O and clean HAL abstraction. Use when asked to "write a driver", "I2C device", "BLE service", "MQTT client", or "sensor integration".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build Device Driver or Protocol Handler

--- a/skills/volt-firmware/SKILL.md
+++ b/skills/volt-firmware/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: volt-firmware
 description: Produce a complete firmware architecture spec for a described device — layer diagram, module responsibilities, HAL interface definitions, key state machines, RTOS decision. Use when asked to "design firmware architecture", "plan embedded firmware", "architect an IoT device", "how should I structure this firmware", or given a device description and asked what the firmware should look like.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Firmware Architecture Spec

--- a/skills/volt-ota/SKILL.md
+++ b/skills/volt-ota/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: volt-ota
 description: Produce a complete OTA update system design — partition layout, update flow, rollback conditions, validation checks, fleet management approach, failure modes and recovery. Use when asked about "OTA updates", "firmware updates over the air", "how do I update devices in the field", "OTA strategy", or "remote firmware update design".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # OTA Update System Design

--- a/skills/volt-power/SKILL.md
+++ b/skills/volt-power/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: volt-power
 description: Power management audit — analyze sleep modes, wake sources, power state machines, radio duty cycles, and battery life estimates. Use when asked to "audit power usage", "optimize battery life", "review power management", "why is my battery draining", "power budget analysis", or "sleep mode review".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Power Management Audit

--- a/skills/volt-recon/SKILL.md
+++ b/skills/volt-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: volt-recon
 description: Firmware reconnaissance for takeover — inventory the MCU, peripherals, RTOS, protocols, OTA, power management, and assess code quality with risk flags. Use when asked to "understand this firmware", "device inventory", or "embedded assessment".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Firmware Reconnaissance

--- a/skills/warden-audit/SKILL.md
+++ b/skills/warden-audit/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: warden-audit
 description: Full security audit — secrets, dependencies, IAM, auth, injection, XSS, HTTPS, rate limiting, public storage. Use when asked for "security audit", "check for vulnerabilities", "security review", or "are we secure".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Full Security Audit

--- a/skills/warden-harden/SKILL.md
+++ b/skills/warden-harden/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: warden-harden
 description: Produce a hardening spec and implement it — auth patterns, security headers, rate limiting, input validation, secrets management, dependency hygiene. Use when asked to "harden this", "add security to this service", "what security do I need", or "secure this before launch".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Harden a Service

--- a/skills/warden-iam/SKILL.md
+++ b/skills/warden-iam/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: warden-iam
 description: Build IAM from scratch — roles, policies, service accounts with least privilege. Use when asked to "set up IAM", "create roles", "service accounts", or "access control".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build IAM from Scratch

--- a/skills/warden-recon/SKILL.md
+++ b/skills/warden-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: warden-recon
 description: Security reconnaissance — full inventory of secrets management, IAM, dependencies, auth, encryption, audit logging, and compliance gaps. Use when asked about "security posture", "how secure is this", or "security assessment".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Security Reconnaissance

--- a/skills/warden-threat/SKILL.md
+++ b/skills/warden-threat/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: warden-threat
 description: Produce a threat model — assets, ranked threats, mitigations, accepted risks. Use when asked to "threat model this", "what could go wrong security-wise", "map our attack surface", or before designing any security-sensitive feature.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Threat Model

--- a/team/apex/agents/apex.md
+++ b/team/apex/agents/apex.md
@@ -1,13 +1,6 @@
 ---
 name: apex
 description: Engineering lead — orchestrates the team, scopes work, controls depth and budget
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
-  - Agent
 model: opus
 ---
 

--- a/team/apex/skills/apex-plan/SKILL.md
+++ b/team/apex/skills/apex-plan/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: apex-plan
 description: Plan and scope a project — discovery, challenge assumptions, present S/M/L options with token and cost estimates. Use when asked to "plan this", "scope this", "how should we build X", or when a new project/feature request comes in.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Apex Plan

--- a/team/apex/skills/apex-recon/SKILL.md
+++ b/team/apex/skills/apex-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: apex-recon
 description: Engineering lead reconnaissance — inventory the project before planning. Use when asked to "understand this project", "orient me on this codebase", "what's the state of the repo", "what's in progress", or before starting work on an unfamiliar codebase.
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Engineering Reconnaissance

--- a/team/apex/skills/apex-review/SKILL.md
+++ b/team/apex/skills/apex-review/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: apex-review
 description: Cross-cutting review of recent work — catches gaps between specialists. Use when asked to "review what we built", "check the work", "pre-launch review", or after completing a significant chunk of work.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Apex Review

--- a/team/apex/skills/apex-status/SKILL.md
+++ b/team/apex/skills/apex-status/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: apex-status
 description: CTO-level project status from git and codebase state. Use when asked "where are we", "project status", "what's done", or at the start of a work session.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Apex Status

--- a/team/apex/skills/apex-takeover/SKILL.md
+++ b/team/apex/skills/apex-takeover/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: apex-takeover
 description: System takeover — take ownership of an existing codebase or inherited system. Use when "we acquired this", "previous team left", "take over this system", "inherited this codebase".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Apex Takeover

--- a/team/atlas/agents/atlas.md
+++ b/team/atlas/agents/atlas.md
@@ -1,12 +1,6 @@
 ---
 name: atlas
 description: Knowledge engineer — architecture docs, ADRs, API specs, system diagrams, onboarding
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/team/atlas/skills/atlas-adr/SKILL.md
+++ b/team/atlas/skills/atlas-adr/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: atlas-adr
 description: Write an Architecture Decision Record — document what was decided, why, what alternatives were considered, and what trade-offs were accepted. Use when asked to "write an ADR", "document this decision", or "why did we choose X".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Write an Architecture Decision Record

--- a/team/atlas/skills/atlas-changelog/SKILL.md
+++ b/team/atlas/skills/atlas-changelog/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: atlas-changelog
 description: Maintain per-repo and cross-repo changelogs — append structured entries after agent work. Use when asked to "log this change", "update changelog", "what changed", "change history".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Maintain Changelog

--- a/team/atlas/skills/atlas-map/SKILL.md
+++ b/team/atlas/skills/atlas-map/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: atlas-map
 description: Map the system architecture — read the codebase, identify services and connections, output a C4-level architecture map as Mermaid diagrams with component descriptions. Use when asked to "map the architecture", "system diagram", "how does this work", or "architecture overview".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Map the System Architecture

--- a/team/atlas/skills/atlas-onboard/SKILL.md
+++ b/team/atlas/skills/atlas-onboard/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: atlas-onboard
 description: Generate onboarding documentation — what this project does, how to set up locally, where things live, key decisions, how to deploy. Written for day-one engineers who know nothing. Use when asked for "onboarding docs", "new engineer guide", "how to get started", or "developer setup".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Generate Onboarding Documentation

--- a/team/atlas/skills/atlas-present/SKILL.md
+++ b/team/atlas/skills/atlas-present/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: atlas-present
 description: Generate a polished HTML presentation page and Obsidian Canvas for big releases — new products, takeovers, major migrations. Non-technical audience. Use when asked to "present this", "release announcement", "show what we built", or "stakeholder update".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Release Presentation

--- a/team/atlas/skills/atlas-recon/SKILL.md
+++ b/team/atlas/skills/atlas-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: atlas-recon
 description: Documentation reconnaissance for takeover — find all docs, assess accuracy, freshness, coverage, and discoverability, and identify critical knowledge gaps. Use when asked "what docs exist", "documentation assessment", or "knowledge gaps".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Documentation Reconnaissance

--- a/team/atlas/skills/atlas-report/SKILL.md
+++ b/team/atlas/skills/atlas-report/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: atlas-report
 description: Render agent findings as a styled HTML report in the browser. Use when asked for "full report", "detailed report", "show in browser", or when CLI output exceeds the 40-line budget.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Render HTML Report

--- a/team/cortex/agents/cortex.md
+++ b/team/cortex/agents/cortex.md
@@ -1,12 +1,6 @@
 ---
 name: cortex
 description: ML/AI engineer — LLM integration, prompt engineering, RAG, evals, and AI feature design for production
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/team/cortex/skills/cortex-eval/SKILL.md
+++ b/team/cortex/skills/cortex-eval/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: cortex-eval
 description: Evaluate model performance — check for accuracy drops, data drift, and error patterns. Use when asked about "model accuracy dropped", "evaluate the model", "check for drift", or "model performance".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Evaluate Model Performance

--- a/team/cortex/skills/cortex-integrate/SKILL.md
+++ b/team/cortex/skills/cortex-integrate/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: cortex-integrate
 description: Design and implement an AI feature integration — model selection, architecture pattern, system prompt, data flow, error handling, cost estimate. Use when asked to "add AI to this", "LLM integration", "add Claude/GPT", or "AI-powered feature".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # AI Feature Integration

--- a/team/cortex/skills/cortex-model/SKILL.md
+++ b/team/cortex/skills/cortex-model/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: cortex-model
 description: Build an ML pipeline — from data to trained model to serving endpoint. Use when asked to "build ML model", "train a model", "prediction pipeline", "classification", or "regression".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build an ML Pipeline

--- a/team/cortex/skills/cortex-prompt/SKILL.md
+++ b/team/cortex/skills/cortex-prompt/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: cortex-prompt
 description: Build a production-ready prompt package — system prompt, few-shot examples, output format, edge case handling, eval criteria. Use when asked to "prompt engineering", "build a prompt", "write a system prompt", or "improve this prompt".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build a Production-Ready Prompt

--- a/team/cortex/skills/cortex-recon/SKILL.md
+++ b/team/cortex/skills/cortex-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: cortex-recon
 description: ML reconnaissance — inventory all models, pipelines, data sources, and monitoring. Use when asked "what ML do we have", "model inventory", or "ML assessment".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # ML Reconnaissance

--- a/team/crest/agents/crest.md
+++ b/team/crest/agents/crest.md
@@ -1,12 +1,6 @@
 ---
 name: crest
 description: Product strategist — diagnosis-first strategy, roadmap sequencing, competitive positioning, and market decisions
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/team/crest/skills/crest-compete/SKILL.md
+++ b/team/crest/skills/crest-compete/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: crest-compete
 description: Competitive analysis ending in a clear positioning call — where to play, how to win. Use when asked to "analyze competitors", "competitive landscape", "how do we compare to X", "competitive positioning", "where should we play", "find our white space", or "who else does this".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Competitive Analysis

--- a/team/crest/skills/crest-narrative/SKILL.md
+++ b/team/crest/skills/crest-narrative/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: crest-narrative
 description: Strategic narrative — write a standalone strategy memo that frames product direction, bets, and rationale for a planning horizon. Use when asked to "write a strategy doc", "product vision", "strategic narrative", "company strategy memo", "planning memo", or "explain our product direction".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Strategic Narrative

--- a/team/crest/skills/crest-okr/SKILL.md
+++ b/team/crest/skills/crest-okr/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: crest-okr
 description: OKR design — create objectives and key results with a North Star metric, input metrics tree, and cadence. Use when asked to "set OKRs", "define our objectives", "what should we measure this quarter", "design our OKR framework", "build a metrics tree", or "what's our North Star".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # OKR Design

--- a/team/crest/skills/crest-recon/SKILL.md
+++ b/team/crest/skills/crest-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: crest-recon
 description: Strategic context reconnaissance — read existing roadmaps, OKRs, competitive docs, and briefs to establish context before planning. Use when asked to "understand our strategy", "what's the current roadmap", "what OKRs do we have", "strategic context", or before starting any prioritization or roadmap work.
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Strategic Reconnaissance

--- a/team/crest/skills/crest-roadmap/SKILL.md
+++ b/team/crest/skills/crest-roadmap/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: crest-roadmap
 description: Build a product roadmap with sequenced bets and explicit tradeoffs. Use when asked to "build a roadmap", "prioritize the backlog strategically", "what do we build next quarter", "sequence our bets", "what should we focus on", or "product strategy for the next N months".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Crest Roadmap

--- a/team/draft/agents/draft.md
+++ b/team/draft/agents/draft.md
@@ -1,12 +1,6 @@
 ---
 name: draft
 description: UX designer — user flows, information architecture, wireframes, and interaction design
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/team/draft/skills/draft-flow/SKILL.md
+++ b/team/draft/skills/draft-flow/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: draft-flow
-description: Use when asked to design a user flow, map how a user moves through a feature, create a wireframe or flow diagram, or document interaction design for a product brief. Examples: "design the flow for X", "map out the user journey", "create a wireframe for this feature", "how should the UX work for this".
+description: |
+  Use when asked to design a user flow, map how a user moves through a feature, create a wireframe or flow diagram, or document interaction design for a product brief. Examples: "design the flow for X", "map out the user journey", "create a wireframe for this feature", "how should the UX work for this".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Draft Flow

--- a/team/draft/skills/draft-ia/SKILL.md
+++ b/team/draft/skills/draft-ia/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: draft-ia
 description: Information architecture — design navigation structure, content hierarchy, sitemap, and taxonomy for a product or feature set. Use when asked to "organize the navigation", "information architecture", "how should content be structured", "sitemap", "nav redesign", "where should X live", or "content hierarchy".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Information Architecture

--- a/team/draft/skills/draft-recon/SKILL.md
+++ b/team/draft/skills/draft-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: draft-recon
 description: UI and UX reconnaissance — scan existing frontend routes, components, navigation, and flows to understand the current UX state before designing. Use when asked to "understand the current UI", "what UX patterns exist", "map the navigation", "what screens exist", or before starting any flow or wireframe work.
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # UX Reconnaissance

--- a/team/draft/skills/draft-review/SKILL.md
+++ b/team/draft/skills/draft-review/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: draft-review
 description: Usability review — evaluate an existing flow or UI against usability heuristics, flag friction points, and recommend fixes. Use when asked to "review the UX", "usability audit", "what's wrong with this flow", "UX feedback", "critique this design", or "why are users dropping off here".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Usability Review

--- a/team/draft/skills/draft-wireframe/SKILL.md
+++ b/team/draft/skills/draft-wireframe/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: draft-wireframe
 description: Text and Mermaid wireframes — produce screen-level layouts with content hierarchy, component placement, and interaction annotations. Use when asked to "wireframe this", "sketch the UI", "layout for this screen", "lo-fi mockup", "screen design", or "what should this page look like".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Wireframe

--- a/team/echo/agents/echo.md
+++ b/team/echo/agents/echo.md
@@ -1,12 +1,6 @@
 ---
 name: echo
 description: User researcher — interviews, personas, Jobs-to-Be-Done, and customer feedback synthesis
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/team/echo/skills/echo-feedback/SKILL.md
+++ b/team/echo/skills/echo-feedback/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: echo-feedback
 description: Feedback synthesis — cluster support tickets, NPS verbatims, app store reviews, and churn surveys by theme, separate signal from noise, and produce an actionable insight report. Use when asked to "synthesize this feedback", "analyze support tickets", "what are users complaining about", "NPS analysis", "churn feedback synthesis", or "what's the feedback telling us".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Feedback Synthesis

--- a/team/echo/skills/echo-interview/SKILL.md
+++ b/team/echo/skills/echo-interview/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: echo-interview
 description: Run a user interview — produce an interview guide and synthesize the output into an actionable insight report. Use when asked to "run a user interview", "synthesize these interview notes", "what do users actually want", "build a persona from this feedback", "find the JTBD in these transcripts", or "analyze this interview data".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Echo Interview

--- a/team/echo/skills/echo-jobs/SKILL.md
+++ b/team/echo/skills/echo-jobs/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: echo-jobs
 description: Jobs-to-Be-Done analysis — given a product, user descriptions, transcripts, or tickets, produce a JTBD job map with switching forces analysis and opportunity ranking. Use when asked to "find the JTBD", "what jobs are users hiring us for", "job mapping", "what are users really trying to do", "JTBD framework", or "why are users switching".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Jobs-to-Be-Done Analysis

--- a/team/echo/skills/echo-recon/SKILL.md
+++ b/team/echo/skills/echo-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: echo-recon
 description: User research reconnaissance — survey existing personas, research docs, interview notes, and feedback artifacts to establish what is already known about users. Use when asked to "what research exists", "review existing personas", "what do we know about our users", or before starting new research or synthesis work.
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Research Reconnaissance

--- a/team/echo/skills/echo-segment/SKILL.md
+++ b/team/echo/skills/echo-segment/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: echo-segment
 description: User segmentation and persona creation from mixed data sources — analytics, CRM, support tickets, reviews, or any combination. Use when asked to "build personas", "who are our users", "segment our users", "create user profiles", "define user archetypes", or "who is the target user".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # User Segmentation and Personas

--- a/team/flux/agents/flux.md
+++ b/team/flux/agents/flux.md
@@ -1,12 +1,6 @@
 ---
 name: flux
 description: Data engineer — databases, migrations, pipelines, data modeling
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/team/flux/skills/flux-health/SKILL.md
+++ b/team/flux/skills/flux-health/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: flux-health
 description: Data quality and pipeline health check — freshness, schema drift, null rates, orphaned records, pipeline status. Use when asked about "data quality check", "pipeline health", "is our data fresh", or "schema drift".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Data Quality and Pipeline Health

--- a/team/flux/skills/flux-migrate/SKILL.md
+++ b/team/flux/skills/flux-migrate/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: flux-migrate
 description: Build zero-downtime database migrations — forward SQL, rollback SQL, deployment sequence. Use when asked to "write migration", "schema change", "add column", "rename table", "drop column", or "migrate safely".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build Zero-Downtime Migration

--- a/team/flux/skills/flux-pipeline/SKILL.md
+++ b/team/flux/skills/flux-pipeline/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: flux-pipeline
 description: Build a data pipeline — ETL/ELT with extraction, transformation, loading, error handling, and scheduling. Use when asked to "build ETL", "data pipeline", "move data from X to Y", or "sync data".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build a Data Pipeline

--- a/team/flux/skills/flux-query/SKILL.md
+++ b/team/flux/skills/flux-query/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: flux-query
 description: Optimize slow database queries — analyze execution plans, add indexes, rewrite queries. Use when asked about "slow query", "optimize SQL", "query performance", or "explain this query".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Optimize Slow Queries

--- a/team/flux/skills/flux-recon/SKILL.md
+++ b/team/flux/skills/flux-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: flux-recon
 description: Database reconnaissance — full inventory of schema, migrations, data volume, backups, connection pooling, and query patterns. Use when asked to "assess this database", "understand the schema", or "database health check".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Database Reconnaissance

--- a/team/flux/skills/flux-schema/SKILL.md
+++ b/team/flux/skills/flux-schema/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: flux-schema
 description: Design and build database schema — tables, columns, types, indexes, constraints, relationships. Given a domain description, output the schema and write the files. Use when asked to "design schema", "database design", "create tables", or "data model".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Design and Build Database Schema

--- a/team/forge/agents/forge.md
+++ b/team/forge/agents/forge.md
@@ -1,12 +1,6 @@
 ---
 name: forge
 description: Infrastructure engineer — cloud services, networking, IaC, cost optimization
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/team/forge/skills/forge-audit/SKILL.md
+++ b/team/forge/skills/forge-audit/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: forge-audit
 description: Audit existing infrastructure for security issues, waste, and misconfigurations. Use when asked to "audit my infra", "check cloud setup", "infra review", "are we wasting money", "security check on infra", or "review my terraform".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Audit Existing Infrastructure

--- a/team/forge/skills/forge-cost/SKILL.md
+++ b/team/forge/skills/forge-cost/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: forge-cost
 description: Audit cloud infrastructure costs and produce a concrete optimization plan with specific changes and estimated savings. Use when asked to "how much is this costing", "reduce cloud spend", "cost optimization", "are we overpaying", "cloud bill", or "budget for this infra".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Cost Audit and Optimization Plan

--- a/team/forge/skills/forge-diagnose/SKILL.md
+++ b/team/forge/skills/forge-diagnose/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: forge-diagnose
 description: Diagnose runtime infrastructure issues — cold starts, timeouts, scaling problems, network failures. Use when asked about "infra is slow", "cold starts", "network issues", "why is this timing out", "scaling problem", "latency spikes", or "service is down".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Diagnose Runtime Infrastructure Issues

--- a/team/forge/skills/forge-infra/SKILL.md
+++ b/team/forge/skills/forge-infra/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: forge-infra
 description: Build production-grade infrastructure as code for a service or project. Use when asked to "set up infra", "provision infrastructure", "create cloud resources", "IaC for this project", "terraform for this", or "deploy this service".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build Infrastructure as Code

--- a/team/forge/skills/forge-network/SKILL.md
+++ b/team/forge/skills/forge-network/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: forge-network
 description: Design and build networking infrastructure — VPCs, subnets, DNS, load balancers, firewall rules. Use when asked to "set up networking", "VPC design", "configure DNS", "load balancer setup", "network architecture", or "firewall rules".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Design and Build Networking

--- a/team/forge/skills/forge-recon/SKILL.md
+++ b/team/forge/skills/forge-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: forge-recon
 description: Infrastructure reconnaissance — inventory all cloud resources, map connections, flag risks. Use when asked to "inventory our infra", "what infrastructure do we have", "map our cloud resources", "infra discovery", or "what's running in our cloud".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Infrastructure Reconnaissance

--- a/team/form/agents/form.md
+++ b/team/form/agents/form.md
@@ -1,12 +1,6 @@
 ---
 name: form
 description: Visual designer — brand identity, color systems, typography, UI design, and design systems
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/team/form/skills/form-audit/skill.md
+++ b/team/form/skills/form-audit/skill.md
@@ -1,6 +1,11 @@
 ---
 name: form-audit
-description: Use when asked to audit UI for visual quality, check design consistency, review brand alignment, evaluate design system compliance, or find visual issues before a launch. Examples: "audit our UI", "check visual consistency", "review the design for issues", "is our UI on-brand", "find visual bugs", "design QA before launch".
+description: |
+  Use when asked to audit UI for visual quality, check design consistency, review brand alignment, evaluate design system compliance, or find visual issues before a launch. Examples: "audit our UI", "check visual consistency", "review the design for issues", "is our UI on-brand", "find visual bugs", "design QA before launch".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Form Audit

--- a/team/form/skills/form-brand/SKILL.md
+++ b/team/form/skills/form-brand/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: form-brand
-description: Use when asked to create a brand identity, define visual design direction, generate a color palette or type system, build a style guide, or establish the look and feel for a product. Examples: "create a brand for X", "define the visual identity", "what colors should we use", "build a style guide", "design system foundations".
+description: |
+  Use when asked to create a brand identity, define visual design direction, generate a color palette or type system, build a style guide, or establish the look and feel for a product. Examples: "create a brand for X", "define the visual identity", "what colors should we use", "build a style guide", "design system foundations".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Form Brand

--- a/team/form/skills/form-component/skill.md
+++ b/team/form/skills/form-component/skill.md
@@ -1,6 +1,11 @@
 ---
 name: form-component
-description: Use when asked to design a UI component, specify a button, input, card, modal, badge, or any interactive element. Examples: "design a button component", "spec out the input field", "define the card component states", "create a component spec for Prism", "what should the dropdown look like".
+description: |
+  Use when asked to design a UI component, specify a button, input, card, modal, badge, or any interactive element. Examples: "design a button component", "spec out the input field", "define the card component states", "create a component spec for Prism", "what should the dropdown look like".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Form Component

--- a/team/form/skills/form-deck/skill.md
+++ b/team/form/skills/form-deck/skill.md
@@ -1,6 +1,11 @@
 ---
 name: form-deck
-description: Use when asked to design a pitch deck, presentation, or slide set. Examples: "design a pitch deck", "create a sales deck", "make a conference presentation", "build an investor deck", "help me present this to the board", "create slides for X".
+description: |
+  Use when asked to design a pitch deck, presentation, or slide set. Examples: "design a pitch deck", "create a sales deck", "make a conference presentation", "build an investor deck", "help me present this to the board", "create slides for X".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Form Deck

--- a/team/form/skills/form-email/skill.md
+++ b/team/form/skills/form-email/skill.md
@@ -1,6 +1,11 @@
 ---
 name: form-email
-description: Use when asked to design an email template, newsletter, drip campaign email, transactional email, or any HTML email asset. Examples: "design a welcome email", "create a newsletter template", "make an onboarding email sequence", "design a password reset email", "build an email campaign".
+description: |
+  Use when asked to design an email template, newsletter, drip campaign email, transactional email, or any HTML email asset. Examples: "design a welcome email", "create a newsletter template", "make an onboarding email sequence", "design a password reset email", "build an email campaign".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Form Email

--- a/team/form/skills/form-logo/skill.md
+++ b/team/form/skills/form-logo/skill.md
@@ -1,6 +1,11 @@
 ---
 name: form-logo
-description: Use when asked to create a logo, design a brand mark, generate a logo concept, or produce any logo asset. Examples: "create a logo for X", "design a brand mark", "make me a logo", "generate logo concepts", "logo for our product".
+description: |
+  Use when asked to create a logo, design a brand mark, generate a logo concept, or produce any logo asset. Examples: "create a logo for X", "design a brand mark", "make me a logo", "generate logo concepts", "logo for our product".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Form Logo

--- a/team/form/skills/form-mobile/skill.md
+++ b/team/form/skills/form-mobile/skill.md
@@ -1,6 +1,11 @@
 ---
 name: form-mobile
-description: Use when asked to design iOS or Android mobile app screens, create mobile UI, spec mobile flows, or produce screen designs for a native app. Examples: "design the onboarding screens", "spec the checkout flow for iOS", "design a home screen for Android", "create mobile UI for this feature".
+description: |
+  Use when asked to design iOS or Android mobile app screens, create mobile UI, spec mobile flows, or produce screen designs for a native app. Examples: "design the onboarding screens", "spec the checkout flow for iOS", "design a home screen for Android", "create mobile UI for this feature".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Form Mobile

--- a/team/form/skills/form-social/skill.md
+++ b/team/form/skills/form-social/skill.md
@@ -1,6 +1,11 @@
 ---
 name: form-social
-description: Use when asked to design social media graphics, ad creatives, or marketing assets. Examples: "design a LinkedIn post for our launch", "create ad creatives for our campaign", "make an Instagram story", "design a Twitter card", "create a banner ad", "social assets for the product announcement".
+description: |
+  Use when asked to design social media graphics, ad creatives, or marketing assets. Examples: "design a LinkedIn post for our launch", "create ad creatives for our campaign", "make an Instagram story", "design a Twitter card", "create a banner ad", "social assets for the product announcement".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Form Social

--- a/team/form/skills/form-tokens/skill.md
+++ b/team/form/skills/form-tokens/skill.md
@@ -1,6 +1,11 @@
 ---
 name: form-tokens
-description: Use when asked to define a design token system, create tokens, document tokens, set up CSS custom properties, build a Tailwind token config, establish a spacing scale, define color semantics, or bridge design decisions to code. Examples: "set up design tokens", "define our token system", "create CSS variables for the design system", "document our color tokens", "establish a spacing scale".
+description: |
+  Use when asked to define a design token system, create tokens, document tokens, set up CSS custom properties, build a Tailwind token config, establish a spacing scale, define color semantics, or bridge design decisions to code. Examples: "set up design tokens", "define our token system", "create CSS variables for the design system", "document our color tokens", "establish a spacing scale".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Form Tokens

--- a/team/form/skills/form-web/skill.md
+++ b/team/form/skills/form-web/skill.md
@@ -1,6 +1,11 @@
 ---
 name: form-web
-description: Use when asked to design a landing page, marketing website, or any web presence intended to convert or inform. Examples: "design a landing page for X", "create a marketing site", "we need a homepage", "design our website", "build a page for our launch".
+description: |
+  Use when asked to design a landing page, marketing website, or any web presence intended to convert or inform. Examples: "design a landing page for X", "create a marketing site", "we need a homepage", "design our website", "build a page for our launch".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Form Web

--- a/team/helm/agents/helm.md
+++ b/team/helm/agents/helm.md
@@ -1,13 +1,6 @@
 ---
 name: helm
 description: Head of Product — product strategy, requirements, and engineering handoff via the Helm↔Apex interface
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
-  - Agent
 model: sonnet
 ---
 

--- a/team/helm/skills/helm-arbiter/SKILL.md
+++ b/team/helm/skills/helm-arbiter/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: helm-arbiter
 description: Scope arbitration — resolve disagreements between product and engineering on what is in or out of scope, with a decision log and escalation path. Use when asked to "resolve this scope disagreement", "arbitrate between product and eng", "scope is creeping", "we can't agree on what's in scope", or "help us decide what to cut".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Scope Arbitration

--- a/team/helm/skills/helm-brief/SKILL.md
+++ b/team/helm/skills/helm-brief/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: helm-brief
-description: Use when asked to write a product brief, turn a feature idea into a spec, define requirements for something to build, or clarify what a product should do and why. Examples: "write a brief for X", "turn this idea into a spec", "what should we build here", "help me define requirements".
+description: |
+  Use when asked to write a product brief, turn a feature idea into a spec, define requirements for something to build, or clarify what a product should do and why. Examples: "write a brief for X", "turn this idea into a spec", "what should we build here", "help me define requirements".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Helm Brief

--- a/team/helm/skills/helm-handoff/SKILL.md
+++ b/team/helm/skills/helm-handoff/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: helm-handoff
-description: Use when a product brief is finalized and ready to hand off to the engineering team, or when asked to send a brief to Apex, kick off engineering work, or start development on a product spec. Examples: "hand this off to engineering", "send brief to Apex", "start building this", "kick off dev on this spec".
+description: |
+  Use when a product brief is finalized and ready to hand off to the engineering team, or when asked to send a brief to Apex, kick off engineering work, or start development on a product spec. Examples: "hand this off to engineering", "send brief to Apex", "start building this", "kick off dev on this spec".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Helm Handoff

--- a/team/helm/skills/helm-plan/SKILL.md
+++ b/team/helm/skills/helm-plan/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: helm-plan
-description: Use when asked to build a product roadmap, prioritize a backlog, decide what to build next, or sequence a list of feature ideas. Examples: "what should we build next", "prioritize this backlog", "make a roadmap", "RICE score these features".
+description: |
+  Use when asked to build a product roadmap, prioritize a backlog, decide what to build next, or sequence a list of feature ideas. Examples: "what should we build next", "prioritize this backlog", "make a roadmap", "RICE score these features".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Helm Plan

--- a/team/helm/skills/helm-recon/SKILL.md
+++ b/team/helm/skills/helm-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: helm-recon
 description: Product landscape reconnaissance — survey existing briefs, research, strategy, and team output before writing new briefs or dispatching specialists. Use when asked to "understand the product state", "what briefs exist", "what has the team produced", "orient me on this product", or before starting a new product initiative.
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Product Reconnaissance

--- a/team/lens/agents/lens.md
+++ b/team/lens/agents/lens.md
@@ -1,12 +1,6 @@
 ---
 name: lens
 description: Data analytics & BI engineer — dashboards, metrics design, reporting, data storytelling
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/team/lens/skills/lens-audit/SKILL.md
+++ b/team/lens/skills/lens-audit/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: lens-audit
 description: Review existing analytics — find all dashboards and reports, check who uses them, whether metrics are defined, and whether they drive decisions. Recommend what to keep, kill, or add. Use when asked "are our dashboards useful", "analytics review", or "metrics audit".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Audit Existing Analytics

--- a/team/lens/skills/lens-dashboard/SKILL.md
+++ b/team/lens/skills/lens-dashboard/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: lens-dashboard
 description: Design and spec an analytical dashboard — define the question each chart answers, write the SQL queries, spec the layout and refresh cadence. Produces a complete dashboard spec ready to implement. Use when asked to "build a dashboard", "analytics dashboard", "BI dashboard", "weekly product health", or "visualize this data".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build Analytical Dashboard

--- a/team/lens/skills/lens-metrics/SKILL.md
+++ b/team/lens/skills/lens-metrics/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: lens-metrics
 description: Produce a complete metrics definition doc — metric name, formula, data source, segmentation, SQL or event tracking spec, and what good/bad looks like. Given a product area, outputs the full metrics spec. Use when asked to "define KPIs", "metrics framework", "what should we measure", "north star metric", or "instrument this feature".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Define and Implement Metrics

--- a/team/lens/skills/lens-recon/SKILL.md
+++ b/team/lens/skills/lens-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: lens-recon
 description: Analytics reconnaissance for takeover — find all analytics tools, inventory what's tracked and dashboarded, assess data freshness and metric definitions, and present a coverage map. Use when asked "what analytics exist", "BI assessment", or "what do we track".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Analytics Reconnaissance

--- a/team/lens/skills/lens-report/SKILL.md
+++ b/team/lens/skills/lens-report/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: lens-report
 description: Build a reporting pipeline — scheduled reports with SQL queries, delivery via Slack or email, threshold alerts, and historical comparison. Use when asked for "automated reports", "scheduled report", "email digest", or "Slack alerts for metrics".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build Reporting Pipeline

--- a/team/lumen/agents/lumen.md
+++ b/team/lumen/agents/lumen.md
@@ -1,12 +1,6 @@
 ---
 name: lumen
 description: Product analyst — metrics architecture, funnel analysis, A/B test design, retention, and growth measurement
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/team/lumen/skills/lumen-abtest/SKILL.md
+++ b/team/lumen/skills/lumen-abtest/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: lumen-abtest
 description: A/B test design — produce an experiment spec with hypothesis, primary metric, MDE, sample size, run time, and decision rule. Also determines when NOT to A/B test and what to do instead. Use when asked to "design an A/B test", "should we test this", "experiment design", "how do we know if this works", "what's the sample size", or "set up an experiment".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Lumen A/B Test

--- a/team/lumen/skills/lumen-funnel/SKILL.md
+++ b/team/lumen/skills/lumen-funnel/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: lumen-funnel
-description: Use when asked to analyze a funnel, find where users drop off, diagnose low conversion or activation rates, design a metrics framework, set up OKRs, or measure whether a feature is working. Examples: "analyze our funnel", "why is activation low", "where are users dropping off", "design OKRs for this quarter", "is this feature working", "set up metrics for this launch".
+description: |
+  Use when asked to analyze a funnel, find where users drop off, diagnose low conversion or activation rates, design a metrics framework, set up OKRs, or measure whether a feature is working. Examples: "analyze our funnel", "why is activation low", "where are users dropping off", "design OKRs for this quarter", "is this feature working", "set up metrics for this launch".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Lumen Funnel

--- a/team/lumen/skills/lumen-instrument/SKILL.md
+++ b/team/lumen/skills/lumen-instrument/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: lumen-instrument
 description: Instrumentation plan — design event taxonomy, property schema, and tracking plan for analytics tools. Use when asked to "what should we track", "instrumentation plan", "set up analytics events", "analytics event schema", "tracking plan", or "instrument this feature".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Instrumentation Plan

--- a/team/lumen/skills/lumen-metrics/SKILL.md
+++ b/team/lumen/skills/lumen-metrics/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: lumen-metrics
 description: Metrics architecture — produce a complete metrics plan given a product description. North Star, input metrics tree, instrumentation spec, action triggers, and counter-metrics. Use when asked to "design a metrics framework", "what should we measure", "build a metrics system", "define our KPIs", "what are our success metrics", "metrics strategy", or "what do we track".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Lumen Metrics

--- a/team/lumen/skills/lumen-recon/SKILL.md
+++ b/team/lumen/skills/lumen-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: lumen-recon
 description: Analytics reconnaissance — scan existing event tracking, metric definitions, dashboards, and analytics configuration to understand what is currently being measured. Use when asked to "what are we tracking", "audit our analytics", "what metrics exist", "analytics inventory", or before designing new metrics or instrumentation.
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Analytics Reconnaissance

--- a/team/pave/agents/pave.md
+++ b/team/pave/agents/pave.md
@@ -1,12 +1,6 @@
 ---
 name: pave
 description: Platform engineer — developer experience, golden paths, service catalogs, environment management, internal tooling. Builds what removes friction for the team that exists.
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/team/pave/skills/pave-audit/SKILL.md
+++ b/team/pave/skills/pave-audit/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: pave-audit
 description: Audit developer experience — measure onboarding time, build speed, deployment friction, and developer satisfaction. Use when asked to "DX audit", "developer experience review", "why is development slow", "onboarding assessment", or "DORA metrics".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Developer Experience Audit

--- a/team/pave/skills/pave-catalog/SKILL.md
+++ b/team/pave/skills/pave-catalog/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: pave-catalog
 description: Build a service catalog — schema, starter entries, and governance model. Produces what information to capture per service, how it's maintained, and where it lives. Use when asked to "service catalog", "what services do we have", "catalog our services", "service inventory", or "who owns what".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Service Catalog

--- a/team/pave/skills/pave-env/SKILL.md
+++ b/team/pave/skills/pave-env/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: pave-env
 description: Set up local development environments — devcontainers, Docker Compose, one-command setup, dev/prod parity. Use when asked to "set up dev environment", "devcontainer", "docker compose for dev", "local development setup", or "one command to run".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Development Environment

--- a/team/pave/skills/pave-golden/SKILL.md
+++ b/team/pave/skills/pave-golden/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: pave-golden
 description: Define a golden path — the opinionated, supported way to do a common developer task (create a new service, set up an environment, deploy a feature). Produces concrete steps, templates, and tooling. Use when asked to "golden path", "create project template", "scaffold a new service", "how should we create services", or "standardize our setup".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Golden Path Definition

--- a/team/pave/skills/pave-recon/SKILL.md
+++ b/team/pave/skills/pave-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: pave-recon
 description: Platform reconnaissance — inventory all developer tooling, environments, build systems, and developer workflows for project takeover. Use when asked to "understand the dev setup", "developer tooling assessment", "platform assessment", or "how do developers work here".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Platform Reconnaissance

--- a/team/pitch/agents/pitch.md
+++ b/team/pitch/agents/pitch.md
@@ -1,12 +1,6 @@
 ---
 name: pitch
 description: Product marketer — positioning, messaging, value proposition, GTM strategy, and launch copy
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/team/pitch/skills/pitch-copy/SKILL.md
+++ b/team/pitch/skills/pitch-copy/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: pitch-copy
 description: Landing page and marketing copy — write hero section, problem/solution blocks, proof points, and CTAs. Use when asked to "write landing page copy", "write the homepage", "marketing copy for this feature", "product page copy", "write the hero section", or "write copy for [surface]".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Marketing Copy

--- a/team/pitch/skills/pitch-launch/SKILL.md
+++ b/team/pitch/skills/pitch-launch/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: pitch-launch
 description: Produce an actual launch plan with announcement copy, channel sequence, and day-1 checklist. Use when asked to "plan a launch", "GTM strategy", "how do we announce this", "launch plan for [feature]", "go-to-market", "write our Product Hunt post", or "how do we get people to notice this".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Pitch Launch

--- a/team/pitch/skills/pitch-message/SKILL.md
+++ b/team/pitch/skills/pitch-message/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: pitch-message
 description: Messaging framework — produce a full headline, subheadline, proof points, and CTA hierarchy for use across all surfaces. Use when asked to "write our messaging", "messaging framework", "what should our headline say", "copy hierarchy", "tagline and messaging", or "how do we talk about the product".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Messaging Framework

--- a/team/pitch/skills/pitch-position/SKILL.md
+++ b/team/pitch/skills/pitch-position/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: pitch-position
 description: Produce a complete positioning document using the Dunford framework — competitive alternatives, unique attributes, value, best-fit customer, market category, positioning statement, and tagline. Use when asked to "write our positioning", "define our value prop", "positioning statement", "what market are we in", "how do we position against X", "what's our tagline", or "write our messaging foundation".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Pitch Position

--- a/team/pitch/skills/pitch-recon/SKILL.md
+++ b/team/pitch/skills/pitch-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: pitch-recon
 description: Marketing and messaging reconnaissance — read existing landing pages, copy, positioning docs, and marketing materials to understand the current messaging state. Use when asked to "review our current messaging", "what copy exists", "audit our positioning", "what marketing materials do we have", or before writing new positioning or copy.
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Marketing Reconnaissance

--- a/team/prism/agents/prism.md
+++ b/team/prism/agents/prism.md
@@ -1,12 +1,6 @@
 ---
 name: prism
 description: Frontend & DX engineer — translates Form's design system into production UI components, pages, and internal tools
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/team/prism/skills/prism-audit/SKILL.md
+++ b/team/prism/skills/prism-audit/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: prism-audit
 description: Frontend audit — bundle size, dependencies, accessibility, performance, component quality. Use when asked for "frontend review", "performance audit", "accessibility check", or "bundle size".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Frontend Audit

--- a/team/prism/skills/prism-component/SKILL.md
+++ b/team/prism/skills/prism-component/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: prism-component
 description: Implement a reusable, accessible, typed component from a design spec. Use when asked to "create a component", "build a widget", "implement this design", or "reusable UI element".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Implement a Component

--- a/team/prism/skills/prism-dashboard/SKILL.md
+++ b/team/prism/skills/prism-dashboard/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: prism-dashboard
 description: Build an internal dashboard with data tables, filters, detail views, and CRUD. Use when asked to build an "admin panel", "internal dashboard", "back office", or "data dashboard UI".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build an Internal Dashboard

--- a/team/prism/skills/prism-recon/SKILL.md
+++ b/team/prism/skills/prism-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: prism-recon
 description: Frontend reconnaissance — map the component tree, routing, state management, build config, and assess quality. Use when asked to "understand this frontend", "frontend assessment", or "what's the UI built with".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Frontend Reconnaissance

--- a/team/prism/skills/prism-ui/SKILL.md
+++ b/team/prism/skills/prism-ui/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: prism-ui
 description: Implement a complete UI screen or feature from a Form visual spec. Use when asked to "build a page", "implement this screen", "build the frontend for this feature", or "create this UI".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Implement a UI Screen or Feature

--- a/team/proof/agents/proof.md
+++ b/team/proof/agents/proof.md
@@ -1,12 +1,6 @@
 ---
 name: proof
 description: QA & testing engineer — test strategy, E2E suites, integration testing, test infrastructure, flaky test triage
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/team/proof/skills/proof-api/SKILL.md
+++ b/team/proof/skills/proof-api/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: proof-api
 description: Build API test suites — endpoint testing, contract testing, load testing for REST/GraphQL/gRPC APIs. Use when asked to "test this API", "API tests", "endpoint testing", "contract tests", or "load test".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # API Test Suite

--- a/team/proof/skills/proof-audit/SKILL.md
+++ b/team/proof/skills/proof-audit/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: proof-audit
 description: Audit test suite health — find flaky tests, slow tests, coverage gaps, and testing anti-patterns. Use when asked to "audit tests", "fix flaky tests", "why are tests slow", "test health", or "improve test suite".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Test Suite Audit

--- a/team/proof/skills/proof-e2e/SKILL.md
+++ b/team/proof/skills/proof-e2e/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: proof-e2e
 description: Build E2E test specs for critical user journeys — Playwright or Cypress, page objects, setup/teardown, CI config. Use when asked to "write E2E tests", "end-to-end testing", "browser tests", "UI tests", or "Playwright tests".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # E2E Test Suite

--- a/team/proof/skills/proof-recon/SKILL.md
+++ b/team/proof/skills/proof-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: proof-recon
 description: Testing reconnaissance — inventory all tests, frameworks, coverage, CI integration, and assess testing maturity for project takeover. Use when asked to "understand the tests", "testing assessment", "what's tested", or "test inventory".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Testing Reconnaissance

--- a/team/proof/skills/proof-strategy/SKILL.md
+++ b/team/proof/skills/proof-strategy/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: proof-strategy
 description: Produce a test strategy for a project or feature — risk map, test type decisions, coverage targets, CI config. Use when asked to "create test strategy", "what should we test", "testing plan", or "improve test coverage".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Test Strategy

--- a/team/relay/agents/relay.md
+++ b/team/relay/agents/relay.md
@@ -1,12 +1,6 @@
 ---
 name: relay
 description: DevOps engineer — CI/CD, deployments, GitOps, developer experience
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/team/relay/skills/relay-audit/SKILL.md
+++ b/team/relay/skills/relay-audit/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: relay-audit
 description: Audit an existing CI/CD pipeline for slowness, security issues, and reliability gaps. Use when asked to "audit pipeline", "why is CI slow", "pipeline review", or "deployment review".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Audit Existing Pipeline

--- a/team/relay/skills/relay-deploy/SKILL.md
+++ b/team/relay/skills/relay-deploy/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: relay-deploy
 description: Set up a complete deployment configuration — Dockerfile, deployment manifest, environment config, and rollback procedure. Use when asked about "deployment setup", "how do I deploy this", "deployment strategy", or "rollback plan".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Set Up Deployment Configuration

--- a/team/relay/skills/relay-docker/SKILL.md
+++ b/team/relay/skills/relay-docker/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: relay-docker
 description: Build production-ready Dockerfiles with multi-stage builds, security hardening, and docker-compose for local dev. Use when asked to "create Dockerfile", "optimize container", or "dockerize this".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build Production Dockerfiles

--- a/team/relay/skills/relay-pipeline/SKILL.md
+++ b/team/relay/skills/relay-pipeline/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: relay-pipeline
 description: Build a full CI/CD pipeline from scratch. Use when asked to "set up CI/CD", "create pipeline", or "automate deploys".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build CI/CD Pipeline

--- a/team/relay/skills/relay-recon/SKILL.md
+++ b/team/relay/skills/relay-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: relay-recon
 description: Map the full CI/CD pipeline — triggers, build, test, deploy flow — with risk assessment. Use when asked "how does this deploy", "map the pipeline", or "understand CI/CD".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Pipeline Reconnaissance

--- a/team/relay/skills/relay-ship/skill.md
+++ b/team/relay/skills/relay-ship/skill.md
@@ -1,6 +1,10 @@
 ---
 name: relay-ship
 description: End-to-end ship workflow — merge base, run tests, review diff, bump version, commit, push, create PR. Use when asked to "ship", "push to main", "create a PR", "get this merged", or "deploy this branch".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Ship a Branch

--- a/team/spine/agents/spine.md
+++ b/team/spine/agents/spine.md
@@ -1,12 +1,6 @@
 ---
 name: spine
 description: Backend engineer — APIs, system design, performance, distributed systems
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/team/spine/skills/spine-api/SKILL.md
+++ b/team/spine/skills/spine-api/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: spine-api
 description: Design and spec an API — endpoints, request/response shapes, error codes, auth pattern, pagination. Applies Stripe's consistency principles. Use when asked to "design an API", "build API endpoints", "create REST API", or "API for this feature".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Design and Build an API

--- a/team/spine/skills/spine-design/SKILL.md
+++ b/team/spine/skills/spine-design/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: spine-design
 description: Produce a system design doc — components, data flow, decisions made, tradeoffs, failure modes. Not a list of options. An actual design with calls made. Use when asked for "system design for", "architect this", "how should we build", or "design the backend".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # System Design

--- a/team/spine/skills/spine-perf/SKILL.md
+++ b/team/spine/skills/spine-perf/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: spine-perf
 description: Find and fix performance bottlenecks — N+1 queries, missing indexes, sync bottlenecks, caching gaps. Use when asked "why is this slow", "performance issue", "optimize this endpoint", or "N+1 queries".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Find and Fix Performance Bottlenecks

--- a/team/spine/skills/spine-recon/SKILL.md
+++ b/team/spine/skills/spine-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: spine-recon
 description: Backend reconnaissance — map all routes, middleware, models, dependencies, auth, and assess code quality for project takeover. Use when asked to "understand this backend", "map the API", or "assess code quality".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Backend Reconnaissance

--- a/team/spine/skills/spine-review/SKILL.md
+++ b/team/spine/skills/spine-review/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: spine-review
 description: API and backend code review — REST conventions, auth, validation, error handling, pagination, rate limiting, test coverage. Use when asked to "review this API", "code review", "review backend", or "pre-launch backend check".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # API and Code Review

--- a/team/spine/skills/spine-service/SKILL.md
+++ b/team/spine/skills/spine-service/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: spine-service
 description: Build a new production-ready service from scratch — config management, health checks, graceful shutdown, structured logging. Use when asked to "new service", "scaffold a backend", "bootstrap service", or "create microservice".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build a New Service

--- a/team/surge/agents/surge.md
+++ b/team/surge/agents/surge.md
@@ -1,12 +1,6 @@
 ---
 name: surge
 description: Growth engineer — acquisition channels, activation funnels, retention playbooks, and PLG strategy
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/team/surge/skills/surge-activation/SKILL.md
+++ b/team/surge/skills/surge-activation/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: surge-activation
-description: Use when asked to improve activation, map the growth funnel, identify growth levers, design a referral program, build a retention playbook, develop a PLG strategy, or find where to invest in growth. Examples: "how do we grow faster", "improve our activation rate", "design a referral program", "build a retention playbook", "what are our best growth levers", "map our growth funnel".
+description: |
+  Use when asked to improve activation, map the growth funnel, identify growth levers, design a referral program, build a retention playbook, develop a PLG strategy, or find where to invest in growth. Examples: "how do we grow faster", "improve our activation rate", "design a referral program", "build a retention playbook", "what are our best growth levers", "map our growth funnel".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Surge Activation

--- a/team/surge/skills/surge-experiment/SKILL.md
+++ b/team/surge/skills/surge-experiment/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: surge-experiment
 description: Growth experiment design — structure a growth hypothesis, define metric, baseline, expected lift, and kill condition for a single experiment. Use when asked to "design a growth experiment", "test this growth idea", "experiment framework", "how do we test if this works", or "growth hypothesis".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Growth Experiment Design

--- a/team/surge/skills/surge-plg/SKILL.md
+++ b/team/surge/skills/surge-plg/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: surge-plg
 description: PLG motion design — free tier definition, activation sequence, expansion trigger points, viral mechanic assessment. Given a product, output the PLG architecture and make the calls. Use when asked to "PLG strategy", "freemium model", "product-led growth plan", "self-serve motion", "how do we add a free tier", "upgrade triggers", or "viral loop design".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # PLG Motion Design

--- a/team/surge/skills/surge-recon/SKILL.md
+++ b/team/surge/skills/surge-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: surge-recon
 description: Growth state reconnaissance — scan existing onboarding flows, acquisition channels, conversion funnels, and growth experiment logs to understand current growth state. Use when asked to "what's our growth state", "audit the funnel", "what growth experiments have we run", "acquisition channel inventory", or before designing new growth experiments.
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Growth Reconnaissance

--- a/team/surge/skills/surge-retention/SKILL.md
+++ b/team/surge/skills/surge-retention/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: surge-retention
 description: Retention diagnosis + intervention plan — analyze the retention curve, identify the primary drop-off point, and produce a specific intervention plan with expected impact. Use when asked to "improve retention", "why are users churning", "build a retention playbook", "reduce churn", "win-back campaign", or "users aren't coming back".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Retention Diagnosis + Intervention Plan

--- a/team/touch/agents/touch.md
+++ b/team/touch/agents/touch.md
@@ -1,12 +1,6 @@
 ---
 name: touch
 description: Mobile engineer — native iOS/Android, cross-platform, app stores, mobile performance
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/team/touch/skills/touch-app/SKILL.md
+++ b/team/touch/skills/touch-app/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: touch-app
 description: Produce a complete mobile app architecture design — platform choice, navigation structure, state management, data layer, key screens. Use when asked to "build a mobile app", "new app", "create iOS/Android app", "app architecture", or "cross-platform app".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Mobile App Architecture Design

--- a/team/touch/skills/touch-audit/SKILL.md
+++ b/team/touch/skills/touch-audit/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: touch-audit
 description: Mobile audit — app size, startup time, crash reporting, store compliance, accessibility, offline behavior. Use when asked for "mobile review", "app store readiness", "mobile performance", or "crash analysis".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Mobile Audit

--- a/team/touch/skills/touch-feature/SKILL.md
+++ b/team/touch/skills/touch-feature/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: touch-feature
 description: Produce a mobile feature spec — user story, technical approach, component breakdown, platform-specific considerations, edge cases. Use when asked to "add a screen", "spec this feature", "mobile feature", "new tab", "push notifications", or "deep link".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Mobile Feature Spec

--- a/team/touch/skills/touch-recon/SKILL.md
+++ b/team/touch/skills/touch-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: touch-recon
 description: Mobile reconnaissance — understand the app's tech stack, architecture, dependencies, and health for takeover. Use when asked to "understand this app", "mobile assessment", or "app health".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Mobile Reconnaissance

--- a/team/touch/skills/touch-release/SKILL.md
+++ b/team/touch/skills/touch-release/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: touch-release
 description: Set up mobile release pipeline — Fastlane, code signing, CI, beta distribution, versioning. Use when asked about "app store setup", "release pipeline", "fastlane", "beta distribution", or "signing".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Set Up Mobile Release Pipeline

--- a/team/vigil/agents/vigil.md
+++ b/team/vigil/agents/vigil.md
@@ -1,12 +1,6 @@
 ---
 name: vigil
 description: Observability & reliability engineer — SLOs, alerting, instrumentation, incident response. Writes configs and runbooks, doesn't produce roadmaps.
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/team/vigil/skills/vigil-alert/SKILL.md
+++ b/team/vigil/skills/vigil-alert/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: vigil-alert
 description: Write SLO-based alert rules with burn rate thresholds and paired runbooks. Outputs actual alert configs, not a strategy doc. Use when asked to "set up alerts", "create runbooks", "define SLOs", or "alerting strategy".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build Alert Rules and Runbooks

--- a/team/vigil/skills/vigil-check/SKILL.md
+++ b/team/vigil/skills/vigil-check/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: vigil-check
 description: Verify observability posture — audit monitoring coverage, find blind spots, prioritize gaps. Use when asked "is monitoring sufficient", "observability review", "are we covered", or "pre-launch monitoring check".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Verify Observability Posture

--- a/team/vigil/skills/vigil-incident/SKILL.md
+++ b/team/vigil/skills/vigil-incident/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: vigil-incident
 description: Incident response — diagnose production issues, find root cause, propose fix with rollback. Use when asked about "something is broken", "production issue", "why is this down", "incident", or "debug production".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Incident Response

--- a/team/vigil/skills/vigil-instrument/SKILL.md
+++ b/team/vigil/skills/vigil-instrument/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: vigil-instrument
 description: Instrument a service with OpenTelemetry — RED metrics, structured logs, distributed tracing, and health checks. Outputs actual code and config, not a plan. Use when asked to "add monitoring", "instrument this", "add logging", "set up tracing", or "observability".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Instrument a Service

--- a/team/vigil/skills/vigil-recon/SKILL.md
+++ b/team/vigil/skills/vigil-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: vigil-recon
 description: Observability reconnaissance — inventory what monitoring exists, map coverage, highlight blind spots. Use when asked "what monitoring exists", "observability assessment", or "what can we see".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Observability Reconnaissance

--- a/team/volt/agents/volt.md
+++ b/team/volt/agents/volt.md
@@ -1,12 +1,6 @@
 ---
 name: volt
 description: Embedded & IoT engineer — firmware architecture, microcontrollers, OTA updates, edge computing, device protocols
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/team/volt/skills/volt-driver/SKILL.md
+++ b/team/volt/skills/volt-driver/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: volt-driver
 description: Build a device driver or protocol handler — I2C sensors, BLE services, MQTT clients, SPI peripherals with interrupt-driven I/O and clean HAL abstraction. Use when asked to "write a driver", "I2C device", "BLE service", "MQTT client", or "sensor integration".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build Device Driver or Protocol Handler

--- a/team/volt/skills/volt-firmware/SKILL.md
+++ b/team/volt/skills/volt-firmware/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: volt-firmware
 description: Produce a complete firmware architecture spec for a described device — layer diagram, module responsibilities, HAL interface definitions, key state machines, RTOS decision. Use when asked to "design firmware architecture", "plan embedded firmware", "architect an IoT device", "how should I structure this firmware", or given a device description and asked what the firmware should look like.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Firmware Architecture Spec

--- a/team/volt/skills/volt-ota/SKILL.md
+++ b/team/volt/skills/volt-ota/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: volt-ota
 description: Produce a complete OTA update system design — partition layout, update flow, rollback conditions, validation checks, fleet management approach, failure modes and recovery. Use when asked about "OTA updates", "firmware updates over the air", "how do I update devices in the field", "OTA strategy", or "remote firmware update design".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # OTA Update System Design

--- a/team/volt/skills/volt-power/SKILL.md
+++ b/team/volt/skills/volt-power/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: volt-power
 description: Power management audit — analyze sleep modes, wake sources, power state machines, radio duty cycles, and battery life estimates. Use when asked to "audit power usage", "optimize battery life", "review power management", "why is my battery draining", "power budget analysis", or "sleep mode review".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Power Management Audit

--- a/team/volt/skills/volt-recon/SKILL.md
+++ b/team/volt/skills/volt-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: volt-recon
 description: Firmware reconnaissance for takeover — inventory the MCU, peripherals, RTOS, protocols, OTA, power management, and assess code quality with risk flags. Use when asked to "understand this firmware", "device inventory", or "embedded assessment".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Firmware Reconnaissance

--- a/team/warden/agents/warden.md
+++ b/team/warden/agents/warden.md
@@ -1,12 +1,6 @@
 ---
 name: warden
 description: Security engineer — IAM, secrets, threat modeling, hardening, auth, and supply chain security
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - Write
 model: sonnet
 ---
 

--- a/team/warden/skills/warden-audit/SKILL.md
+++ b/team/warden/skills/warden-audit/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: warden-audit
 description: Full security audit — secrets, dependencies, IAM, auth, injection, XSS, HTTPS, rate limiting, public storage. Use when asked for "security audit", "check for vulnerabilities", "security review", or "are we secure".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Full Security Audit

--- a/team/warden/skills/warden-harden/SKILL.md
+++ b/team/warden/skills/warden-harden/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: warden-harden
 description: Produce a hardening spec and implement it — auth patterns, security headers, rate limiting, input validation, secrets management, dependency hygiene. Use when asked to "harden this", "add security to this service", "what security do I need", or "secure this before launch".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Harden a Service

--- a/team/warden/skills/warden-iam/SKILL.md
+++ b/team/warden/skills/warden-iam/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: warden-iam
 description: Build IAM from scratch — roles, policies, service accounts with least privilege. Use when asked to "set up IAM", "create roles", "service accounts", or "access control".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Build IAM from Scratch

--- a/team/warden/skills/warden-recon/SKILL.md
+++ b/team/warden/skills/warden-recon/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: warden-recon
 description: Security reconnaissance — full inventory of secrets management, IAM, dependencies, auth, encryption, audit logging, and compliance gaps. Use when asked about "security posture", "how secure is this", or "security assessment".
+allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Security Reconnaissance

--- a/team/warden/skills/warden-threat/SKILL.md
+++ b/team/warden/skills/warden-threat/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: warden-threat
 description: Produce a threat model — assets, ranked threats, mitigations, accepted risks. Use when asked to "threat model this", "what could go wrong security-wise", "map our attack surface", or before designing any security-sensitive feature.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.6.4
+author: tonone-ai <hello@tonone.ai>
+license: MIT
 ---
 
 # Threat Model


### PR DESCRIPTION
## Summary

Fixes all three blocking issues identified in the Tons of Skills marketplace review.

**Blocking Issue 1 — Missing frontmatter on all 126 skills**

Added 4 required fields to every `SKILL.md`:
- `allowed-tools` — security sandbox declaration (two-tier: analysis skills get read-only tools; implementation skills get full tools)
- `version: 0.6.4`
- `author: tonone-ai <hello@tonone.ai>`
- `license: MIT`

Tool tiers:
- **Analysis** (`*-recon`, `*-audit`, `*-check`, `*-health`, `*-diagnose`): `Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion`
- **Full** (everything else): `Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion`

**Blocking Issue 2 — YAML parse errors on 16 skills**

Skills whose `description` contained `Examples: "..."` were flagged by strict YAML parsers as ambiguous (colon-space pattern). All affected descriptions converted to block scalar (`|`) format. Applied to all skills with colon-in-value patterns.

Affected: `helm-brief`, `helm-handoff`, `helm-plan`, `draft-flow`, `lumen-funnel`, `surge-activation`, `form-audit`, `form-brand`, `form-component`, `form-deck`, `form-email`, `form-logo`, `form-mobile`, `form-social`, `form-tokens`, `form-web`.

**Blocking Issue 3 — Wrong tools field format in all 23 agents**

Removed `tools:` allowlist from all agent definitions (both `agents/` and `team/*/agents/`). Agents now use the Anthropic spec's correct model: full tool access by default (the `disallowedTools` denylist approach). The old allowlist was also inadvertently restricting agents from using `Edit`, `WebFetch`, `WebSearch`, and other tools they need.

## Test Coverage

All changes are configuration/frontmatter — no application code paths changed.

## Pre-Landing Review

297 files, all frontmatter additions. No logic changes.

## Test plan
- [x] All 10 structure tests pass (`tests/test_structure.py`)
- [x] Verified sample files: `forge-infra/SKILL.md` (4 fields added), `helm-brief/SKILL.md` (description block scalar + 4 fields), `agents/forge.md` (tools field removed)

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)