### PR TITLE
fix: statusline auto-installs on plugin load

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -25,7 +25,7 @@
     "platform"
   ],
   "hooks": {
-    "Setup": [
+    "SessionStart": [
       {
         "hooks": [
           {

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,6 +1,6 @@
 {
   "hooks": {
-    "Setup": [
+    "SessionStart": [
       {
         "hooks": [
           {

--- a/hooks/install-statusline.sh
+++ b/hooks/install-statusline.sh
@@ -43,6 +43,11 @@ if [ -n "$CURRENT_SL" ] && [ "$CURRENT_SL" != "node \"$STATUSLINE_SCRIPT\"" ]; t
 fi
 
 # Patch settings.json with tonone statusline
+EXPECTED_CMD="node \"$STATUSLINE_SCRIPT\""
+if [ "$CURRENT_SL" = "$EXPECTED_CMD" ]; then
+	exit 0
+fi
+
 if command -v node &>/dev/null; then
 	node -e "
     const fs = require('fs');


### PR DESCRIPTION
## Summary
- **"Setup" is not a valid hook event** — the statusline install script never ran when users installed tonone
- Changed hook event from `Setup` to `SessionStart` in both `plugin.json` and `hooks.json`
- Added early-exit check so the script is a no-op on subsequent sessions (fast + idempotent)

## Test plan
- [ ] Install tonone fresh (`claude plugin install tonone@tonone-ai`), start a new session, verify `~/.claude/settings.json` gets `statusLine` entry
- [ ] Start a second session — verify the script exits immediately (no rewrite)
- [ ] Verify the statusline renders in the toolbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)