### PR TITLE
feat: statusline line 2 + sync drifted skills with CI gate

### DIFF
--- a/hooks/tonone-statusline.js
+++ b/hooks/tonone-statusline.js
@@ -51,6 +51,20 @@ function gitDirtyCount(cwd) {
   }
 }
 
+function gitAhead(cwd) {
+  try {
+    const out = execSync("git rev-list --count @{u}..HEAD", {
+      cwd,
+      encoding: "utf8",
+      timeout: 1000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return parseInt(out.trim(), 10) || 0;
+  } catch {
+    return 0;
+  }
+}
+
 // ── Formatters ────────────────────────────────────────────────────────────────
 
 function fmtTokens(n) {
@@ -65,6 +79,17 @@ function fmtCost(usd) {
   if (usd === 0) return null;
   if (usd < 0.01) return `$${usd.toFixed(3)}`;
   return `$${usd.toFixed(2)}`;
+}
+
+function fmtDuration(ms) {
+  if (ms == null || ms <= 0) return null;
+  const totalSec = Math.floor(ms / 1000);
+  if (totalSec < 60) return `${totalSec}s`;
+  const mins = Math.floor(totalSec / 60);
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.floor(mins / 60);
+  const rem = mins % 60;
+  return rem > 0 ? `${hrs}h${rem}m` : `${hrs}h`;
 }
 
 function fmtRelativeTime(isoTimestamp) {
@@ -153,9 +178,13 @@ function render(data) {
   const session = data.session_id || "";
   const segments = [];
 
-  // 1. Branch (cyan, always shown)
+  // 1. Branch + ahead count (cyan, always shown)
   const branch = gitBranch(cwd);
-  if (branch) segments.push(`${c.cyan}\u25c6 ${branch}${c.reset}`);
+  if (branch) {
+    const ahead = gitAhead(cwd);
+    const aheadStr = ahead > 0 ? ` ${c.green}\u2191${ahead}${c.reset}` : "";
+    segments.push(`${c.cyan}\u25c6 ${branch}${c.reset}${aheadStr}`);
+  }
 
   // 2. Dirty count (yellow, hidden when clean)
   const dirty = gitDirtyCount(cwd);
@@ -207,6 +236,35 @@ function render(data) {
   const modelName = data.model?.display_name;
   if (modelName) {
     line2Parts.push(`${c.dimWhite}${modelName}${c.reset}`);
+  }
+
+  // Session duration
+  const duration = fmtDuration(data.cost?.total_duration_ms);
+  if (duration) {
+    line2Parts.push(`${c.dimWhite}${duration}${c.reset}`);
+  }
+
+  // Lines changed (+N -N)
+  const added = data.cost?.total_lines_added || 0;
+  const removed = data.cost?.total_lines_removed || 0;
+  if (added > 0 || removed > 0) {
+    let linesStr = "";
+    if (added > 0) linesStr += `${c.green}+${added}${c.reset}`;
+    if (added > 0 && removed > 0) linesStr += " ";
+    if (removed > 0) linesStr += `${c.red}-${removed}${c.reset}`;
+    line2Parts.push(linesStr);
+  }
+
+  // Cost per line (wow metric — hidden when no lines or no cost)
+  const totalLines = added + removed;
+  const totalCost = data.cost?.total_cost_usd || 0;
+  if (totalLines > 0 && totalCost > 0) {
+    const cpl = totalCost / totalLines;
+    const cplStr =
+      cpl < 0.001
+        ? `$${(cpl * 1000).toFixed(1)}\u00d710\u207b\u00b3`
+        : `$${cpl.toFixed(3)}`;
+    line2Parts.push(`${c.dimWhite}${cplStr}/line${c.reset}`);
   }
 
   // 5-hour usage

--- a/hooks/tonone-statusline.js
+++ b/hooks/tonone-statusline.js
@@ -198,7 +198,41 @@ function render(data) {
   const rateLimit = renderRateLimit(data.rate_limits);
   if (rateLimit) segments.push(rateLimit);
 
-  return segments.join(` ${c.dim}\u2502${c.reset} `);
+  const line1 = segments.join(` ${c.dim}\u2502${c.reset} `);
+
+  // ── Line 2: model + usage windows ──────────────────────────────────────────
+  const line2Parts = [];
+
+  // Model name (always shown when available)
+  const modelName = data.model?.display_name;
+  if (modelName) {
+    line2Parts.push(`${c.dimWhite}${modelName}${c.reset}`);
+  }
+
+  // 5-hour usage
+  const fiveH = data.rate_limits?.five_hour;
+  if (fiveH?.used_percentage != null) {
+    const pct = Math.round(fiveH.used_percentage);
+    let col = c.dimWhite;
+    if (pct >= 90) col = `${c.blink}${c.red}`;
+    else if (pct >= 70) col = c.yellow;
+    line2Parts.push(`${col}5h: ${pct}%${c.reset}`);
+  }
+
+  // 7-day (weekly) usage
+  const sevenD = data.rate_limits?.seven_day;
+  if (sevenD?.used_percentage != null) {
+    const pct = Math.round(sevenD.used_percentage);
+    let col = c.dimWhite;
+    if (pct >= 90) col = `${c.blink}${c.red}`;
+    else if (pct >= 70) col = c.yellow;
+    line2Parts.push(`${col}7d: ${pct}%${c.reset}`);
+  }
+
+  if (line2Parts.length === 0) return line1;
+
+  const line2 = line2Parts.join(` ${c.dim}\u2502${c.reset} `);
+  return `${line1}\n${line2}`;
 }
 
 // ── Stdin reader with 3s timeout guard ───────────────────────────────────────

--- a/skills/draft-review/SKILL.md
+++ b/skills/draft-review/SKILL.md
@@ -60,6 +60,20 @@ Evaluate against each heuristic. Only flag real violations — not hypothetical 
 
 Severity: **Critical** (blocks task completion), **Major** (slows significantly), **Minor** (annoying but workaroundable).
 
+### Design Intelligence (via uiux)
+
+During heuristic evaluation (Step 3), query UX guidelines for the specific interaction patterns being reviewed:
+
+```bash
+python3 -m draft_agent.uiux search --domain ux --query "{pattern_category}" --limit 5
+```
+
+Use results to:
+
+- Supplement Nielsen's heuristics with specific do/don't guidelines
+- Check severity ratings from the database against your own assessment
+- Reference platform-specific rules (web vs mobile) from the results
+
 ### Step 4: Check the Critical Moments
 
 Always check these specifically, as they have highest impact:

--- a/skills/form-brand/SKILL.md
+++ b/skills/form-brand/SKILL.md
@@ -114,6 +114,23 @@ Type scale (base: [N]px, ratio: [e.g., 1.25 Major Third]):
 
 ---
 
+## Design Intelligence (via uiux)
+
+After defining brand adjectives and visual language (Phase 3), query the design database to validate color and style choices against industry data:
+
+```bash
+python3 -m form_agent.uiux search --domain color --query "{industry/product_type}" --limit 3
+python3 -m form_agent.uiux search --domain style --query "{product_type}" --limit 3
+```
+
+Use results to:
+
+- Validate color palette aligns with industry conventions
+- Check recommended style matches brand adjectives
+- Cross-reference anti-patterns before finalizing visual direction
+
+---
+
 ## Phase 4: Design Tokens + Brand Brief
 
 ### 4.1 Design Tokens

--- a/skills/form-tokens/SKILL.md
+++ b/skills/form-tokens/SKILL.md
@@ -109,6 +109,22 @@ Ask the team to confirm they understand the two-tier model and the rule above. I
 
 ---
 
+## Design Intelligence (via uiux)
+
+After confirming token architecture (Phase 2), use the design system generator to seed initial token values:
+
+```bash
+python3 -m form_agent.uiux design-system --product-type "{product_type}"
+```
+
+Use the generated design system output to:
+
+- Seed primitive color tokens from the industry-matched palette
+- Seed typography tokens from the recommended font pairing
+- Validate spacing and effect choices against the style recommendation
+
+---
+
 ## Phase 3: Token Categories
 
 Define tokens in this order. Each category builds on the previous.

--- a/skills/lens-dashboard/SKILL.md
+++ b/skills/lens-dashboard/SKILL.md
@@ -71,6 +71,21 @@ Define dashboard with 3–5 panels maximum:
 - Table — detail drill-down, top N lists
 - Avoid: pie charts for more than 3 categories, dual-axis charts, 3D anything
 
+### Design Intelligence (via uiux)
+
+When selecting chart types for each panel (Step 2), query the chart database:
+
+```bash
+python3 -m lens_agent.uiux search --domain chart --query "{data_type}" --limit 3
+```
+
+Use results to:
+
+- Select optimal chart type based on data characteristics and volume threshold
+- Check accessibility grade — prefer AA or higher for public dashboards
+- Apply the recommended library (Chart.js, Recharts, D3, etc.) matching the detected stack
+- Use the dashboard style search for overall visual treatment
+
 ### Step 3: Write the SQL Queries
 
 Write production-quality SQL for each panel. Include:

--- a/skills/pitch-copy/SKILL.md
+++ b/skills/pitch-copy/SKILL.md
@@ -25,6 +25,20 @@ Before writing, confirm:
 
 If none of this is available, ask. Copy without context is guessing.
 
+### Design Intelligence (via uiux)
+
+After establishing context (Step 1), query landing page patterns for structural guidance:
+
+```bash
+python3 -m pitch_agent.uiux search --domain landing --query "{product_type}" --limit 3
+```
+
+Use results to:
+
+- Align copy block structure with proven landing page section orders
+- Place CTAs according to the pattern's recommended placement
+- Apply conversion optimization techniques specific to the product type
+
 ### Step 2: Write the Hero Section
 
 The hero is most critical — users form opinion in seconds.

--- a/skills/prism-component/SKILL.md
+++ b/skills/prism-component/SKILL.md
@@ -29,6 +29,21 @@ If no existing components exist, use framework conventions. Default stack if gre
 
 **Stop if design tokens are missing.** Ask Form for the token file before implementing. Do not invent color or spacing values.
 
+### Design Intelligence (via uiux)
+
+After detecting the project framework (Step 0), load stack-specific guidelines and icon references:
+
+```bash
+python3 -m prism_agent.uiux search --domain stacks --query "{detected_framework}" --limit 3
+python3 -m prism_agent.uiux search --domain icons --query "{component_type}" --limit 5
+```
+
+Use results to:
+
+- Follow framework-specific component patterns (e.g., React composition vs Vue slots)
+- Select appropriate icons from the Phosphor Icons catalog
+- Apply stack-specific accessibility and performance guidelines
+
 ### Step 1: Read the Spec
 
 Identify what Form has specified:

--- a/skills/prism-ui/SKILL.md
+++ b/skills/prism-ui/SKILL.md
@@ -67,6 +67,20 @@ UserProfilePage (server — fetches data)
     └── SaveButton (shared component)
 ```
 
+### Design Intelligence (via uiux)
+
+After planning the component structure (Step 2), query performance and stack guidelines:
+
+```bash
+python3 -m prism_agent.uiux search --domain react --query "{optimization_area}" --limit 3
+```
+
+Use results to:
+
+- Apply framework-specific performance patterns (memoization, code splitting, Suspense)
+- Avoid documented performance anti-patterns
+- Choose correct data fetching strategy based on the guidelines
+
 ### Step 3: Write the Implementation
 
 Write all files. Not scaffolding — complete, working code.

--- a/skills/touch-app/SKILL.md
+++ b/skills/touch-app/SKILL.md
@@ -58,6 +58,23 @@ Output the full architecture spec in this structure:
 
 ---
 
+### Design Intelligence (via uiux)
+
+After the platform decision is made, query platform-specific UI rules:
+
+```bash
+python3 -m touch_agent.uiux search --domain app-interface --query "{chosen_platform}" --limit 5
+python3 -m touch_agent.uiux search --domain stacks --query "{chosen_framework}" --limit 3
+```
+
+Use results to:
+
+- Validate platform choice against UI convention requirements (iOS vs Android)
+- Apply framework-specific architecture patterns from stack guidelines
+- Set performance budgets using platform-specific touch target and animation rules
+
+---
+
 ### Architecture Pattern
 
 **Pattern:** [MVVM / MVVM + service layer / MVVM + domain layer]

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -139,6 +139,33 @@ def test_team_agents_match_agents_directory():
     ), f"In agents/ but missing team/ dir: {sorted(only_in_agents_dir)}"
 
 
+def test_root_skills_match_team_skills():
+    """
+    Every root skills/<name>/SKILL.md must be identical to its canonical copy in
+    team/<agent>/skills/<name>/SKILL.md.  Drift means the root copy is missing
+    features that the team copy gained (or vice versa).
+    """
+    skills_dir = REPO / "skills"
+    drifted = []
+    for skill_dir in sorted(skills_dir.iterdir()):
+        if not skill_dir.is_dir():
+            continue
+        root_file = skill_dir / "SKILL.md"
+        if not root_file.exists():
+            continue
+        agent = skill_dir.name.split("-")[0]
+        team_file = REPO / "team" / agent / "skills" / skill_dir.name / "SKILL.md"
+        if not team_file.exists():
+            continue  # team-only or root-only mismatches caught elsewhere
+        if root_file.read_text() != team_file.read_text():
+            drifted.append(skill_dir.name)
+    assert (
+        not drifted
+    ), f"{len(drifted)} root skill(s) drifted from team/ canonical copy: " + ", ".join(
+        drifted
+    )
+
+
 def test_plugin_json_name_matches_agent_directory():
     """
     plugin.json 'name' must match the agent directory name (bare, no prefix).


### PR DESCRIPTION
## Summary
- **Statusline line 2**: adds model, usage windows, commits ahead, duration, lines changed, and cost/line to the statusline's second row
- **Skill drift fix**: syncs 8 root skills that had fallen behind their `team/` canonicals (all missing "Design Intelligence via uiux" sections)
- **CI gate**: adds `test_root_skills_match_team_skills` to `test_structure.py` so future drift fails CI

## Test plan
- [ ] Verify statusline line 2 renders correctly in a Claude Code session
- [ ] Run `python3 -m pytest tests/test_structure.py -v` — all 11 tests pass
- [ ] Confirm the 8 synced skills match their `team/` copies (`diff -q` returns nothing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)