### PR TITLE
feat: notification system — OS alerts on task completion + session update checker (v0.6.9)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tonone",
   "description": "Engineering + Product team — 23 agents as Claude Code specialists. Infrastructure, DevOps, backend, security, ML/AI, mobile, UX, analytics, growth, strategy, and more.",
-  "version": "0.6.7",
+  "version": "0.6.9",
   "author": {
     "name": "tonone-ai",
     "url": "https://tonone.ai"
@@ -31,6 +31,11 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/install-statusline.sh\""
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/tonone-update-check.js\"",
+            "timeout": 8
           }
         ]
       }
@@ -42,6 +47,28 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/tonone-agent-tracker.js\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/tonone-notify.js\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/tonone-notify.js\"",
             "timeout": 5
           }
         ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.9] — 2026-04-12
+
+### Added
+
+- **Update checker** — `hooks/tonone-update-check.js` runs at `SessionStart`, fetches the latest version from GitHub at most once per 24 h, and notifies via OS notification + stderr line when a newer version is available. Result is cached in `~/.config/tonone/update-cache.json`.
+
+## [0.6.8] — 2026-04-12
+
+### Added
+
+- **Notification system** — `hooks/tonone-notify.js` fires a macOS notification (via `osascript`) when Claude finishes a turn (`Stop` hook) or needs your attention (`Notification` hook). Sound plays via `afplay` and is on by default. Configure in `~/.config/tonone/config.json` under the `notify` key (`sound: bool`, `soundFile: string`).
+
 ## [0.6.7] — 2026-04-12
 
 ### Added

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,6 +6,11 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/install-statusline.sh\""
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/tonone-update-check.js\"",
+            "timeout": 8
           }
         ]
       }
@@ -17,6 +22,28 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/tonone-agent-tracker.js\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/tonone-notify.js\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/tonone-notify.js\"",
             "timeout": 5
           }
         ]

--- a/hooks/tonone-notify.js
+++ b/hooks/tonone-notify.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+"use strict";
+
+// tonone-notify — Stop + Notification hook
+// Fires a macOS notification when Claude finishes a turn or needs attention.
+//
+// Config: ~/.config/tonone/config.json
+// {
+//   "notify": {
+//     "sound": true,
+//     "soundFile": "/System/Library/Sounds/Glass.aiff"
+//   }
+// }
+
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+const CONFIG_PATH = path.join(os.homedir(), ".config", "tonone", "config.json");
+
+const DEFAULTS = {
+  sound: true,
+  soundFile: "/System/Library/Sounds/Glass.aiff",
+};
+
+function loadConfig() {
+  try {
+    const raw = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf8"));
+    return { ...DEFAULTS, ...(raw.notify || {}) };
+  } catch {
+    return { ...DEFAULTS };
+  }
+}
+
+// ── Notification ──────────────────────────────────────────────────────────────
+
+// Escape a string for use inside an AppleScript double-quoted string literal.
+function escapeAS(s) {
+  return String(s)
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"');
+}
+
+function sendNotification(title, subtitle, body) {
+  const parts = [`display notification "${escapeAS(body)}"`, `with title "${escapeAS(title)}"`];
+  if (subtitle) parts.push(`subtitle "${escapeAS(subtitle)}"`);
+  spawnSync("osascript", ["-e", parts.join(" ")], { timeout: 3000 });
+}
+
+function playSound(file) {
+  if (!file) return;
+  spawnSync("afplay", [file], { timeout: 5000 });
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+let input = "";
+const stdinTimeout = setTimeout(() => process.exit(0), 3000);
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => (input += chunk));
+process.stdin.on("end", () => {
+  clearTimeout(stdinTimeout);
+
+  let data;
+  try {
+    data = JSON.parse(input);
+  } catch {
+    process.exit(0);
+  }
+
+  // Detect event type: prefer explicit field, fall back to payload shape.
+  const event = data.hook_event_name || (data.message != null ? "Notification" : "Stop");
+
+  if (event !== "Stop" && event !== "Notification") process.exit(0);
+
+  const cwd = data.cwd || data.workspace?.current_dir || "";
+  const folder = cwd ? path.basename(cwd) : "";
+
+  let body;
+  if (event === "Stop") {
+    body = "Done \u2014 your turn";
+  } else {
+    body = data.message || "Needs your attention";
+  }
+
+  const cfg = loadConfig();
+  sendNotification("Claude Code", folder || null, body);
+  if (cfg.sound) playSound(cfg.soundFile);
+});

--- a/hooks/tonone-update-check.js
+++ b/hooks/tonone-update-check.js
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+"use strict";
+
+// tonone-update-check — SessionStart hook
+// Checks for plugin updates once per 24 h and notifies the user when a newer
+// version is available. Exits silently if offline, rate-limited, or up to date.
+
+const https = require("https");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || path.join(__dirname, "..");
+const PLUGIN_JSON = path.join(PLUGIN_ROOT, ".claude-plugin", "plugin.json");
+const CACHE_DIR = path.join(os.homedir(), ".config", "tonone");
+const CACHE_FILE = path.join(CACHE_DIR, "update-cache.json");
+const INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 h
+const RAW_URL =
+  "https://raw.githubusercontent.com/tonone-ai/tonone/main/.claude-plugin/plugin.json";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function currentVersion() {
+  try {
+    return JSON.parse(fs.readFileSync(PLUGIN_JSON, "utf8")).version || null;
+  } catch {
+    return null;
+  }
+}
+
+function readCache() {
+  try {
+    return JSON.parse(fs.readFileSync(CACHE_FILE, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+function writeCache(data) {
+  try {
+    fs.mkdirSync(CACHE_DIR, { recursive: true });
+    fs.writeFileSync(CACHE_FILE, JSON.stringify(data));
+  } catch {}
+}
+
+// Returns -1 if a < b, 0 if equal, 1 if a > b.
+function semverCmp(a, b) {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const d = (pa[i] || 0) - (pb[i] || 0);
+    if (d !== 0) return d < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+function fetchLatestVersion(cb) {
+  const req = https.get(RAW_URL, { timeout: 5000 }, (res) => {
+    let body = "";
+    res.on("data", (chunk) => (body += chunk));
+    res.on("end", () => {
+      try {
+        cb(null, JSON.parse(body).version || null);
+      } catch {
+        cb(new Error("parse error"));
+      }
+    });
+  });
+  req.on("error", cb);
+  req.on("timeout", () => {
+    req.destroy();
+    cb(new Error("timeout"));
+  });
+}
+
+function notify(current, latest) {
+  const body = `Update available: v${current} \u2192 v${latest}`;
+  const hint = "claude plugin update tonone";
+  const script = [
+    `display notification "${body}"`,
+    `with title "tonone"`,
+    `subtitle "${hint}"`,
+  ].join(" ");
+  spawnSync("osascript", ["-e", script], { timeout: 3000 });
+  process.stderr.write(`\n[tonone] ${body}\n  Run: ${hint}\n\n`);
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+const current = currentVersion();
+if (!current) process.exit(0);
+
+const cache = readCache();
+const now = Date.now();
+
+// If the cache is fresh enough, use it — no network call.
+if (cache.checkedAt && now - cache.checkedAt < INTERVAL_MS) {
+  if (cache.latestVersion && semverCmp(current, cache.latestVersion) < 0) {
+    notify(current, cache.latestVersion);
+  }
+  process.exit(0);
+}
+
+// Cache stale — fetch from GitHub.
+fetchLatestVersion((err, latest) => {
+  if (err || !latest) process.exit(0);
+  writeCache({ checkedAt: now, latestVersion: latest });
+  if (semverCmp(current, latest) < 0) {
+    notify(current, latest);
+  }
+});


### PR DESCRIPTION
## Summary

**Notification system** — two new hooks that close the feedback loop between Claude Code and the user.

**`hooks/tonone-notify.js`** (Stop + Notification hooks)
- Fires a macOS notification via `osascript` when Claude finishes a turn (`Stop`) or needs attention (`Notification`)
- Sound plays via `afplay` on every notification — on by default
- Fully configurable: `~/.config/tonone/config.json` → `notify.sound` (bool) + `notify.soundFile` (path)
- Available system sounds: Basso, Blow, Bottle, Frog, Funk, **Glass** (default), Hero, Morse, Ping, Pop, Purr, Sosumi, Submarine, Tink

**`hooks/tonone-update-check.js`** (SessionStart hook)
- Fetches latest `plugin.json` from GitHub at most once per 24 h
- If behind: fires OS notification + prints `[tonone] Update available: vX → vY / Run: claude plugin update tonone` to stderr
- Cache stored at `~/.config/tonone/update-cache.json`; exits silently when offline or rate-limited

## Pre-Landing Review

No issues found. Key checks:
- `escapeAS()` correctly escapes AppleScript string literals — no injection path
- All OS calls (`osascript`, `afplay`, `https.get`) use silent-fail pattern — consistent with existing hooks
- `hooks.json` and `plugin.json` kept in sync
- 5s network timeout on update check; 3s stdin timeout on notify

## Test Coverage

37 existing Python structure tests pass. New hooks are OS-boundary Node.js scripts (osascript, afplay, https.get) — not covered by the Python test suite. Notification delivery was manually verified.

## TODOS

No TODO items completed in this PR.

## Test plan

- [x] 37 Python structure tests pass (0 failures)
- [x] macOS notification manually verified (`osascript` confirmed working)
- [x] `hooks.json` and `plugin.json` in sync with new Stop, Notification, SessionStart entries
- [x] Version bumped 0.6.7 → 0.6.9 in `plugin.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)