### PR TITLE
feat: 3-line statusline redesign with pace projection

### DIFF
--- a/.reports/apex-takeover-2026-04-12-0247.html
+++ b/.reports/apex-takeover-2026-04-12-0247.html
@@ -1,0 +1,1664 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Apex Takeover Report — tonone</title>
+    <style>
+      :root {
+        --bg: #0f172a;
+        --bg-card: #1e293b;
+        --bg-card-alt: #162032;
+        --text: #e2e8f0;
+        --text-muted: #94a3b8;
+        --border: #334155;
+        --accent: #3b82f6;
+        --critical: #dc2626;
+        --critical-bg: rgba(220, 38, 38, 0.12);
+        --warning: #d97706;
+        --warning-bg: rgba(217, 119, 6, 0.12);
+        --info: #2563eb;
+        --info-bg: rgba(37, 99, 235, 0.12);
+        --success: #16a34a;
+        --success-bg: rgba(22, 163, 74, 0.12);
+        --font-mono: "JetBrains Mono", "Fira Code", "Cascadia Code", monospace;
+        --font-sans: "Inter", system-ui, -apple-system, sans-serif;
+      }
+      [data-theme="light"] {
+        --bg: #ffffff;
+        --bg-card: #f8fafc;
+        --bg-card-alt: #f1f5f9;
+        --text: #1e293b;
+        --text-muted: #64748b;
+        --border: #e2e8f0;
+        --critical-bg: #fef2f2;
+        --warning-bg: #fffbeb;
+        --info-bg: #eff6ff;
+        --success-bg: #f0fdf4;
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family: var(--font-sans);
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.6;
+        display: flex;
+        min-height: 100vh;
+      }
+      /* Sidebar */
+      .sidebar {
+        width: 260px;
+        position: fixed;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        background: var(--bg-card);
+        border-right: 1px solid var(--border);
+        padding: 1.5rem 1rem;
+        overflow-y: auto;
+        z-index: 100;
+        transition: transform 0.3s ease;
+      }
+      .sidebar-brand {
+        font-size: 0.7rem;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--text-muted);
+        margin-bottom: 0.25rem;
+      }
+      .sidebar-title {
+        font-size: 1.1rem;
+        font-weight: 700;
+        margin-bottom: 1.5rem;
+        color: var(--text);
+      }
+      .sidebar-section {
+        font-size: 0.65rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--text-muted);
+        margin: 1.25rem 0 0.5rem;
+      }
+      .sidebar a {
+        display: block;
+        padding: 0.35rem 0.75rem;
+        margin: 0.15rem 0;
+        color: var(--text-muted);
+        text-decoration: none;
+        font-size: 0.85rem;
+        border-radius: 6px;
+        transition: all 0.15s;
+      }
+      .sidebar a:hover,
+      .sidebar a.active {
+        color: var(--text);
+        background: var(--bg);
+      }
+      .hamburger {
+        display: none;
+        position: fixed;
+        top: 1rem;
+        left: 1rem;
+        z-index: 200;
+        background: var(--bg-card);
+        border: 1px solid var(--border);
+        color: var(--text);
+        width: 40px;
+        height: 40px;
+        border-radius: 8px;
+        font-size: 1.2rem;
+        cursor: pointer;
+      }
+      /* Theme toggle */
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        z-index: 200;
+        background: var(--bg-card);
+        border: 1px solid var(--border);
+        color: var(--text);
+        width: 40px;
+        height: 40px;
+        border-radius: 8px;
+        font-size: 1.1rem;
+        cursor: pointer;
+        transition: all 0.15s;
+      }
+      .theme-toggle:hover {
+        border-color: var(--accent);
+      }
+      /* Main */
+      main {
+        margin-left: 260px;
+        flex: 1;
+        max-width: 900px;
+        padding: 2rem 3rem 4rem;
+      }
+      header {
+        margin-bottom: 2.5rem;
+      }
+      header h1 {
+        font-size: 1.75rem;
+        font-weight: 800;
+        margin-bottom: 0.5rem;
+      }
+      .meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1.5rem;
+        color: var(--text-muted);
+        font-size: 0.85rem;
+      }
+      .meta-item {
+        display: flex;
+        align-items: center;
+        gap: 0.35rem;
+      }
+      .meta-label {
+        font-weight: 600;
+        color: var(--text);
+      }
+      section {
+        margin-bottom: 3rem;
+      }
+      section > h2 {
+        font-size: 1.25rem;
+        font-weight: 700;
+        margin-bottom: 1rem;
+        padding-bottom: 0.5rem;
+        border-bottom: 1px solid var(--border);
+      }
+      section > h3 {
+        font-size: 1.05rem;
+        font-weight: 600;
+        margin: 1.5rem 0 0.75rem;
+      }
+      p,
+      li {
+        color: var(--text);
+        font-size: 0.9rem;
+      }
+      p {
+        margin-bottom: 0.75rem;
+      }
+      ul,
+      ol {
+        padding-left: 1.5rem;
+        margin-bottom: 0.75rem;
+      }
+      li {
+        margin-bottom: 0.35rem;
+      }
+      strong {
+        font-weight: 600;
+      }
+      /* Cards */
+      .card {
+        background: var(--bg-card);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 1.25rem 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .card-critical {
+        border-left: 4px solid var(--critical);
+        background: var(--critical-bg);
+      }
+      .card-warning {
+        border-left: 4px solid var(--warning);
+        background: var(--warning-bg);
+      }
+      .card-info {
+        border-left: 4px solid var(--info);
+        background: var(--info-bg);
+      }
+      .card-success {
+        border-left: 4px solid var(--success);
+        background: var(--success-bg);
+      }
+      .severity {
+        font-weight: 700;
+        font-size: 0.8rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin-bottom: 0.5rem;
+      }
+      .severity-critical {
+        color: var(--critical);
+      }
+      .severity-warning {
+        color: var(--warning);
+      }
+      .severity-info {
+        color: var(--info);
+      }
+      .card h4 {
+        font-size: 0.95rem;
+        font-weight: 600;
+        margin-bottom: 0.5rem;
+      }
+      .card p:last-child {
+        margin-bottom: 0;
+      }
+      .card code {
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        background: var(--bg);
+        padding: 0.15rem 0.4rem;
+        border-radius: 4px;
+      }
+      /* Tables */
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.85rem;
+        margin-bottom: 1rem;
+      }
+      th,
+      td {
+        text-align: left;
+        padding: 0.6rem 0.75rem;
+        border-bottom: 1px solid var(--border);
+      }
+      th {
+        font-weight: 600;
+        color: var(--text-muted);
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+      tr:hover td {
+        background: var(--bg-card-alt);
+      }
+      /* Code */
+      pre {
+        position: relative;
+        background: var(--bg-card);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem;
+        overflow-x: auto;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        line-height: 1.5;
+        margin-bottom: 1rem;
+      }
+      .copy-btn {
+        position: absolute;
+        top: 0.5rem;
+        right: 0.5rem;
+        background: var(--bg);
+        border: 1px solid var(--border);
+        color: var(--text-muted);
+        padding: 0.2rem 0.5rem;
+        border-radius: 4px;
+        font-size: 0.7rem;
+        cursor: pointer;
+        opacity: 0;
+        transition: opacity 0.15s;
+      }
+      pre:hover .copy-btn {
+        opacity: 1;
+      }
+      .copy-btn:hover {
+        color: var(--text);
+        border-color: var(--accent);
+      }
+      /* Details */
+      details {
+        background: var(--bg-card);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        margin-bottom: 0.75rem;
+      }
+      details summary {
+        padding: 0.75rem 1rem;
+        cursor: pointer;
+        font-weight: 600;
+        font-size: 0.9rem;
+        user-select: none;
+      }
+      details summary:hover {
+        color: var(--accent);
+      }
+      details > div,
+      details > pre,
+      details > table,
+      details > p {
+        margin: 0 1rem 1rem;
+      }
+      /* Risk matrix */
+      .risk-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 0.75rem;
+        margin-bottom: 1rem;
+      }
+      .risk-item {
+        padding: 1rem;
+        border-radius: 8px;
+        border: 1px solid var(--border);
+        background: var(--bg-card);
+      }
+      .risk-score {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 800;
+      }
+      .risk-label {
+        font-size: 0.8rem;
+        color: var(--text-muted);
+        margin-top: 0.25rem;
+      }
+      /* Roadmap */
+      .roadmap-phase {
+        margin-bottom: 1.5rem;
+      }
+      .roadmap-phase h4 {
+        font-size: 0.95rem;
+        font-weight: 700;
+        margin-bottom: 0.75rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+      .phase-badge {
+        font-size: 0.7rem;
+        padding: 0.15rem 0.6rem;
+        border-radius: 999px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+      .phase-now {
+        background: var(--critical-bg);
+        color: var(--critical);
+      }
+      .phase-next {
+        background: var(--warning-bg);
+        color: var(--warning);
+      }
+      .phase-later {
+        background: var(--info-bg);
+        color: var(--info);
+      }
+      /* Mermaid */
+      .mermaid {
+        background: var(--bg-card);
+        padding: 1.5rem;
+        border-radius: 8px;
+        border: 1px solid var(--border);
+        margin-bottom: 1rem;
+        text-align: center;
+      }
+      /* Stats row */
+      .stats {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 0.75rem;
+        margin-bottom: 1.5rem;
+      }
+      .stat {
+        background: var(--bg-card);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem;
+        text-align: center;
+      }
+      .stat-value {
+        font-size: 1.5rem;
+        font-weight: 800;
+        font-family: var(--font-mono);
+      }
+      .stat-label {
+        font-size: 0.75rem;
+        color: var(--text-muted);
+        margin-top: 0.25rem;
+      }
+      /* Responsive */
+      @media (max-width: 768px) {
+        .sidebar {
+          transform: translateX(-100%);
+        }
+        .sidebar.open {
+          transform: translateX(0);
+        }
+        .hamburger {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+        main {
+          margin-left: 0;
+          padding: 2rem 1.25rem;
+        }
+      }
+      @media print {
+        .sidebar,
+        .hamburger,
+        .theme-toggle {
+          display: none !important;
+        }
+        main {
+          margin-left: 0;
+          max-width: 100%;
+        }
+        body {
+          background: #fff;
+          color: #000;
+        }
+        .card {
+          break-inside: avoid;
+        }
+        details[open] > summary {
+          font-weight: 700;
+        }
+        details:not([open]) > * {
+          display: block !important;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <button
+      class="hamburger"
+      onclick="document.querySelector('.sidebar').classList.toggle('open')"
+      aria-label="Toggle menu"
+    >
+      &#9776;
+    </button>
+    <button
+      class="theme-toggle"
+      onclick="toggleTheme()"
+      aria-label="Toggle theme"
+    >
+      &#9790;
+    </button>
+
+    <nav class="sidebar">
+      <div class="sidebar-brand">tonone</div>
+      <div class="sidebar-title">Takeover Report</div>
+      <div class="sidebar-section">Overview</div>
+      <a href="#summary">Executive Summary</a>
+      <a href="#stats">System at a Glance</a>
+      <a href="#architecture">Architecture</a>
+      <div class="sidebar-section">Assessment</div>
+      <a href="#findings">Findings</a>
+      <a href="#risk">Risk Assessment</a>
+      <a href="#debt">Technical Debt</a>
+      <div class="sidebar-section">Plan</div>
+      <a href="#quickwins">Quick Wins (Week 1)</a>
+      <a href="#roadmap">30/60/90 Day Roadmap</a>
+      <a href="#donot">Don't Touch List</a>
+      <div class="sidebar-section">Specialists</div>
+      <a href="#atlas-detail">Atlas (Architecture)</a>
+      <a href="#relay-detail">Relay (CI/CD)</a>
+      <a href="#warden-detail">Warden (Security)</a>
+      <a href="#spine-detail">Spine (Quality)</a>
+      <a href="#prism-detail">Prism (DX)</a>
+      <a href="#cortex-detail">Cortex (AI/Prompt)</a>
+    </nav>
+
+    <main>
+      <header>
+        <h1>Apex Takeover Report</h1>
+        <div class="meta">
+          <div class="meta-item">
+            <span class="meta-label">Agent:</span> Apex (Engineering Lead)
+          </div>
+          <div class="meta-item">
+            <span class="meta-label">Skill:</span> apex-takeover
+          </div>
+          <div class="meta-item">
+            <span class="meta-label">Target:</span> tonone &mdash;
+            /Users/f/repos/tn/tonone
+          </div>
+          <div class="meta-item">
+            <span class="meta-label">Date:</span> 2026-04-12
+          </div>
+          <div class="meta-item">
+            <span class="meta-label">Version:</span> 0.6.6
+          </div>
+        </div>
+      </header>
+
+      <!-- ====== EXECUTIVE SUMMARY ====== -->
+      <section id="summary">
+        <h2>Executive Summary</h2>
+        <div class="card card-info">
+          <ul>
+            <li>
+              <strong>System type:</strong> Prompt-engineering framework &mdash;
+              23 AI agents and 138 skills delivered as a Claude Code plugin. No
+              deployed services, no cloud, no APIs. The git repo is the
+              artifact.
+            </li>
+            <li>
+              <strong>Architecture quality:</strong> High. Consistent 3-layer
+              plugin architecture (root plugin &rarr; agent layer &rarr; skill
+              layer) with strong structural conventions enforced by CI.
+            </li>
+            <li>
+              <strong>Prompt engineering:</strong> Strong. All 23 agents follow
+              a uniform persona template. The Helm&harr;Apex handoff protocol is
+              the standout design. Output kit provides effective format control.
+            </li>
+            <li>
+              <strong>Primary risks:</strong> No prompt injection defenses, 12
+              newer skills missing output-kit contract, agent definition drift
+              invisible without versioning, no eval infrastructure for agent
+              behaviors.
+            </li>
+            <li>
+              <strong>Immediate posture:</strong> Healthy for stage 0&rarr;1.
+              Security is clean, CI gates work, documentation is strong. The
+              gaps are all forward-looking &mdash; things to build before
+              scaling, not fires to fight.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <!-- ====== STATS ====== -->
+      <section id="stats">
+        <h2>System at a Glance</h2>
+        <div class="stats">
+          <div class="stat">
+            <div class="stat-value">23</div>
+            <div class="stat-label">Agents</div>
+          </div>
+          <div class="stat">
+            <div class="stat-value">138</div>
+            <div class="stat-label">Skills</div>
+          </div>
+          <div class="stat">
+            <div class="stat-value">0</div>
+            <div class="stat-label">Cloud Services</div>
+          </div>
+          <div class="stat">
+            <div class="stat-value">0</div>
+            <div class="stat-label">External Deps</div>
+          </div>
+          <div class="stat">
+            <div class="stat-value">2</div>
+            <div class="stat-label">CI Jobs</div>
+          </div>
+          <div class="stat">
+            <div class="stat-value">91%</div>
+            <div class="stat-label">Output Kit Compliance</div>
+          </div>
+        </div>
+        <table>
+          <thead>
+            <tr>
+              <th>Domain</th>
+              <th>Specialist</th>
+              <th>Status</th>
+              <th>Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Architecture</td>
+              <td>Atlas</td>
+              <td>&#9679; Healthy</td>
+              <td>3-layer plugin system, strong conventions</td>
+            </tr>
+            <tr>
+              <td>Infrastructure</td>
+              <td>Forge</td>
+              <td>&#9679; N/A</td>
+              <td>No cloud infra &mdash; correct for this stage</td>
+            </tr>
+            <tr>
+              <td>CI/CD</td>
+              <td>Relay</td>
+              <td>&#9650; Gaps</td>
+              <td>Validation gate works; release tagging broken</td>
+            </tr>
+            <tr>
+              <td>Security</td>
+              <td>Warden</td>
+              <td>&#9679; Clean</td>
+              <td>Zero attack surface, minor CI hardening opps</td>
+            </tr>
+            <tr>
+              <td>Observability</td>
+              <td>Vigil</td>
+              <td>&#9679; N/A</td>
+              <td>No services to instrument</td>
+            </tr>
+            <tr>
+              <td>Quality</td>
+              <td>Spine</td>
+              <td>&#9650; Gaps</td>
+              <td>12 skills missing output-kit, test gaps</td>
+            </tr>
+            <tr>
+              <td>DX</td>
+              <td>Prism</td>
+              <td>&#9650; Gaps</td>
+              <td>Manual sync hazard, no root task runner</td>
+            </tr>
+            <tr>
+              <td>AI/Prompts</td>
+              <td>Cortex</td>
+              <td>&#9650; Gaps</td>
+              <td>Strong architecture, no injection defenses</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <!-- ====== ARCHITECTURE ====== -->
+      <section id="architecture">
+        <h2>Architecture</h2>
+        <div class="mermaid">
+          graph TD subgraph "Root Plugin" RP["/.claude-plugin/plugin.json"]
+          SL["hooks/tonone-statusline.js"] AT["hooks/tonone-agent-tracker.js"]
+          end subgraph "Agent Layer (x23)" AD["team/&lt;agent&gt;/agents/*.md"]
+          SK["team/&lt;agent&gt;/skills/*/SKILL.md"]
+          SC["team/&lt;agent&gt;/scripts/"] HK["team/&lt;agent&gt;/hooks/"]
+          TS["team/&lt;agent&gt;/tests/"] end subgraph "Standalone Skills (138)"
+          SS["skills/*/SKILL.md"] end subgraph "Bundles" FT["bundle/full-team/"]
+          ET["bundle/engineering-team/"] PT["bundle/product-team/"] end subgraph
+          "Docs" OK["docs/output-kit.md"] NG["docs/naming-guide.md"]
+          AG["docs/agent-guide.md"] end RP --> AD RP --> SS AD --> SK AD --> SC
+          AD --> HK FT --> ET FT --> PT SK -.->|"follows"| OK SS -.->|"follows"|
+          OK
+        </div>
+
+        <h3>Tech Stack</h3>
+        <table>
+          <thead>
+            <tr>
+              <th>Layer</th>
+              <th>Technology</th>
+              <th>Purpose</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Agent definitions</td>
+              <td>Markdown + YAML frontmatter</td>
+              <td>Persona, scope, principles, routing</td>
+            </tr>
+            <tr>
+              <td>Skills</td>
+              <td>Markdown (SKILL.md)</td>
+              <td>Step-by-step workflows with tool declarations</td>
+            </tr>
+            <tr>
+              <td>Scripts</td>
+              <td>Python 3.10+ (per-agent venv)</td>
+              <td>Analyzer stubs &mdash; not yet implemented</td>
+            </tr>
+            <tr>
+              <td>Hooks</td>
+              <td>Node.js (stdlib only)</td>
+              <td>Statusline display, agent tracking</td>
+            </tr>
+            <tr>
+              <td>Tests</td>
+              <td>pytest</td>
+              <td>Structural validation</td>
+            </tr>
+            <tr>
+              <td>CI</td>
+              <td>GitHub Actions</td>
+              <td>Structure checks + shellcheck</td>
+            </tr>
+            <tr>
+              <td>Package mgr</td>
+              <td>uv (preferred) / pip</td>
+              <td>Per-agent Python environments</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3>Key Design Decisions</h3>
+        <ul>
+          <li>
+            <strong>Agents are prompts, not code.</strong> The product value is
+            in the structured markdown that defines each agent's persona,
+            decision framework, and workflow.
+          </li>
+          <li>
+            <strong>Self-contained agents.</strong> Each agent has its own
+            plugin manifest, scripts, tests, and hooks. No cross-agent code
+            dependencies.
+          </li>
+          <li>
+            <strong>Output kit as a shared contract.</strong> All 23 agents and
+            138 skills reference a single formatting standard (40-line CLI max,
+            severity indicators, box-drawing).
+          </li>
+          <li>
+            <strong>Dual-location agent defs.</strong> Canonical copy in
+            <code>team/&lt;agent&gt;/agents/</code>, working copy in root
+            <code>agents/</code>. CI enforces sync.
+          </li>
+          <li>
+            <strong>Model tiering.</strong> Apex runs on Opus; specialists run
+            on Sonnet. Cost control by design.
+          </li>
+        </ul>
+      </section>
+
+      <!-- ====== FINDINGS ====== -->
+      <section id="findings">
+        <h2>Findings</h2>
+
+        <div class="card card-warning">
+          <div class="severity severity-warning">
+            &#9650; WARNING &mdash; F1
+          </div>
+          <h4>No prompt injection defenses</h4>
+          <p>
+            No agent carries a standing instruction to treat user-provided
+            content as untrusted. Skills like <code>cortex-integrate</code> and
+            <code>warden-audit</code> read untrusted codebases directly into LLM
+            context. <code>cortex-prompt</code> uses XML delimiters for user
+            content but no explicit "do not override system instructions" guard.
+          </p>
+          <p>
+            <strong>Fix:</strong> Add a standard prompt injection defense
+            paragraph to the agent template and backfill into all 23 agents. Add
+            to the skill template for skills that accept external input.
+          </p>
+        </div>
+
+        <div class="card card-warning">
+          <div class="severity severity-warning">
+            &#9650; WARNING &mdash; F2
+          </div>
+          <h4>12 skills missing output-kit contract line</h4>
+          <p>
+            All v0.6.6 skills (touch-ui, surge-landing, prism-stack,
+            prism-chart, pitch-landing, lens-chart, form-style, form-palette,
+            draft-patterns, draft-landing + 2 others) lack the mandatory
+            output-kit reference. These have a lighter body format
+            (reference-style vs. step-by-step workflow). No CI test catches
+            this.
+          </p>
+          <p>
+            <strong>Fix:</strong> Add
+            <code>test_skill_output_kit_contract</code> to
+            <code>test_structure.py</code>. Backfill the contract line into the
+            12 missing skills.
+          </p>
+        </div>
+
+        <div class="card card-warning">
+          <div class="severity severity-warning">
+            &#9650; WARNING &mdash; F3
+          </div>
+          <h4>No eval infrastructure for agent behaviors</h4>
+          <p>
+            <code>cortex-eval</code> exists for evaluating user ML features, but
+            nothing measures whether the 23 agents themselves comply with output
+            format, schema adherence, or decision quality. Prompt drift is
+            invisible.
+          </p>
+          <p>
+            <strong>Fix:</strong> Build an agent eval suite &mdash; test output
+            format compliance, routing accuracy, handoff schema adherence. Start
+            with the output-kit 40-line rule and severity indicator usage.
+          </p>
+        </div>
+
+        <div class="card card-warning">
+          <div class="severity severity-warning">
+            &#9650; WARNING &mdash; F4
+          </div>
+          <h4>Git tags stale &mdash; release process broken</h4>
+          <p>
+            Only one git tag exists (<code>v0.1.0</code>) but CHANGELOG shows
+            current version <code>0.6.6</code>. No automated version bumping, no
+            tag-on-merge. Version lives in <code>marketplace.json</code> only.
+          </p>
+          <p>
+            <strong>Fix:</strong> Add a CI job or post-merge hook that creates a
+            git tag matching the version in <code>marketplace.json</code>.
+            Backfill tags for 0.6.0&ndash;0.6.6.
+          </p>
+        </div>
+
+        <div class="card card-warning">
+          <div class="severity severity-warning">
+            &#9650; WARNING &mdash; F5
+          </div>
+          <h4>Sparse skill routing in CLAUDE.md</h4>
+          <p>
+            CLAUDE.md covers ~10 trigger patterns for 138 skills. High miss rate
+            likely for mid-specificity requests. Users asking for things outside
+            the top-10 patterns won't get routed to the right skill.
+          </p>
+          <p>
+            <strong>Fix:</strong> Expand routing rules or add a skill discovery
+            mechanism. Consider a "routing index" skill that maps intents to
+            skills programmatically.
+          </p>
+        </div>
+
+        <div class="card card-info">
+          <div class="severity severity-info">&#9679; INFO &mdash; F6</div>
+          <h4>No cost ceiling or timeout protocol for specialist dispatch</h4>
+          <p>
+            Apex dispatches specialists via the Agent tool but there's no kill
+            switch if a specialist runs deep on what was scoped as a Small task.
+            The S/M/L format with estimates is a good start but lacks
+            enforcement.
+          </p>
+          <p>
+            <strong>Fix:</strong> Add explicit token budget guidance per S/M/L
+            tier in the Apex prompt. Consider a meta-skill that monitors
+            dispatch cost.
+          </p>
+        </div>
+
+        <div class="card card-info">
+          <div class="severity severity-info">&#9679; INFO &mdash; F7</div>
+          <h4>Agent tracker uses description-string matching</h4>
+          <p>
+            <code>tonone-agent-tracker.js</code> matches agent completion by
+            <code>desc</code> string equality. If two subagents share a
+            description prefix, the wrong one could be marked finished.
+          </p>
+          <p>
+            <strong>Fix:</strong> Use the agent ID (already available in hook
+            context) for matching instead of the description string.
+          </p>
+        </div>
+
+        <div class="card card-info">
+          <div class="severity severity-info">&#9679; INFO &mdash; F8</div>
+          <h4>No SKILL.md template in new-agent scaffold</h4>
+          <p>
+            <code>templates/new-agent/skills/SKILL_NAME/</code> directory exists
+            but contains no populated SKILL.md scaffold. New agent authors must
+            copy from an existing skill and strip it.
+          </p>
+          <p>
+            <strong>Fix:</strong> Add a scaffold SKILL.md with placeholder
+            frontmatter and the output-kit contract line.
+          </p>
+        </div>
+
+        <div class="card card-info">
+          <div class="severity severity-info">&#9679; INFO &mdash; F9</div>
+          <h4>CI dependencies unpinned</h4>
+          <p>
+            <code>pip install pytest</code> without version pin in CI. GitHub
+            Actions at major version (<code>@v4</code>) not SHA-pinned. Low risk
+            at current scale but blocks reproducible builds.
+          </p>
+          <p>
+            <strong>Fix:</strong> Pin <code>pytest</code> version in CI. SHA-pin
+            Actions when hardening is prioritized.
+          </p>
+        </div>
+
+        <div class="card card-info">
+          <div class="severity severity-info">&#9679; INFO &mdash; F10</div>
+          <h4>No root-level task runner</h4>
+          <p>
+            No <code>make</code>, <code>just</code>, or
+            <code>npm run</code> commands at root for common dev tasks (run all
+            tests, lint all, validate structure). Developers must know to run
+            pytest against specific test files.
+          </p>
+          <p>
+            <strong>Fix:</strong> Add a <code>Makefile</code> or
+            <code>justfile</code> with <code>test</code>, <code>lint</code>,
+            <code>validate</code> targets.
+          </p>
+        </div>
+      </section>
+
+      <!-- ====== RISK ASSESSMENT ====== -->
+      <section id="risk">
+        <h2>Risk Assessment</h2>
+        <p>
+          Top 10 risks ranked by likelihood &times; impact. Scale: L
+          (likelihood) 1&ndash;5, I (impact) 1&ndash;5, Score = L &times; I.
+        </p>
+        <table>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Risk</th>
+              <th>L</th>
+              <th>I</th>
+              <th>Score</th>
+              <th>Mitigation</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>1</td>
+              <td>Prompt injection via untrusted codebase content</td>
+              <td>3</td>
+              <td>5</td>
+              <td style="color: var(--critical); font-weight: 700">15</td>
+              <td>Add injection defense to agent template</td>
+            </tr>
+            <tr>
+              <td>2</td>
+              <td>Agent behavior drift (no evals)</td>
+              <td>4</td>
+              <td>3</td>
+              <td style="color: var(--warning); font-weight: 700">12</td>
+              <td>Build agent eval suite</td>
+            </tr>
+            <tr>
+              <td>3</td>
+              <td>Skill routing misses (138 skills, 10 patterns)</td>
+              <td>4</td>
+              <td>3</td>
+              <td style="color: var(--warning); font-weight: 700">12</td>
+              <td>Expand routing or add discovery</td>
+            </tr>
+            <tr>
+              <td>4</td>
+              <td>New skills skip output-kit contract (no CI gate)</td>
+              <td>4</td>
+              <td>2</td>
+              <td style="color: var(--warning); font-weight: 700">8</td>
+              <td>Add structural test</td>
+            </tr>
+            <tr>
+              <td>5</td>
+              <td>Agent def drift between locations (sync break)</td>
+              <td>2</td>
+              <td>4</td>
+              <td style="color: var(--warning); font-weight: 700">8</td>
+              <td>CI catches this &mdash; monitor</td>
+            </tr>
+            <tr>
+              <td>6</td>
+              <td>Version tag desync (users on wrong version)</td>
+              <td>3</td>
+              <td>2</td>
+              <td style="color: var(--info); font-weight: 700">6</td>
+              <td>Automate tag on merge</td>
+            </tr>
+            <tr>
+              <td>7</td>
+              <td>Specialist dispatch exceeds user budget</td>
+              <td>2</td>
+              <td>3</td>
+              <td style="color: var(--info); font-weight: 700">6</td>
+              <td>Token budget guidance per tier</td>
+            </tr>
+            <tr>
+              <td>8</td>
+              <td>Agent tracker false match on duplicate desc</td>
+              <td>2</td>
+              <td>2</td>
+              <td style="color: var(--info); font-weight: 700">4</td>
+              <td>Switch to ID-based matching</td>
+            </tr>
+            <tr>
+              <td>9</td>
+              <td>CI supply chain (unpinned deps)</td>
+              <td>1</td>
+              <td>3</td>
+              <td style="color: var(--info); font-weight: 700">3</td>
+              <td>Pin versions when ready</td>
+            </tr>
+            <tr>
+              <td>10</td>
+              <td>New agent onboarding friction (missing template)</td>
+              <td>2</td>
+              <td>1</td>
+              <td style="color: var(--info); font-weight: 700">2</td>
+              <td>Complete scaffold template</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <!-- ====== TECHNICAL DEBT ====== -->
+      <section id="debt">
+        <h2>Technical Debt Inventory</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Category</th>
+              <th>Item</th>
+              <th>Severity</th>
+              <th>Effort</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Prompt safety</td>
+              <td>No injection defense in 23 agents</td>
+              <td style="color: var(--warning)">&#9650; Medium</td>
+              <td>S &mdash; template paragraph + backfill</td>
+            </tr>
+            <tr>
+              <td>Test coverage</td>
+              <td>No SKILL.md frontmatter validation</td>
+              <td style="color: var(--warning)">&#9650; Medium</td>
+              <td>S &mdash; one pytest function</td>
+            </tr>
+            <tr>
+              <td>Test coverage</td>
+              <td>No output-kit contract assertion</td>
+              <td style="color: var(--warning)">&#9650; Medium</td>
+              <td>S &mdash; one pytest function</td>
+            </tr>
+            <tr>
+              <td>Release process</td>
+              <td>Git tags not tracking versions</td>
+              <td style="color: var(--warning)">&#9650; Medium</td>
+              <td>S &mdash; CI job + backfill</td>
+            </tr>
+            <tr>
+              <td>Skill quality</td>
+              <td>12 v0.6.6 skills lack output-kit line</td>
+              <td style="color: var(--info)">&#9679; Low</td>
+              <td>S &mdash; add line to 12 files</td>
+            </tr>
+            <tr>
+              <td>Skill quality</td>
+              <td>v0.6.6 format divergence undocumented</td>
+              <td style="color: var(--info)">&#9679; Low</td>
+              <td>S &mdash; document in skill-guide.md</td>
+            </tr>
+            <tr>
+              <td>Agent versioning</td>
+              <td>Agent .md files have no version field</td>
+              <td style="color: var(--info)">&#9679; Low</td>
+              <td>M &mdash; add field + backfill 23 agents</td>
+            </tr>
+            <tr>
+              <td>DX</td>
+              <td>No root task runner (make/just)</td>
+              <td style="color: var(--info)">&#9679; Low</td>
+              <td>S &mdash; one file</td>
+            </tr>
+            <tr>
+              <td>DX</td>
+              <td>No SKILL.md in new-agent template</td>
+              <td style="color: var(--info)">&#9679; Low</td>
+              <td>S &mdash; one file</td>
+            </tr>
+            <tr>
+              <td>Hooks</td>
+              <td>Agent tracker desc-matching fragility</td>
+              <td style="color: var(--info)">&#9679; Low</td>
+              <td>S &mdash; switch to ID field</td>
+            </tr>
+            <tr>
+              <td>Routing</td>
+              <td>CLAUDE.md skill routing sparse</td>
+              <td style="color: var(--warning)">&#9650; Medium</td>
+              <td>L &mdash; 138 skills need routing rules</td>
+            </tr>
+            <tr>
+              <td>Eval</td>
+              <td>No agent behavior eval infrastructure</td>
+              <td style="color: var(--warning)">&#9650; Medium</td>
+              <td>L &mdash; new system to build</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <!-- ====== QUICK WINS ====== -->
+      <section id="quickwins">
+        <h2>Quick Wins &mdash; Week 1</h2>
+        <p>
+          High-impact, low-effort items that reduce risk or improve confidence
+          immediately.
+        </p>
+
+        <div class="card card-success">
+          <h4>1. Add output-kit contract test</h4>
+          <p>
+            One pytest function in <code>test_structure.py</code> asserting
+            every SKILL.md contains the output-kit reference. Catches 12
+            existing gaps + prevents future regressions.
+            <strong>~30 min.</strong>
+          </p>
+        </div>
+
+        <div class="card card-success">
+          <h4>2. Backfill output-kit line into 12 skills</h4>
+          <p>
+            Add the contract line to the 12 v0.6.6 skills. Mechanical change, no
+            design decisions. <strong>~20 min.</strong>
+          </p>
+        </div>
+
+        <div class="card card-success">
+          <h4>3. Add SKILL.md frontmatter test</h4>
+          <p>
+            Assert required frontmatter fields (<code>name</code>,
+            <code>description</code>, <code>version</code>,
+            <code>allowed-tools</code>) exist in every SKILL.md.
+            <strong>~30 min.</strong>
+          </p>
+        </div>
+
+        <div class="card card-success">
+          <h4>4. Add scaffold SKILL.md to new-agent template</h4>
+          <p>
+            Populate
+            <code>templates/new-agent/skills/SKILL_NAME/SKILL.md</code> with
+            placeholder frontmatter and output-kit contract.
+            <strong>~15 min.</strong>
+          </p>
+        </div>
+
+        <div class="card card-success">
+          <h4>5. Backfill git tags for 0.6.0&ndash;0.6.6</h4>
+          <p>
+            Create annotated tags from commit history matching CHANGELOG
+            entries. Brings tag state in sync with reality.
+            <strong>~20 min.</strong>
+          </p>
+        </div>
+
+        <div class="card card-success">
+          <h4>6. Add root Makefile</h4>
+          <p>
+            Targets: <code>test</code> (run test_structure.py),
+            <code>lint</code> (shellcheck), <code>validate</code> (both).
+            One-command entry point for developers. <strong>~15 min.</strong>
+          </p>
+        </div>
+      </section>
+
+      <!-- ====== ROADMAP ====== -->
+      <section id="roadmap">
+        <h2>30 / 60 / 90 Day Roadmap</h2>
+
+        <div class="roadmap-phase">
+          <h4>
+            <span class="phase-badge phase-now">Days 1&ndash;30</span> Seal the
+            hull
+          </h4>
+          <ul>
+            <li>
+              Execute all Week 1 quick wins (tests, templates, tags, Makefile)
+            </li>
+            <li>
+              Add prompt injection defense paragraph to agent template; backfill
+              into all 23 agents
+            </li>
+            <li>
+              Document the v0.6.6 skill format as an intentional variant (or
+              converge it)
+            </li>
+            <li>Add automated git tag creation on merge to main</li>
+            <li>Pin pytest version in CI; consider SHA-pinning Actions</li>
+          </ul>
+        </div>
+
+        <div class="roadmap-phase">
+          <h4>
+            <span class="phase-badge phase-next">Days 31&ndash;60</span> Build
+            confidence
+          </h4>
+          <ul>
+            <li>
+              Build agent eval suite &mdash; start with output-kit compliance
+              (40-line rule, severity indicators)
+            </li>
+            <li>
+              Expand CLAUDE.md routing rules &mdash; cover top 50 skill triggers
+              at minimum
+            </li>
+            <li>Add token budget guidance per S/M/L tier in Apex prompt</li>
+            <li>
+              Fix agent tracker to use ID-based matching instead of description
+              strings
+            </li>
+            <li>
+              Add version field to agent definition frontmatter; enforce in CI
+            </li>
+          </ul>
+        </div>
+
+        <div class="roadmap-phase">
+          <h4>
+            <span class="phase-badge phase-later">Days 61&ndash;90</span> Scale
+            the system
+          </h4>
+          <ul>
+            <li>
+              Build skill routing index &mdash; programmatic intent-to-skill
+              mapping
+            </li>
+            <li>
+              Expand eval suite to cover routing accuracy, handoff schema
+              adherence, decision quality
+            </li>
+            <li>
+              Implement Python analyzer scripts for agents that need them (move
+              beyond stubs)
+            </li>
+            <li>
+              Consider automated agent def sync (eliminate manual copy from
+              team/ to agents/)
+            </li>
+            <li>
+              Assess whether <code>lib/uiux</code> should be surfaced as a skill
+              or remain a library
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <!-- ====== DON'T TOUCH LIST ====== -->
+      <section id="donot">
+        <h2>Don't Touch List</h2>
+        <p>
+          Load-bearing walls of the system. Do not change without strong
+          justification and broad review.
+        </p>
+
+        <div class="card">
+          <h4>1. Agent definition structure</h4>
+          <p>
+            The 7-section template (Communication &rarr; Operating Principle
+            &rarr; Scope &rarr; Platform Fluency &rarr; Workflow &rarr; Key
+            Rules &rarr; Anti-Patterns) is consistent across all 23 agents.
+            Changing this structure means touching every agent. Leave it alone.
+          </p>
+        </div>
+
+        <div class="card">
+          <h4>2. Helm &harr; Apex handoff protocol</h4>
+          <p>
+            The 6-field brief schema with mandatory <code>out_of_scope</code> is
+            the best-designed interface in the system. It works. Don't simplify
+            or "improve" it.
+          </p>
+        </div>
+
+        <div class="card">
+          <h4>3. Output kit (docs/output-kit.md)</h4>
+          <p>
+            The 40-line CLI max, severity indicators (<code
+              >&blacksquare; &#9650; &#9679;</code
+            >), and atlas-report escalation pattern are load-bearing constraints
+            referenced by 126+ skills. Changes cascade everywhere.
+          </p>
+        </div>
+
+        <div class="card">
+          <h4>4. Plugin manifest format (.claude-plugin/plugin.json)</h4>
+          <p>
+            This is the Claude Code contract. The schema is external &mdash;
+            it's defined by the Claude Code platform, not by this project.
+            Respect it as-is.
+          </p>
+        </div>
+
+        <div class="card">
+          <h4>5. CI structural tests (test_structure.py)</h4>
+          <p>
+            These tests enforce the architectural invariants that keep 23 agents
+            and 138 skills consistent. Add to them, never weaken them.
+          </p>
+        </div>
+
+        <div class="card">
+          <h4>6. Statusline hooks</h4>
+          <p>
+            Both <code>tonone-statusline.js</code> and
+            <code>tonone-agent-tracker.js</code> are well-written with proper
+            null-safety, timeouts, and atomic writes. They work in production.
+            Touch only to fix the desc-matching issue in the tracker.
+          </p>
+        </div>
+
+        <div class="card">
+          <h4>7. Model tiering (Apex=Opus, specialists=Sonnet)</h4>
+          <p>
+            This is an intentional cost-control design. Don't promote all agents
+            to Opus "for quality" &mdash; it would blow up token spend with
+            marginal quality gain for specialist work.
+          </p>
+        </div>
+      </section>
+
+      <!-- ====== SPECIALIST DETAILS ====== -->
+      <section id="atlas-detail">
+        <h2>Atlas &mdash; Architecture Details</h2>
+        <details>
+          <summary>Full findings</summary>
+          <div>
+            <p>
+              <strong>System type:</strong> Pure text/markdown-driven
+              prompt-engineering framework. No compiled languages, no bundlers,
+              no runtime framework.
+            </p>
+            <p>
+              <strong>Languages:</strong> Python 3.10+ (per-agent analyzer
+              stubs), JavaScript/Node.js (hooks only &mdash; statusline, agent
+              tracker). Package manager: <code>uv</code> (preferred) or pip.
+            </p>
+            <p><strong>Three-layer architecture:</strong></p>
+            <ol>
+              <li>
+                <strong>Root plugin</strong>
+                (<code>/.claude-plugin/plugin.json</code>) &mdash; installs the
+                full 23-agent team. Two hooks: SessionStart runs statusline
+                installer, PostToolUse[Agent] runs agent tracker.
+              </li>
+              <li>
+                <strong>Agent layer</strong> (<code>team/&lt;agent&gt;/</code>)
+                &mdash; each agent is self-contained with plugin manifest, agent
+                definition, skills, scripts, hooks, and tests.
+              </li>
+              <li>
+                <strong>Standalone skills</strong>
+                (<code>skills/*/SKILL.md</code>) &mdash; 138 skills as
+                independent installable plugins.
+              </li>
+            </ol>
+            <p>
+              <strong>Bundles:</strong> <code>bundle/</code> contains thin
+              manifests grouping agents into engineering-team (15), product-team
+              (8), and full-team (23).
+            </p>
+            <p>
+              <strong>Internal coupling:</strong> Agents reference each other by
+              name in prompts (conversational coupling only). No code-level
+              imports between agents.
+            </p>
+            <p>
+              <strong>External dependencies:</strong> Effectively none. Python
+              deps list is empty in every pyproject.toml. Node.js hooks use only
+              stdlib.
+            </p>
+            <p>
+              <strong>Documentation:</strong> Good coverage &mdash;
+              output-kit.md, naming-guide.md, agent-guide.md, skill-guide.md,
+              architecture.md, CLAUDE.md, CONTRIBUTING.md, ROADMAP.md,
+              CHANGELOG.md. No ADRs (appropriate for this stage).
+            </p>
+          </div>
+        </details>
+      </section>
+
+      <section id="relay-detail">
+        <h2>Relay &mdash; CI/CD Details</h2>
+        <details>
+          <summary>Full findings</summary>
+          <div>
+            <p>
+              <strong>CI pipeline:</strong> GitHub Actions, single workflow
+              <code>.github/workflows/ci.yml</code>. Runs on push to main and
+              all PRs.
+            </p>
+            <p>
+              <strong>Jobs:</strong> (1) <code>validate-structure</code> &mdash;
+              pytest against <code>tests/test_structure.py</code>; (2)
+              <code>lint-shell</code> &mdash; shellcheck at WARNING severity on
+              all <code>setup.sh</code> files. Agent matrix job exists but is
+              disabled (stub tests only).
+            </p>
+            <p>
+              <strong>Release process:</strong> Manual. CHANGELOG.md maintained
+              by hand. Version in <code>marketplace.json</code>. One stale git
+              tag (<code>v0.1.0</code>) vs. actual version 0.6.6.
+            </p>
+            <p>
+              <strong>Hooks:</strong> No pre-commit hooks active. Only default
+              git sample hooks.
+            </p>
+            <p>
+              <strong>Deployment:</strong> None. This is a plugin repo &mdash;
+              the git repo is the artifact.
+            </p>
+            <p>
+              <strong>Gaps:</strong> Stale git tags, no dep caching, no branch
+              protection documented, disabled agent matrix job is dead code.
+            </p>
+          </div>
+        </details>
+      </section>
+
+      <section id="warden-detail">
+        <h2>Warden &mdash; Security Details</h2>
+        <details>
+          <summary>Full findings</summary>
+          <div>
+            <p>
+              <strong>Secrets:</strong> Clean. No hardcoded secrets, API keys,
+              tokens, or connection strings. No .env files committed. .gitignore
+              correctly excludes sensitive patterns.
+            </p>
+            <p>
+              <strong>Dependencies:</strong> All 23 agent
+              <code>pyproject.toml</code> files declare
+              <code>dependencies = []</code>. Only CI installs pytest unpinned.
+              Low risk.
+            </p>
+            <p>
+              <strong>Access control:</strong> N/A &mdash; no endpoints, no HTTP
+              servers, no network surface.
+            </p>
+            <p>
+              <strong>Supply chain:</strong> <code>setup.sh</code> scripts use
+              local editable installs only. No
+              <code>curl | bash</code> patterns. CI uses Actions at major
+              version, not SHA-pinned. Non-urgent.
+            </p>
+            <p>
+              <strong>Assessment:</strong> Attack surface is effectively zero.
+              The only real exposure is the CI pipeline itself (unpinned deps +
+              non-SHA-pinned Actions). Both are low-severity at this scale.
+            </p>
+          </div>
+        </details>
+      </section>
+
+      <section id="spine-detail">
+        <h2>Spine &mdash; Quality Details</h2>
+        <details>
+          <summary>Full findings</summary>
+          <div>
+            <p>
+              <strong>Agent consistency:</strong> All 23 agents follow a uniform
+              7-section template. Quality is high &mdash; each agent has a real
+              persona, concrete decision frameworks, and explicit
+              skip/never-skip contracts.
+            </p>
+            <p>
+              <strong>Skill quality:</strong> 126 of 138 skills (91%) include
+              the output-kit contract. 12 v0.6.6 skills are missing it. These
+              newer skills have a lighter reference-style body format
+              (intentional or underbuilt &mdash; undocumented). v0.6.4 skills
+              have high step quality with concrete decision tables.
+            </p>
+            <p>
+              <strong>Sync state:</strong> Root <code>agents/</code> and
+              <code>team/*/agents/</code> are identical across all sampled
+              agents. CI test enforces this.
+            </p>
+            <p>
+              <strong>Template:</strong> Usable but incomplete &mdash; missing
+              SKILL.md scaffold in the skills subdirectory.
+            </p>
+            <p>
+              <strong>Test coverage:</strong> Covers plugin.json fields, agent
+              def existence, setup.sh existence, bidirectional sync. Does NOT
+              cover: SKILL.md frontmatter fields, output-kit contract presence,
+              v0.6.6 format consistency.
+            </p>
+          </div>
+        </details>
+      </section>
+
+      <section id="prism-detail">
+        <h2>Prism &mdash; DX Details</h2>
+        <details>
+          <summary>Full findings</summary>
+          <div>
+            <p>
+              <strong>UI components:</strong> None. No web UI.
+              <code>lib/uiux/</code> is a Python CLI package for design system
+              generation (BM25 search over CSV design data, Unicode box
+              diagrams). 13 design domains in CSV format.
+            </p>
+            <p>
+              <strong>Hooks quality:</strong> Both hooks are well-written.
+              Statusline: clean segment composition, null-safe, 3s stdin
+              timeout, ANSI color helpers. Agent tracker: path traversal guard
+              on session ID, atomic write via temp+rename, 10-min pruning,
+              silent fail on exit. One issue: desc-string matching for
+              completion.
+            </p>
+            <p>
+              <strong>Developer experience:</strong> Template scaffolding exists
+              at <code>templates/new-agent/</code>.
+              <code>docs/agent-guide.md</code> is thorough (9-step walkthrough).
+              Dual-location sync is a manual hazard but CI enforces it.
+            </p>
+            <p>
+              <strong>Gaps:</strong> No root task runner.
+              <code>lib/uiux</code> has zero discoverability (not wired into any
+              skill). Agent tracker uses fragile string matching. No linter for
+              agent Communication section presence.
+            </p>
+          </div>
+        </details>
+      </section>
+
+      <section id="cortex-detail">
+        <h2>Cortex &mdash; AI/Prompt Architecture Details</h2>
+        <details>
+          <summary>Full findings</summary>
+          <div>
+            <p>
+              <strong>Prompt architecture:</strong> Strong. All agents follow
+              role-before-task, constraints-before-instructions,
+              negative-examples pattern. Form agent stands out with "AI slop
+              detection" gate and logo evaluation checklist as concrete
+              behavioral anchors.
+            </p>
+            <p>
+              <strong>Orchestration:</strong> Apex dispatches via Agent tool,
+              parallel for independent work, sequential for dependent. S/M/L
+              format with token/cost estimates is a good cost gate. "One lateral
+              check-in max, then escalate" prevents sprawl. Model tiering
+              (Apex=Opus, specialists=Sonnet) is correct.
+            </p>
+            <p>
+              <strong>Helm&harr;Apex handoff:</strong> Best-designed interface
+              in the system. 6-field schema is explicit and falsifiable.
+              Mandatory <code>out_of_scope</code> with forcing function ("if you
+              wrote none, you haven't thought hard enough").
+              <code>helm-handoff</code> validates before dispatch. One risk:
+              <code>open_questions</code> can contain non-blocking feasibility
+              asks.
+            </p>
+            <p>
+              <strong>Prompt risks:</strong> No injection mitigations. Skills
+              that read untrusted codebases pipe content directly into LLM
+              context. XML delimiters used for user content in
+              <code>cortex-prompt</code> but no explicit "treat as untrusted"
+              instruction. The review skill checks for "LLM trust boundary
+              violations" but this is a reviewer check, not a runtime control.
+            </p>
+            <p>
+              <strong>Output control:</strong> Tight. Output kit is
+              well-enforced at the prompt level. 40-line rule with atlas-report
+              escalation is clean progressive disclosure. Communication protocol
+              kill-list is specific enough to be enforceable. Risk: 40-line rule
+              has no enforcement mechanism beyond prompt instruction.
+            </p>
+            <p>
+              <strong>Missing:</strong> No agent eval infrastructure, no cost
+              ceiling protocol, sparse skill routing (10 patterns for 138
+              skills), no version field in agent definitions.
+            </p>
+          </div>
+        </details>
+      </section>
+    </main>
+
+    <script>
+      function toggleTheme() {
+        const html = document.documentElement;
+        const current = html.getAttribute("data-theme");
+        const next = current === "dark" ? "light" : "dark";
+        html.setAttribute("data-theme", next);
+        document.querySelector(".theme-toggle").textContent =
+          next === "dark" ? "\u263E" : "\u2600";
+      }
+
+      // Copy buttons
+      document.querySelectorAll("pre").forEach((pre) => {
+        const btn = document.createElement("button");
+        btn.className = "copy-btn";
+        btn.textContent = "Copy";
+        btn.addEventListener("click", () => {
+          const code = pre.querySelector("code") || pre;
+          navigator.clipboard.writeText(code.textContent).then(() => {
+            btn.textContent = "Copied!";
+            setTimeout(() => (btn.textContent = "Copy"), 1500);
+          });
+        });
+        pre.style.position = "relative";
+        pre.appendChild(btn);
+      });
+
+      // Sidebar active link
+      const sections = document.querySelectorAll("section[id]");
+      const navLinks = document.querySelectorAll(".sidebar a");
+      window.addEventListener("scroll", () => {
+        let current = "";
+        sections.forEach((section) => {
+          if (window.scrollY >= section.offsetTop - 100) current = section.id;
+        });
+        navLinks.forEach((link) => {
+          link.classList.toggle(
+            "active",
+            link.getAttribute("href") === "#" + current,
+          );
+        });
+      });
+
+      // Mermaid init with graceful degradation
+      (function () {
+        const script = document.createElement("script");
+        script.src = "https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js";
+        script.onload = function () {
+          mermaid.initialize({
+            startOnLoad: true,
+            theme:
+              document.documentElement.getAttribute("data-theme") === "dark"
+                ? "dark"
+                : "default",
+            flowchart: { useMaxWidth: true, htmlLabels: true },
+          });
+        };
+        script.onerror = function () {
+          document.querySelectorAll(".mermaid").forEach((el) => {
+            const pre = document.createElement("pre");
+            pre.style.textAlign = "left";
+            const code = document.createElement("code");
+            code.textContent = el.textContent;
+            pre.appendChild(code);
+            el.replaceWith(pre);
+          });
+        };
+        document.head.appendChild(script);
+      })();
+    </script>
+  </body>
+</html>

--- a/.reports/draft-statusline-review-2026-04-12.html
+++ b/.reports/draft-statusline-review-2026-04-12.html
@@ -1,0 +1,708 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Draft UX Review — Statusline Redesign</title>
+    <style>
+      :root {
+        --bg: #0f172a;
+        --bg-card: #1e293b;
+        --bg-card-alt: #162032;
+        --text: #e2e8f0;
+        --text-muted: #94a3b8;
+        --border: #334155;
+        --accent: #3b82f6;
+        --critical: #dc2626;
+        --critical-bg: rgba(220, 38, 38, 0.12);
+        --warning: #d97706;
+        --warning-bg: rgba(217, 119, 6, 0.12);
+        --info: #2563eb;
+        --info-bg: rgba(37, 99, 235, 0.12);
+        --success: #16a34a;
+        --success-bg: rgba(22, 163, 74, 0.12);
+        --font-mono: "JetBrains Mono", "Fira Code", "Cascadia Code", monospace;
+        --font-sans: "Inter", system-ui, -apple-system, sans-serif;
+      }
+      [data-theme="light"] {
+        --bg: #ffffff;
+        --bg-card: #f8fafc;
+        --bg-card-alt: #f1f5f9;
+        --text: #1e293b;
+        --text-muted: #64748b;
+        --border: #e2e8f0;
+        --critical-bg: #fef2f2;
+        --warning-bg: #fffbeb;
+        --info-bg: #eff6ff;
+        --success-bg: #f0fdf4;
+      }
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      body {
+        font-family: var(--font-sans);
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.7;
+        padding: 0;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 16px;
+        right: 16px;
+        z-index: 100;
+        background: var(--bg-card);
+        border: 1px solid var(--border);
+        color: var(--text-muted);
+        border-radius: 8px;
+        padding: 6px 12px;
+        cursor: pointer;
+        font-size: 13px;
+      }
+      .container { max-width: 860px; margin: 0 auto; padding: 48px 32px; }
+      .header {
+        border-bottom: 1px solid var(--border);
+        padding-bottom: 32px;
+        margin-bottom: 40px;
+      }
+      .header .agent-tag {
+        display: inline-block;
+        background: var(--accent);
+        color: white;
+        font-size: 11px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        padding: 3px 10px;
+        border-radius: 4px;
+        margin-bottom: 12px;
+      }
+      .header h1 {
+        font-size: 28px;
+        font-weight: 700;
+        margin-bottom: 8px;
+        letter-spacing: -0.02em;
+      }
+      .header .subtitle {
+        color: var(--text-muted);
+        font-size: 15px;
+      }
+      .verdict-box {
+        background: var(--critical-bg);
+        border: 1px solid var(--critical);
+        border-radius: 10px;
+        padding: 20px 24px;
+        margin-bottom: 40px;
+      }
+      .verdict-box h2 {
+        color: var(--critical);
+        font-size: 16px;
+        font-weight: 700;
+        margin-bottom: 6px;
+      }
+      .verdict-box p {
+        color: var(--text);
+        font-size: 14px;
+      }
+      h2 {
+        font-size: 20px;
+        font-weight: 700;
+        margin: 40px 0 16px 0;
+        letter-spacing: -0.01em;
+      }
+      h3 {
+        font-size: 16px;
+        font-weight: 600;
+        margin: 24px 0 10px 0;
+        color: var(--text);
+      }
+      p, li { font-size: 14px; color: var(--text); }
+      .section {
+        background: var(--bg-card);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 24px;
+        margin-bottom: 24px;
+      }
+      .section h2 { margin-top: 0; }
+
+      /* Status bar mockups */
+      .mockup {
+        background: #0c0c0c;
+        border: 1px solid #333;
+        border-radius: 8px;
+        padding: 16px 20px;
+        font-family: var(--font-mono);
+        font-size: 13px;
+        line-height: 1.8;
+        overflow-x: auto;
+        margin: 16px 0;
+      }
+      .mockup .line { white-space: nowrap; }
+      .mockup .cyan { color: #22d3ee; }
+      .mockup .green { color: #4ade80; }
+      .mockup .yellow { color: #facc15; }
+      .mockup .red { color: #f87171; }
+      .mockup .magenta { color: #c084fc; }
+      .mockup .dim { color: #64748b; }
+      .mockup .dimwhite { color: #94a3b8; }
+      .mockup .bold { font-weight: 700; }
+      .mockup .label { color: #64748b; font-size: 11px; }
+      .mockup .sep { color: #334155; }
+
+      /* Findings table */
+      .finding {
+        border-left: 3px solid var(--border);
+        padding: 12px 16px;
+        margin: 12px 0;
+        background: var(--bg-card-alt);
+        border-radius: 0 8px 8px 0;
+      }
+      .finding.critical { border-left-color: var(--critical); background: var(--critical-bg); }
+      .finding.major { border-left-color: var(--warning); background: var(--warning-bg); }
+      .finding.minor { border-left-color: var(--info); background: var(--info-bg); }
+      .finding .sev {
+        font-size: 11px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        margin-bottom: 4px;
+      }
+      .finding.critical .sev { color: var(--critical); }
+      .finding.major .sev { color: var(--warning); }
+      .finding.minor .sev { color: var(--info); }
+      .finding .title { font-weight: 600; font-size: 14px; margin-bottom: 4px; }
+      .finding .desc { font-size: 13px; color: var(--text-muted); }
+
+      /* Heuristic table */
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 13px;
+        margin: 16px 0;
+      }
+      th, td {
+        text-align: left;
+        padding: 10px 12px;
+        border-bottom: 1px solid var(--border);
+      }
+      th {
+        font-weight: 600;
+        color: var(--text-muted);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+      }
+      td { color: var(--text); }
+      .pass { color: var(--success); }
+      .fail { color: var(--critical); }
+      .warn { color: var(--warning); }
+
+      /* Comparison grid */
+      .comparison {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 16px;
+        margin: 16px 0;
+      }
+      .comparison .col h4 {
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--text-muted);
+        margin-bottom: 8px;
+      }
+      .comparison .col.before h4 { color: var(--critical); }
+      .comparison .col.after h4 { color: var(--success); }
+
+      ul { padding-left: 20px; margin: 8px 0; }
+      li { margin: 4px 0; }
+
+      .callout {
+        background: var(--success-bg);
+        border: 1px solid var(--success);
+        border-radius: 8px;
+        padding: 16px 20px;
+        margin: 16px 0;
+      }
+      .callout h4 { color: var(--success); font-size: 13px; margin-bottom: 6px; }
+      .callout p { font-size: 13px; }
+
+      .principle {
+        display: flex;
+        gap: 12px;
+        padding: 12px 0;
+        border-bottom: 1px solid var(--border);
+      }
+      .principle:last-child { border-bottom: none; }
+      .principle .num {
+        flex-shrink: 0;
+        width: 28px;
+        height: 28px;
+        background: var(--accent);
+        color: white;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 12px;
+        font-weight: 700;
+      }
+      .principle .body { font-size: 13px; }
+      .principle .body strong { color: var(--text); }
+      .principle .body span { color: var(--text-muted); }
+
+      @media (max-width: 680px) {
+        .container { padding: 24px 16px; }
+        .comparison { grid-template-columns: 1fr; }
+      }
+    </style>
+  </head>
+  <body>
+    <button class="theme-toggle" onclick="
+      const html = document.documentElement;
+      html.dataset.theme = html.dataset.theme === 'dark' ? 'light' : 'dark';
+    ">Toggle theme</button>
+
+    <div class="container">
+      <div class="header">
+        <span class="agent-tag">Draft &mdash; UX Review</span>
+        <h1>Statusline Usability Review</h1>
+        <p class="subtitle">tonone two-line CLI status bar &bull; Nielsen heuristic evaluation &bull; 2026-04-12</p>
+      </div>
+
+      <!-- Verdict -->
+      <div class="verdict-box">
+        <h2>Verdict: The creator can't parse it. That's the diagnosis.</h2>
+        <p>The statusline packs 14&ndash;15 data points across 2 lines using abstract symbols with no labels. It violates <strong>Recognition over Recall</strong> (Nielsen #6) at a fundamental level. The fix: group by mental model, add micro-labels, cut to what matters <em>now</em>.</p>
+      </div>
+
+      <!-- Current Design -->
+      <div class="section">
+        <h2>Current Design</h2>
+        <p style="margin-bottom: 12px; color: var(--text-muted);">Full session with all segments visible:</p>
+        <div class="mockup">
+          <div class="line">
+            <span class="cyan">&#9670; main</span> <span class="green">&#8593;3</span>
+            <span class="sep"> &#9474; </span>
+            <span class="yellow">&#9650;2</span>
+            <span class="sep"> &#9474; </span>
+            <span class="magenta bold">spine</span>
+            <span class="magenta"> &#8853;1</span>
+            <span class="sep"> &#9474; </span>
+            <span class="dimwhite">50k tk</span>
+            <span class="sep"> &#9474; </span>
+            <span class="dimwhite">$0.38</span>
+            <span class="sep"> &#9474; </span>
+            <span class="green">&#9608;&#9608;&#9608;&#9608;&#9617;&#9617;&#9617;&#9617;&#9617;&#9617; 52%</span>
+            <span class="sep"> &#9474; </span>
+            <span class="green">&#9678;65% &#8635;2h</span>
+          </div>
+          <div class="line">
+            <span class="dimwhite">Opus 4.6</span>
+            <span class="sep"> &#9474; </span>
+            <span class="dimwhite">23m</span>
+            <span class="sep"> &#9474; </span>
+            <span class="green">+156</span> <span class="red">-23</span>
+            <span class="sep"> &#9474; </span>
+            <span class="dimwhite">$0.010/line</span>
+            <span class="sep"> &#9474; </span>
+            <span class="dimwhite">5h: 24%</span>
+            <span class="sep"> &#9474; </span>
+            <span class="dimwhite">7d: 41%</span>
+          </div>
+        </div>
+        <p style="color: var(--text-muted); font-size: 13px;">8 segments on Line 1 &bull; 6 segments on Line 2 &bull; 6 abstract symbols &bull; 0 labels</p>
+      </div>
+
+      <!-- Nielsen Heuristics -->
+      <div class="section">
+        <h2>Nielsen's 10 Heuristics</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Heuristic</th>
+              <th>Result</th>
+              <th>Severity</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>1</td>
+              <td>Visibility of system status</td>
+              <td class="pass">&#10003; Pass</td>
+              <td>&mdash;</td>
+            </tr>
+            <tr>
+              <td>2</td>
+              <td>Match between system and real world</td>
+              <td class="fail">&#10007; Fail</td>
+              <td class="fail">Major</td>
+            </tr>
+            <tr>
+              <td>3</td>
+              <td>User control and freedom</td>
+              <td class="pass">&#10003; N/A</td>
+              <td>&mdash;</td>
+            </tr>
+            <tr>
+              <td>4</td>
+              <td>Consistency and standards</td>
+              <td class="fail">&#10007; Fail</td>
+              <td class="warn">Major</td>
+            </tr>
+            <tr>
+              <td>5</td>
+              <td>Error prevention</td>
+              <td class="pass">&#10003; N/A</td>
+              <td>&mdash;</td>
+            </tr>
+            <tr>
+              <td>6</td>
+              <td>Recognition rather than recall</td>
+              <td class="fail">&#10007; Fail</td>
+              <td class="fail">Critical</td>
+            </tr>
+            <tr>
+              <td>7</td>
+              <td>Flexibility and efficiency of use</td>
+              <td class="pass">&#10003; Pass</td>
+              <td>&mdash;</td>
+            </tr>
+            <tr>
+              <td>8</td>
+              <td>Aesthetic and minimalist design</td>
+              <td class="fail">&#10007; Fail</td>
+              <td class="warn">Major</td>
+            </tr>
+            <tr>
+              <td>9</td>
+              <td>Help users recognize, diagnose, recover</td>
+              <td class="pass">&#10003; Pass</td>
+              <td>&mdash;</td>
+            </tr>
+            <tr>
+              <td>10</td>
+              <td>Help and documentation</td>
+              <td class="fail">&#10007; Fail</td>
+              <td class="warn">Minor</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Findings -->
+      <div class="section">
+        <h2>Findings</h2>
+
+        <div class="finding critical">
+          <div class="sev">&#9632; Critical &mdash; Nielsen #6</div>
+          <div class="title">Symbol soup: 6 abstract glyphs with zero labels</div>
+          <div class="desc">
+            &#9670; = branch, &#9650; = dirty, &#8853; = subagents, &#9678; = rate limit, &#8593; = ahead, &#8635; = reset.
+            These require memorizing a legend. The user &mdash; who <em>designed</em> this &mdash; can't parse it at a glance. That's the clearest possible signal. Symbols work only when universally understood ($ for money, % for percentage). Custom symbols create a private language.
+            <br><br>
+            <strong>Fix:</strong> Replace symbols with micro-labels. <code>&#9650;2</code> &rarr; <code>2 dirty</code>. <code>&#8853;1</code> &rarr; <code>+1 sub</code>. The 3&ndash;4 extra characters per segment buy instant comprehension.
+          </div>
+        </div>
+
+        <div class="finding major">
+          <div class="sev">&#9650; Major &mdash; Nielsen #8</div>
+          <div class="title">14 segments across 2 lines overloads working memory</div>
+          <div class="desc">
+            Miller's Law: humans chunk 7&plusmn;2 items. The statusline presents 14&ndash;15 discrete data points with flat hierarchy &mdash; identical pipe separators, similar visual weight. The eye has nowhere to anchor.
+            <br><br>
+            <strong>Fix:</strong> Reduce to max 5 segments per line. Cut tokens (cost tells the same story), cost/line (vanity metric &mdash; show at session end), and the duplicate rate limit.
+          </div>
+        </div>
+
+        <div class="finding major">
+          <div class="sev">&#9650; Major &mdash; Nielsen #4</div>
+          <div class="title">No semantic grouping &mdash; 4 domains share one line with identical separators</div>
+          <div class="desc">
+            Line 1 mixes git state (branch, dirty, ahead), agent state (name, subagents), consumption (tokens, cost), and system health (context, rate limit). All separated by the same dim pipe. The brain can't chunk what looks visually identical.
+            <br><br>
+            <strong>Fix:</strong> Group by mental model. Line 1 = work context (what you're doing). Line 2 = resources (what's being consumed). Use visual separator hierarchy: spaces within groups, pipes between groups.
+          </div>
+        </div>
+
+        <div class="finding major">
+          <div class="sev">&#9650; Major &mdash; Nielsen #4</div>
+          <div class="title">Rate limit appears on both lines with different formats</div>
+          <div class="desc">
+            Line 1: <code>&#9678;65% &#8635;2h</code> (five-hour only, shown &gt;50%). Line 2: <code>5h: 24%</code> and <code>7d: 41%</code> (both windows, always shown). Two displays for overlapping data, different thresholds for visibility, different symbols. Which one do you look at?
+            <br><br>
+            <strong>Fix:</strong> One location. Line 2 only. Both windows. Drop the &#9678; symbol from Line 1 entirely.
+          </div>
+        </div>
+
+        <div class="finding major">
+          <div class="sev">&#9650; Major</div>
+          <div class="title">Progressive disclosure creates layout instability</div>
+          <div class="desc">
+            When segments hide (tokens at 0, cost at $0, agent when none), everything downstream shifts left. You can't build positional memory &mdash; "cost is always in position 6" is only true sometimes. A status bar's strength is glanceability, which requires spatial stability.
+            <br><br>
+            <strong>Fix:</strong> Use fixed-order <em>groups</em> (not segments). Groups always appear in the same position. Items within a group can still hide. Since there are only 2&ndash;3 groups per line, positional shift is minimal and predictable.
+          </div>
+        </div>
+
+        <div class="finding minor">
+          <div class="sev">&#9679; Minor</div>
+          <div class="title">Yellow means 3 unrelated things</div>
+          <div class="desc">
+            Yellow = dirty files = cost &gt;$1 = rate limit 70&ndash;90%. When the same color signals different alerts, color loses its power as a channel. Keep yellow for warnings only (cost, rate limit). Dirty count doesn't need a warning color &mdash; it's normal working state.
+          </div>
+        </div>
+
+        <div class="finding minor">
+          <div class="sev">&#9679; Minor</div>
+          <div class="title">"tk" is a non-standard abbreviation</div>
+          <div class="desc">
+            In publishing, "tk" means "to come" (placeholder text). For tokens, use "tok" or just show the number without a unit label &mdash; the position makes it clear.
+          </div>
+        </div>
+
+        <div class="finding minor">
+          <div class="sev">&#9679; Minor</div>
+          <div class="title">Line 2 lacks a coherent organizing principle</div>
+          <div class="desc">
+            Model name, session duration, lines changed, cost/line, rate limits. The code comment says "model + usage windows" but it's really 5 unrelated things. Cost/line is a "wow metric" (per the code comment) &mdash; interesting at session end, noise on a persistent display.
+          </div>
+        </div>
+      </div>
+
+      <!-- Proposed Redesign -->
+      <div class="section">
+        <h2>Proposed Redesign</h2>
+
+        <h3>Design Principles</h3>
+        <div>
+          <div class="principle">
+            <div class="num">1</div>
+            <div class="body"><strong>Max 5 segments per line.</strong> <span>If you can't fit it in 5, you're showing too much for a status bar.</span></div>
+          </div>
+          <div class="principle">
+            <div class="num">2</div>
+            <div class="body"><strong>Labels for anything non-universal.</strong> <span>$ and % don't need labels. &#9650; does. Spend 3&ndash;5 characters on a word to save the user 3&ndash;5 seconds of confusion.</span></div>
+          </div>
+          <div class="principle">
+            <div class="num">3</div>
+            <div class="body"><strong>Group by mental model, not data source.</strong> <span>Line 1: work context (what you're doing). Line 2: resource gauges (what's being consumed).</span></div>
+          </div>
+          <div class="principle">
+            <div class="num">4</div>
+            <div class="body"><strong>Stable group positions.</strong> <span>Groups always appear in order. Items within a group can hide. Positional shift stays within one group.</span></div>
+          </div>
+          <div class="principle">
+            <div class="num">5</div>
+            <div class="body"><strong>One source of truth per metric.</strong> <span>Rate limit in one place. Cost in one place. No duplicates.</span></div>
+          </div>
+        </div>
+
+        <h3>Line 1 &mdash; Work Context</h3>
+        <p style="color: var(--text-muted); margin-bottom: 8px;">What you're working on. Answers: which branch? any uncommitted work? who's running? what changed?</p>
+        <div class="mockup">
+          <div class="line">
+            <span class="cyan">main</span> <span class="green">&#8593;3</span>
+            <span class="sep"> &#9474; </span>
+            <span class="yellow">2 dirty</span>
+            <span class="sep"> &#9474; </span>
+            <span class="magenta bold">spine</span> <span class="magenta">+1 sub</span>
+            <span class="sep"> &#9474; </span>
+            <span class="green">+156</span> <span class="red">-23</span> <span class="dim">lines</span>
+          </div>
+        </div>
+        <p style="font-size: 13px; color: var(--text-muted);">4 groups: git identity, working tree state, agent activity, work output. Each instantly scannable.</p>
+
+        <h3>Line 2 &mdash; Resource Gauges</h3>
+        <p style="color: var(--text-muted); margin-bottom: 8px;">What's being consumed. Answers: which model? how long? how much spent? how much runway left?</p>
+        <div class="mockup">
+          <div class="line">
+            <span class="dimwhite">Opus 4.6</span>
+            <span class="sep"> &#9474; </span>
+            <span class="dimwhite">23m</span>
+            <span class="sep"> &#9474; </span>
+            <span class="dimwhite">$0.38</span>
+            <span class="sep"> &#9474; </span>
+            <span class="green">&#9608;&#9608;&#9608;&#9608;&#9617;&#9617;&#9617;&#9617;&#9617;&#9617; 48%</span>
+            <span class="sep"> &#9474; </span>
+            <span class="dimwhite">5h: 24%</span>
+            <span class="dim"> &#183; </span>
+            <span class="dimwhite">7d: 41%</span>
+          </div>
+        </div>
+        <p style="font-size: 13px; color: var(--text-muted);">5 groups: model, duration, cost, context window, rate limits (5h &middot; 7d as one group). All "gauges" &mdash; things that fill up or drain.</p>
+
+        <h3>What Changed</h3>
+        <div class="comparison">
+          <div class="col before">
+            <h4>Removed</h4>
+            <ul>
+              <li><strong>&#9670; symbol</strong> before branch &mdash; position is the label</li>
+              <li><strong>Token count</strong> &mdash; cost tells the same story more usefully</li>
+              <li><strong>Cost/line</strong> &mdash; vanity metric, show at session end instead</li>
+              <li><strong>Line 1 rate limit</strong> (&#9678;) &mdash; duplicate of Line 2</li>
+              <li><strong>&#9650; &#8853; &#9678; symbols</strong> &mdash; replaced with words</li>
+            </ul>
+          </div>
+          <div class="col after">
+            <h4>Added / Changed</h4>
+            <ul>
+              <li><strong>"dirty"</strong> label after count</li>
+              <li><strong>"+1 sub"</strong> label instead of &#8853;1</li>
+              <li><strong>"lines"</strong> label after +N -N</li>
+              <li><strong>Lines changed</strong> moved to Line 1 (it's work context)</li>
+              <li><strong>5h/7d</strong> joined with &middot; as one group (both are rate limits)</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <!-- Side-by-side comparison -->
+      <div class="section">
+        <h2>Before / After Comparison</h2>
+
+        <h3>Full session (everything visible)</h3>
+        <div class="comparison">
+          <div class="col before">
+            <h4>Before (14 segments)</h4>
+            <div class="mockup" style="font-size: 11px;">
+              <div class="line"><span class="cyan">&#9670; main</span> <span class="green">&#8593;3</span> <span class="sep">&#9474;</span> <span class="yellow">&#9650;2</span> <span class="sep">&#9474;</span> <span class="magenta bold">spine</span> <span class="magenta">&#8853;1</span> <span class="sep">&#9474;</span> <span class="dimwhite">50k tk</span> <span class="sep">&#9474;</span> <span class="dimwhite">$0.38</span> <span class="sep">&#9474;</span> <span class="green">&#9608;&#9608;&#9608;&#9608;&#9617;&#9617;&#9617;&#9617;&#9617;&#9617; 52%</span> <span class="sep">&#9474;</span> <span class="green">&#9678;65%</span></div>
+              <div class="line"><span class="dimwhite">Opus 4.6</span> <span class="sep">&#9474;</span> <span class="dimwhite">23m</span> <span class="sep">&#9474;</span> <span class="green">+156</span> <span class="red">-23</span> <span class="sep">&#9474;</span> <span class="dimwhite">$0.010/line</span> <span class="sep">&#9474;</span> <span class="dimwhite">5h: 24%</span> <span class="sep">&#9474;</span> <span class="dimwhite">7d: 41%</span></div>
+            </div>
+          </div>
+          <div class="col after">
+            <h4>After (9 segments)</h4>
+            <div class="mockup" style="font-size: 11px;">
+              <div class="line"><span class="cyan">main</span> <span class="green">&#8593;3</span> <span class="sep">&#9474;</span> <span class="yellow">2 dirty</span> <span class="sep">&#9474;</span> <span class="magenta bold">spine</span> <span class="magenta">+1 sub</span> <span class="sep">&#9474;</span> <span class="green">+156</span> <span class="red">-23</span> <span class="dim">lines</span></div>
+              <div class="line"><span class="dimwhite">Opus 4.6</span> <span class="sep">&#9474;</span> <span class="dimwhite">23m</span> <span class="sep">&#9474;</span> <span class="dimwhite">$0.38</span> <span class="sep">&#9474;</span> <span class="green">&#9608;&#9608;&#9608;&#9608;&#9617;&#9617;&#9617;&#9617;&#9617;&#9617; 48%</span> <span class="sep">&#9474;</span> <span class="dimwhite">5h: 24%</span><span class="dim"> &#183; </span><span class="dimwhite">7d: 41%</span></div>
+            </div>
+          </div>
+        </div>
+
+        <h3>Fresh session (minimal state)</h3>
+        <div class="comparison">
+          <div class="col before">
+            <h4>Before</h4>
+            <div class="mockup" style="font-size: 11px;">
+              <div class="line"><span class="cyan">&#9670; main</span> <span class="sep">&#9474;</span> <span class="green">&#9608;&#9617;&#9617;&#9617;&#9617;&#9617;&#9617;&#9617;&#9617;&#9617; 94%</span></div>
+              <div class="line"><span class="dimwhite">Opus 4.6</span></div>
+            </div>
+          </div>
+          <div class="col after">
+            <h4>After</h4>
+            <div class="mockup" style="font-size: 11px;">
+              <div class="line"><span class="cyan">main</span></div>
+              <div class="line"><span class="dimwhite">Opus 4.6</span> <span class="sep">&#9474;</span> <span class="green">&#9608;&#9617;&#9617;&#9617;&#9617;&#9617;&#9617;&#9617;&#9617;&#9617; 94%</span></div>
+            </div>
+          </div>
+        </div>
+
+        <h3>Warning state (high usage)</h3>
+        <div class="comparison">
+          <div class="col before">
+            <h4>Before</h4>
+            <div class="mockup" style="font-size: 11px;">
+              <div class="line"><span class="cyan">&#9670; feat-x</span> <span class="green">&#8593;7</span> <span class="sep">&#9474;</span> <span class="yellow">&#9650;5</span> <span class="sep">&#9474;</span> <span class="magenta bold">spine</span> <span class="magenta">&#8853;3</span> <span class="sep">&#9474;</span> <span class="dimwhite">800k tk</span> <span class="sep">&#9474;</span> <span class="red">$6.20</span> <span class="sep">&#9474;</span> <span class="red">&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;&#9617;&#9617; 15%</span> <span class="sep">&#9474;</span> <span class="yellow">&#9678;82% &#8635;1h</span></div>
+              <div class="line"><span class="dimwhite">Opus 4.6</span> <span class="sep">&#9474;</span> <span class="dimwhite">48m</span> <span class="sep">&#9474;</span> <span class="green">+420</span> <span class="red">-87</span> <span class="sep">&#9474;</span> <span class="dimwhite">$0.012/line</span> <span class="sep">&#9474;</span> <span class="yellow">5h: 82%</span> <span class="sep">&#9474;</span> <span class="dimwhite">7d: 55%</span></div>
+            </div>
+          </div>
+          <div class="col after">
+            <h4>After</h4>
+            <div class="mockup" style="font-size: 11px;">
+              <div class="line"><span class="cyan">feat-x</span> <span class="green">&#8593;7</span> <span class="sep">&#9474;</span> <span class="yellow">5 dirty</span> <span class="sep">&#9474;</span> <span class="magenta bold">spine</span> <span class="magenta">+3 sub</span> <span class="sep">&#9474;</span> <span class="green">+420</span> <span class="red">-87</span> <span class="dim">lines</span></div>
+              <div class="line"><span class="dimwhite">Opus 4.6</span> <span class="sep">&#9474;</span> <span class="dimwhite">48m</span> <span class="sep">&#9474;</span> <span class="red">$6.20</span> <span class="sep">&#9474;</span> <span class="red">&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;&#9617;&#9617; 15%</span> <span class="sep">&#9474;</span> <span class="yellow">5h: 82%</span><span class="dim"> &#183; </span><span class="dimwhite">7d: 55%</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- What's Working -->
+      <div class="section">
+        <div class="callout">
+          <h4>What's Working Well (don't change)</h4>
+          <ul style="margin-top: 8px;">
+            <li><strong>Color-escalation on context bar and rate limit</strong> &mdash; green/yellow/red/blink progression is immediately understood</li>
+            <li><strong>The 10-block progress bar</strong> &mdash; universally scannable, great spatial encoding</li>
+            <li><strong>Progressive disclosure concept</strong> &mdash; hiding zero-value segments is correct; the execution just needs group-level stability</li>
+            <li><strong>Two-line layout</strong> &mdash; the right amount of space for a status bar</li>
+            <li><strong>+N / -N for lines</strong> &mdash; matches git convention, no learning curve</li>
+            <li><strong>Cost color thresholds</strong> ($1 yellow, $5 red) &mdash; sensible escalation</li>
+          </ul>
+        </div>
+      </div>
+
+      <!-- Implementation Notes -->
+      <div class="section">
+        <h2>Implementation Changes</h2>
+        <p style="color: var(--text-muted); margin-bottom: 16px;">Minimal code changes in <code>hooks/tonone-statusline.js</code>:</p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>Change</th>
+              <th>Current Code</th>
+              <th>New Code</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Drop &#9670; from branch</td>
+              <td><code>\u25c6 ${branch}</code></td>
+              <td><code>${branch}</code></td>
+            </tr>
+            <tr>
+              <td>Label dirty count</td>
+              <td><code>\u25b2${dirty}</code></td>
+              <td><code>${dirty} dirty</code></td>
+            </tr>
+            <tr>
+              <td>Label subagents</td>
+              <td><code>\u2295${subCount}</code></td>
+              <td><code>+${subCount} sub</code></td>
+            </tr>
+            <tr>
+              <td>Move lines changed</td>
+              <td>Line 2, segment 3</td>
+              <td>Line 1, segment 4</td>
+            </tr>
+            <tr>
+              <td>Add "lines" label</td>
+              <td><code>+${added} -${removed}</code></td>
+              <td><code>+${added} -${removed} lines</code></td>
+            </tr>
+            <tr>
+              <td>Drop token count</td>
+              <td>Segment 5 on Line 1</td>
+              <td>Remove</td>
+            </tr>
+            <tr>
+              <td>Drop cost/line</td>
+              <td>Line 2, segment 4</td>
+              <td>Remove</td>
+            </tr>
+            <tr>
+              <td>Drop Line 1 rate limit</td>
+              <td><code>renderRateLimit()</code> on Line 1</td>
+              <td>Remove from Line 1</td>
+            </tr>
+            <tr>
+              <td>Join rate windows</td>
+              <td>Two pipe-separated segments</td>
+              <td>One group with &middot; separator</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Top Priority -->
+      <div class="section" style="border-color: var(--accent);">
+        <h2 style="color: var(--accent);">Top Priority Fix</h2>
+        <p>If only one thing changes: <strong>replace symbols with micro-labels</strong>. This single change addresses the core complaint ("hard to understand what is what") with minimal code change. <code>&#9650;2</code> &rarr; <code>2 dirty</code>, <code>&#8853;1</code> &rarr; <code>+1 sub</code>, drop <code>&#9670;</code>. Three lines of code, immediate comprehension gain.</p>
+      </div>
+
+      <p style="color: var(--text-muted); font-size: 12px; text-align: center; margin-top: 40px;">
+        Draft &mdash; UX Design &bull; tonone Product Team &bull; 2026-04-12
+      </p>
+    </div>
+  </body>
+</html>

--- a/.reports/team-review-2026-04-12-0301.html
+++ b/.reports/team-review-2026-04-12-0301.html
@@ -1,0 +1,1133 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>tonone Full Team Review - 2026-04-12</title>
+<style>
+:root {
+  --bg: #0f172a;
+  --bg-card: #1e293b;
+  --bg-card-alt: #162032;
+  --text: #e2e8f0;
+  --text-muted: #94a3b8;
+  --border: #334155;
+  --accent: #3b82f6;
+  --critical: #dc2626;
+  --critical-bg: rgba(220,38,38,0.12);
+  --warning: #d97706;
+  --warning-bg: rgba(217,119,6,0.12);
+  --info: #2563eb;
+  --info-bg: rgba(37,99,235,0.12);
+  --success: #16a34a;
+  --success-bg: rgba(22,163,74,0.12);
+  --font-mono: "JetBrains Mono", "Fira Code", "Cascadia Code", monospace;
+  --font-sans: "Inter", system-ui, -apple-system, sans-serif;
+  --sidebar-w: 260px;
+}
+[data-theme="light"] {
+  --bg: #ffffff;
+  --bg-card: #f8fafc;
+  --bg-card-alt: #f1f5f9;
+  --text: #1e293b;
+  --text-muted: #64748b;
+  --border: #e2e8f0;
+  --critical-bg: #fef2f2;
+  --warning-bg: #fffbeb;
+  --info-bg: #eff6ff;
+  --success-bg: #f0fdf4;
+}
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; }
+body {
+  font-family: var(--font-sans);
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  display: flex;
+  min-height: 100vh;
+}
+.sidebar {
+  position: fixed;
+  top: 0; left: 0;
+  width: var(--sidebar-w);
+  height: 100vh;
+  background: var(--bg-card);
+  border-right: 1px solid var(--border);
+  padding: 24px 16px;
+  overflow-y: auto;
+  z-index: 100;
+  transition: transform 0.3s ease;
+}
+.sidebar h2 {
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  margin-bottom: 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+.sidebar .brand {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--accent);
+  margin-bottom: 4px;
+  letter-spacing: -0.02em;
+}
+.sidebar .subtitle {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-bottom: 20px;
+}
+.sidebar a {
+  display: block;
+  padding: 6px 10px;
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: 13px;
+  border-radius: 6px;
+  transition: all 0.15s;
+}
+.sidebar a:hover, .sidebar a.active {
+  color: var(--text);
+  background: rgba(59,130,246,0.1);
+}
+.sidebar .agent-badge {
+  display: inline-block;
+  font-size: 10px;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: 4px;
+  margin-right: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.badge-apex { background: rgba(59,130,246,0.2); color: #60a5fa; }
+.badge-helm { background: rgba(168,85,247,0.2); color: #c084fc; }
+.badge-crest { background: rgba(236,72,153,0.2); color: #f472b6; }
+.badge-pitch { background: rgba(251,146,60,0.2); color: #fb923c; }
+.badge-surge { background: rgba(34,197,94,0.2); color: #4ade80; }
+.badge-atlas { background: rgba(20,184,166,0.2); color: #2dd4bf; }
+.hamburger {
+  display: none;
+  position: fixed;
+  top: 12px; left: 12px;
+  z-index: 200;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  color: var(--text);
+  width: 40px; height: 40px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 20px;
+  align-items: center;
+  justify-content: center;
+}
+main {
+  margin-left: var(--sidebar-w);
+  flex: 1;
+  padding: 32px 48px;
+  max-width: 960px;
+}
+.theme-toggle {
+  position: fixed;
+  top: 12px; right: 16px;
+  z-index: 200;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  color: var(--text);
+  width: 40px; height: 40px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+}
+.theme-toggle:hover { border-color: var(--accent); }
+header { margin-bottom: 40px; }
+header h1 {
+  font-size: 28px;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  margin-bottom: 8px;
+}
+header h1 span { color: var(--accent); }
+.meta {
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+.meta-item { display: flex; align-items: center; gap: 6px; }
+.meta-item strong { color: var(--text); font-weight: 600; }
+section { margin-bottom: 48px; }
+section > h2 {
+  font-size: 20px;
+  font-weight: 700;
+  margin-bottom: 16px;
+  padding-bottom: 8px;
+  border-bottom: 2px solid var(--border);
+  letter-spacing: -0.01em;
+}
+section > h3 {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 24px 0 12px;
+  color: var(--text);
+}
+p { margin-bottom: 12px; color: var(--text); }
+.finding-card {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px 20px;
+  margin-bottom: 12px;
+  background: var(--bg-card);
+  border-left: 4px solid var(--border);
+}
+.finding-card.critical { border-left-color: var(--critical); background: var(--critical-bg); }
+.finding-card.warning { border-left-color: var(--warning); background: var(--warning-bg); }
+.finding-card.info { border-left-color: var(--info); background: var(--info-bg); }
+.finding-card.success { border-left-color: var(--success); background: var(--success-bg); }
+.finding-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+.severity {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 2px 8px;
+  border-radius: 4px;
+}
+.severity-critical { background: var(--critical); color: #fff; }
+.severity-warning { background: var(--warning); color: #fff; }
+.severity-info { background: var(--info); color: #fff; }
+.severity-success { background: var(--success); color: #fff; }
+.finding-title { font-weight: 600; font-size: 15px; }
+.finding-source {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  margin-left: auto;
+}
+.finding-body { font-size: 14px; color: var(--text); line-height: 1.65; }
+.finding-body strong { color: var(--text); }
+.finding-body .fix {
+  display: block;
+  margin-top: 8px;
+  padding: 8px 12px;
+  background: var(--bg-card-alt);
+  border-radius: 6px;
+  font-size: 13px;
+  border: 1px solid var(--border);
+}
+.finding-body .fix::before {
+  content: "Fix: ";
+  font-weight: 700;
+  color: var(--accent);
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+  font-size: 13px;
+}
+th, td {
+  text-align: left;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+}
+th {
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  background: var(--bg-card);
+}
+td { color: var(--text); }
+tr:hover td { background: var(--bg-card-alt); }
+.grade {
+  display: inline-block;
+  font-weight: 700;
+  font-size: 13px;
+  padding: 2px 10px;
+  border-radius: 6px;
+  text-align: center;
+  min-width: 32px;
+}
+.grade-a { background: rgba(34,197,94,0.2); color: #4ade80; }
+.grade-b { background: rgba(59,130,246,0.2); color: #60a5fa; }
+.grade-c { background: rgba(251,146,60,0.2); color: #fb923c; }
+.grade-d { background: rgba(220,38,38,0.2); color: #f87171; }
+.grade-f { background: rgba(220,38,38,0.3); color: #ef4444; }
+.scorecard {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  margin: 16px 0;
+}
+.score-item {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px;
+  text-align: center;
+}
+.score-value {
+  font-size: 32px;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+}
+.score-label {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+.verdict-box {
+  background: var(--bg-card);
+  border: 2px solid var(--accent);
+  border-radius: 12px;
+  padding: 24px;
+  margin: 24px 0;
+}
+.verdict-box h3 {
+  color: var(--accent);
+  margin: 0 0 12px;
+  font-size: 16px;
+}
+.verdict-box p { margin-bottom: 8px; }
+details {
+  margin: 12px 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-card);
+}
+details summary {
+  padding: 10px 14px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+  user-select: none;
+}
+details summary:hover { color: var(--accent); }
+details > div { padding: 0 14px 14px; }
+pre {
+  background: var(--bg-card-alt);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px 16px;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  position: relative;
+}
+code { font-family: var(--font-mono); font-size: 13px; }
+.mermaid {
+  background: var(--bg-card);
+  border-radius: 8px;
+  padding: 16px;
+  margin: 16px 0;
+  text-align: center;
+}
+.action-list { list-style: none; counter-reset: actions; }
+.action-list li {
+  counter-increment: actions;
+  padding: 12px 16px 12px 48px;
+  margin-bottom: 8px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  position: relative;
+  font-size: 14px;
+}
+.action-list li::before {
+  content: counter(actions);
+  position: absolute;
+  left: 14px; top: 12px;
+  width: 24px; height: 24px;
+  background: var(--accent);
+  color: #fff;
+  border-radius: 50%;
+  font-size: 12px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.action-list li strong { display: block; margin-bottom: 4px; }
+.agent-section {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  margin-bottom: 20px;
+  overflow: hidden;
+}
+.agent-section-header {
+  padding: 14px 20px;
+  background: var(--bg-card);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.agent-section-header h3 { margin: 0; font-size: 16px; }
+.agent-section-body { padding: 16px 20px; }
+.tag {
+  display: inline-block;
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  background: var(--bg-card-alt);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  margin-right: 4px;
+}
+@media (max-width: 768px) {
+  .sidebar { transform: translateX(-100%); }
+  .sidebar.open { transform: translateX(0); }
+  .hamburger { display: flex; }
+  main { margin-left: 0; padding: 60px 20px 32px; }
+  .scorecard { grid-template-columns: repeat(2, 1fr); }
+}
+@media print {
+  .sidebar, .hamburger, .theme-toggle { display: none !important; }
+  main { margin-left: 0; max-width: 100%; }
+  html { color-scheme: light; }
+  body { background: #fff; color: #000; }
+  .finding-card { break-inside: avoid; }
+  details { open: true; }
+  details[open] summary { display: none; }
+}
+</style>
+</head>
+<body>
+
+<button class="hamburger" onclick="document.querySelector('.sidebar').classList.toggle('open')">&#9776;</button>
+<button class="theme-toggle" onclick="toggleTheme()">&#9790;</button>
+
+<nav class="sidebar">
+  <div class="brand">tonone</div>
+  <div class="subtitle">Full Team Review</div>
+  <h2>Sections</h2>
+  <a href="#summary">Executive Summary</a>
+  <a href="#scorecard">Scorecard</a>
+  <a href="#engineering">Engineering (Apex)</a>
+  <a href="#product">Product (Helm)</a>
+  <a href="#strategy">Strategy (Crest)</a>
+  <a href="#marketing">Marketing (Pitch)</a>
+  <a href="#growth">Growth (Surge)</a>
+  <a href="#docs">Documentation (Atlas)</a>
+  <a href="#architecture">Architecture</a>
+  <a href="#risks">Critical Risks</a>
+  <a href="#actions">Action Plan</a>
+  <h2 style="margin-top:20px">Agents</h2>
+  <a href="#engineering"><span class="agent-badge badge-apex">APEX</span> Engineering</a>
+  <a href="#product"><span class="agent-badge badge-helm">HELM</span> Product</a>
+  <a href="#strategy"><span class="agent-badge badge-crest">CREST</span> Strategy</a>
+  <a href="#marketing"><span class="agent-badge badge-pitch">PITCH</span> Marketing</a>
+  <a href="#growth"><span class="agent-badge badge-surge">SURGE</span> Growth</a>
+  <a href="#docs"><span class="agent-badge badge-atlas">ATLAS</span> Docs</a>
+</nav>
+
+<main>
+
+<header>
+  <h1><span>tonone</span> Full Team Review</h1>
+  <div class="meta">
+    <div class="meta-item"><strong>Agents:</strong> Apex, Helm, Crest, Pitch, Surge, Atlas</div>
+    <div class="meta-item"><strong>Date:</strong> 2026-04-12</div>
+    <div class="meta-item"><strong>Repo:</strong> tonone-ai/tonone</div>
+    <div class="meta-item"><strong>Branch:</strong> main</div>
+  </div>
+</header>
+
+<!-- ============ EXECUTIVE SUMMARY ============ -->
+<section id="summary">
+  <h2>Executive Summary</h2>
+  <div class="verdict-box">
+    <h3>The Verdict</h3>
+    <p><strong>tonone is a well-structured, high-quality prompt engineering product masquerading as a software project.</strong> The 23 agent definitions and 140+ skill workflows are production-grade. The Python runtime, tests, and hooks are almost entirely scaffolding. This is not a weakness if you own it. The value IS the prompts.</p>
+    <p>The product solves a real, painful problem for solo technical founders. The competitive position is structurally unique (pre-built team, not a framework). But three things threaten launch: no onboarding path from install to value, a brand name that doesn't work, and 100% platform dependency on Claude Code.</p>
+  </div>
+
+  <div class="finding-card info">
+    <div class="finding-body">
+      <strong>What 6 agents agree on:</strong> The core product (agent definitions + skill workflows) is genuinely strong. The biggest gap isn't code quality, it's the space between "installed" and "wow this is incredible." Every agent independently flagged activation clarity as the #1 priority.
+    </div>
+  </div>
+</section>
+
+<!-- ============ SCORECARD ============ -->
+<section id="scorecard">
+  <h2>Scorecard</h2>
+  <div class="scorecard">
+    <div class="score-item">
+      <div class="score-value" style="color: var(--success);">A</div>
+      <div class="score-label">Agent Definitions</div>
+    </div>
+    <div class="score-item">
+      <div class="score-value" style="color: var(--success);">A</div>
+      <div class="score-label">Skill Workflows</div>
+    </div>
+    <div class="score-item">
+      <div class="score-value" style="color: var(--success);">A-</div>
+      <div class="score-label">Documentation</div>
+    </div>
+    <div class="score-item">
+      <div class="score-value" style="color: var(--info);">B</div>
+      <div class="score-label">Product Coherence</div>
+    </div>
+    <div class="score-item">
+      <div class="score-value" style="color: var(--warning);">C</div>
+      <div class="score-label">Test Coverage</div>
+    </div>
+    <div class="score-item">
+      <div class="score-value" style="color: var(--warning);">C</div>
+      <div class="score-label">Runtime Code</div>
+    </div>
+    <div class="score-item">
+      <div class="score-value" style="color: var(--critical);">D</div>
+      <div class="score-label">Onboarding UX</div>
+    </div>
+    <div class="score-item">
+      <div class="score-value" style="color: var(--critical);">D</div>
+      <div class="score-label">Growth Mechanics</div>
+    </div>
+  </div>
+
+  <table>
+    <thead>
+      <tr><th>Dimension</th><th>Grade</th><th>Assessment</th><th>Agent</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Agent definitions (23/23)</td><td><span class="grade grade-a">A</span></td><td>Production-grade. Opinionated, concrete, with real decision frameworks.</td><td><span class="agent-badge badge-apex">APEX</span></td></tr>
+      <tr><td>Skill workflows (140+)</td><td><span class="grade grade-a">A</span></td><td>Detailed multi-step workflows. Core product value.</td><td><span class="agent-badge badge-apex">APEX</span></td></tr>
+      <tr><td>Docs &amp; architecture</td><td><span class="grade grade-a">A-</span></td><td>README sells well. Architecture doc is thorough. Skill count mismatch.</td><td><span class="agent-badge badge-atlas">ATLAS</span></td></tr>
+      <tr><td>CI / structural integrity</td><td><span class="grade grade-b">B+</span></td><td>Honest, solid. Tests what exists, doesn't pretend otherwise.</td><td><span class="agent-badge badge-apex">APEX</span></td></tr>
+      <tr><td>Product roster coherence</td><td><span class="grade grade-b">B</span></td><td>Strong mapping to real org. Relay/Pave overlap. Missing Legal agent.</td><td><span class="agent-badge badge-helm">HELM</span></td></tr>
+      <tr><td>Helm-to-Apex handoff</td><td><span class="grade grade-a">A</span></td><td>6-field brief schema is tight. Strongest part of system design.</td><td><span class="agent-badge badge-helm">HELM</span></td></tr>
+      <tr><td>Competitive position</td><td><span class="grade grade-b">B</span></td><td>Structurally unique but fragile moat. First-mover advantage is real.</td><td><span class="agent-badge badge-crest">CREST</span></td></tr>
+      <tr><td>Messaging &amp; positioning</td><td><span class="grade grade-c">C+</span></td><td>Right instinct, wrong execution. Leads with mechanics, not outcome.</td><td><span class="agent-badge badge-pitch">PITCH</span></td></tr>
+      <tr><td>Brand name</td><td><span class="grade grade-d">D</span></td><td>Not memorable, not searchable, pronunciation ambiguous.</td><td><span class="agent-badge badge-pitch">PITCH</span></td></tr>
+      <tr><td>Test coverage</td><td><span class="grade grade-c">C</span></td><td>3 root structural tests. 16/23 agents have zero functional tests.</td><td><span class="agent-badge badge-apex">APEX</span></td></tr>
+      <tr><td>Python runtime</td><td><span class="grade grade-d">D</span></td><td>16/23 agents are NotImplementedError stubs. 7 have real uiux code.</td><td><span class="agent-badge badge-apex">APEX</span></td></tr>
+      <tr><td>Onboarding / activation</td><td><span class="grade grade-d">D</span></td><td>No /start, no /welcome, no guided entry. 140+ skills, zero routing.</td><td><span class="agent-badge badge-surge">SURGE</span></td></tr>
+      <tr><td>Viral / growth mechanics</td><td><span class="grade grade-d">D</span></td><td>K-factor 0.05-0.15. No share moments, no attribution in output.</td><td><span class="agent-badge badge-surge">SURGE</span></td></tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ============ ENGINEERING ============ -->
+<section id="engineering">
+  <h2><span class="agent-badge badge-apex">APEX</span> Engineering Assessment</h2>
+
+  <div class="finding-card success">
+    <div class="finding-header">
+      <span class="severity severity-success">STRONG</span>
+      <span class="finding-title">Agent definitions are production-grade</span>
+    </div>
+    <div class="finding-body">
+      All 23 agent .md files are substantive (50+ lines, enforced by CI). They read like real engineering leadership documents: opinionated operating principles, concrete scope boundaries, platform fluency tables, decision frameworks. Forge's scale-awareness model, Spine's "boring technology default," Helm's 6-field brief schema. Not generated boilerplate.
+    </div>
+  </div>
+
+  <div class="finding-card success">
+    <div class="finding-header">
+      <span class="severity severity-success">STRONG</span>
+      <span class="finding-title">140+ skills are detailed workflow scripts</span>
+    </div>
+    <div class="finding-body">
+      Every agent has 4-7 skills. SKILL.md files are structured prompt workflows with concrete bash commands, severity classifications, and spec templates. For a Claude Code plugin, this IS the implementation. The skill density and quality is the core product value.
+    </div>
+  </div>
+
+  <div class="finding-card warning">
+    <div class="finding-header">
+      <span class="severity severity-warning">WARNING</span>
+      <span class="finding-title">16/23 agents have zero runtime Python code</span>
+    </div>
+    <div class="finding-body">
+      Every agent has <code>runner.py</code> containing exactly: <code>raise NotImplementedError("Implement your analyzers here")</code>. All 23 are identical stubs. Only 7 agents (form, draft, pitch, prism, touch, surge, lens) have a real <code>uiux/</code> submodule. The other 16 have zero functional Python.
+      <span class="fix">Either remove the stub files (accept this is a prompt-only product) or implement analyzers for the highest-value agents first (Warden, Forge, Relay).</span>
+    </div>
+  </div>
+
+  <div class="finding-card warning">
+    <div class="finding-header">
+      <span class="severity severity-warning">WARNING</span>
+      <span class="finding-title">Test coverage is structural only</span>
+    </div>
+    <div class="finding-body">
+      3 root-level tests enforce consistency across all 23 agents (file existence, structure compliance). Per-agent: 23 empty <code>__init__.py</code> stubs, 7 <code>test_uiux.py</code> files with ~3 tests each. Zero functional tests for 16 agents. CI test matrix is explicitly disabled.
+      <span class="fix">Honest for current maturity. Add skill output tests (run skill, validate structure) for the top 10 most-used skills as usage data arrives.</span>
+    </div>
+  </div>
+
+  <div class="finding-card info">
+    <div class="finding-header">
+      <span class="severity severity-info">INFO</span>
+      <span class="finding-title">CI is honest and well-designed</span>
+    </div>
+    <div class="finding-body">
+      Structure validation, shell linting, agent/skill compliance. Agent test matrix explicitly disabled with a clear comment. The CI tests what matters today and doesn't pretend to test what doesn't exist. Well-designed for current maturity.
+    </div>
+  </div>
+
+  <details>
+    <summary>Implementation depth by component</summary>
+    <div>
+      <table>
+        <thead><tr><th>Component</th><th>Status</th><th>Detail</th></tr></thead>
+        <tbody>
+          <tr><td>Agent definitions</td><td><span class="grade grade-a">A</span></td><td>23/23 substantive, CI-enforced</td></tr>
+          <tr><td>Skills (SKILL.md)</td><td><span class="grade grade-a">A</span></td><td>140+ detailed workflows</td></tr>
+          <tr><td>Plugin wiring</td><td><span class="grade grade-b">B+</span></td><td>Root + 20 per-agent manifests (3 missing)</td></tr>
+          <tr><td>Root hooks</td><td><span class="grade grade-b">B</span></td><td>Statusline + agent tracker (real)</td></tr>
+          <tr><td>Per-agent hooks</td><td><span class="grade grade-d">D</span></td><td>23/23 identical post_install stubs</td></tr>
+          <tr><td>Python runtime</td><td><span class="grade grade-d">D</span></td><td>7/23 real, 16/23 NotImplementedError</td></tr>
+          <tr><td>Tests</td><td><span class="grade grade-c">C</span></td><td>3 structural + 7 uiux = 10 total</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </details>
+</section>
+
+<!-- ============ PRODUCT ============ -->
+<section id="product">
+  <h2><span class="agent-badge badge-helm">HELM</span> Product Assessment</h2>
+
+  <div class="finding-card critical">
+    <div class="finding-header">
+      <span class="severity severity-critical">CRITICAL</span>
+      <span class="finding-title">No onboarding path from install to value</span>
+    </div>
+    <div class="finding-body">
+      A new user installs the plugin and faces 23 agents and 140+ skills with zero guided entry point. No <code>/start</code>, no <code>/setup</code>, no welcome flow. Time-to-first-value is indeterminate. <code>atlas-onboard</code> exists but is positioned as knowledge engineering, not user onboarding.
+      <span class="fix">Build a <code>/welcome</code> or <code>/start</code> skill that asks 3 questions and routes the user to their first high-value agent within 90 seconds.</span>
+    </div>
+  </div>
+
+  <div class="finding-card success">
+    <div class="finding-header">
+      <span class="severity severity-success">STRONG</span>
+      <span class="finding-title">Helm-to-Apex handoff is well-designed</span>
+    </div>
+    <div class="finding-body">
+      The 6-field brief schema is tight, the contract is explicit, both agents reference it. Helm infers rather than stalls. This is the strongest part of the system design and a genuine differentiator from unstructured agent frameworks.
+    </div>
+  </div>
+
+  <div class="finding-card warning">
+    <div class="finding-header">
+      <span class="severity severity-warning">WARNING</span>
+      <span class="finding-title">Relay/Pave overlap creates routing confusion</span>
+    </div>
+    <div class="finding-body">
+      Relay owns CI/CD and GitOps. Pave owns developer experience and golden paths. A solo founder won't know which to call for "set up my pipeline." The boundaries need sharper dispatch language.
+      <span class="fix">Clarify in agent definitions: Relay = pipelines and deployment. Pave = local dev environment and internal tooling. Add disambiguation to skill routing rules.</span>
+    </div>
+  </div>
+
+  <div class="finding-card warning">
+    <div class="finding-header">
+      <span class="severity severity-warning">WARNING</span>
+      <span class="finding-title">Skill routing is Apex-biased, product tasks underserved</span>
+    </div>
+    <div class="finding-body">
+      Routing rules in CLAUDE.md cover engineering tasks well (ship, review, investigate, qa). Product tasks have no entry points: "I have a feature idea" doesn't route to Helm, "pricing question" doesn't route to Pitch.
+      <span class="fix">Add product-task routing: "new feature idea" to Helm, "pricing or positioning" to Pitch, "growth problem" to Surge, "user research" to Echo.</span>
+    </div>
+  </div>
+
+  <div class="finding-card info">
+    <div class="finding-header">
+      <span class="severity severity-info">INFO</span>
+      <span class="finding-title">Missing role: Legal/Compliance</span>
+    </div>
+    <div class="finding-body">
+      Warden covers security, but contract review, terms of service, privacy policy, and regulatory guidance (GDPR, SOC 2 prep) are common solo-founder pain points with no home in the current roster. Not blocking for launch but a real gap.
+    </div>
+  </div>
+
+  <details>
+    <summary>Target user profile</summary>
+    <div>
+      <p><strong>Primary:</strong> Solo technical founder building a SaaS. Both the PM and the engineer. Context-switches between tools, AI assistants, and their own knowledge gaps.</p>
+      <p><strong>Secondary:</strong> Small team (2-4 engineers) operating above their headcount.</p>
+      <p><strong>Not:</strong> Enterprise (Devin owns that). Agencies (product team is overkill for ship-focused work).</p>
+      <p><strong>PMF risk:</strong> The "AI team" frame raises the bar on quality expectations. If any agent produces generic output, the frame collapses. "AI assistant" sets a lower bar; "AI team" implies specialist depth.</p>
+    </div>
+  </details>
+</section>
+
+<!-- ============ STRATEGY ============ -->
+<section id="strategy">
+  <h2><span class="agent-badge badge-crest">CREST</span> Competitive Strategy</h2>
+
+  <h3>Competitive Map</h3>
+  <table>
+    <thead><tr><th>Category</th><th>Competitors</th><th>Approach</th><th>tonone Advantage</th></tr></thead>
+    <tbody>
+      <tr><td>Framework builders</td><td>CrewAI, AutoGen, LangGraph</td><td>You bring your own agents, code to configure</td><td>Zero-config, pre-built team</td></tr>
+      <tr><td>Coded AI dev teams</td><td>MetaGPT, ChatDev, OpenHands</td><td>Simulated software companies, autonomous execution</td><td>Human-in-the-loop, org-chart coherence</td></tr>
+      <tr><td>Commercial AI engineers</td><td>Devin, Copilot Workspace</td><td>Async autonomous, deep IDE integration</td><td>Open source, full-stack team (not just code)</td></tr>
+    </tbody>
+  </table>
+
+  <h3>Three Unique Differentiators</h3>
+  <div class="finding-card info">
+    <div class="finding-body">
+      <strong>1. Claude Code native.</strong> Installs as a plugin, zero config, activates via slash commands. No Python environments, API keys, or orchestration code.<br><br>
+      <strong>2. Prompt-only architecture.</strong> Agents are Markdown files. No runtime dependency, no framework lock-in. Fork an agent, edit a .md, done.<br><br>
+      <strong>3. Full team metaphor with role separation.</strong> Not just "agents that can do things" but an org chart with handoff contracts, output standards, and domain ownership. Creates coherent behavior under ambiguity.
+    </div>
+  </div>
+
+  <div class="finding-card critical">
+    <div class="finding-header">
+      <span class="severity severity-critical">CRITICAL</span>
+      <span class="finding-title">100% platform dependency on Claude Code</span>
+    </div>
+    <div class="finding-body">
+      Distribution is entirely dependent on Anthropic's platform trajectory. If Claude Code loses to Cursor/Copilot, tonone's install base ceiling drops dramatically. Worse: if Anthropic ships a first-party team template, tonone gets compressed to customization only.
+      <span class="fix">Monitor Claude Code market share quarterly. If professional dev share drops below 20% in 18 months, re-evaluate. Meanwhile, the Codex CLI support is a smart hedge but needs more investment.</span>
+    </div>
+  </div>
+
+  <div class="finding-card warning">
+    <div class="finding-header">
+      <span class="severity severity-warning">WARNING</span>
+      <span class="finding-title">Prompt-only architecture is trivially copyable</span>
+    </div>
+    <div class="finding-body">
+      Any developer can fork this repo, rename agents, and republish. The moat is in brand, quality of agent definitions, and contributor network effect. Not in code.
+      <span class="fix">The real moat is being the canonical "team install" in the Claude Code ecosystem. Ship fast, build community, become the default before someone copies the approach.</span>
+    </div>
+  </div>
+
+  <div class="verdict-box">
+    <h3>Where to Play / How to Win</h3>
+    <p><strong>Where:</strong> Solo developers and small teams (1-5 engineers) who need to operate above their headcount. Not enterprise (Devin). Not framework builders (CrewAI/LangGraph). The gap: developer who wants senior team judgment, not framework configuration.</p>
+    <p><strong>How:</strong> Own the Claude Code plugin category before Anthropic does it themselves. Deepen agent quality over agent count. Add autonomous loop as next capability milestone. Track which skills get used, kill the ones that don't.</p>
+    <p><strong>Not now:</strong> Enterprise sales, multi-LLM support, GUI builders. These dilute the Claude Code native bet before it's proven.</p>
+  </div>
+</section>
+
+<!-- ============ MARKETING ============ -->
+<section id="marketing">
+  <h2><span class="agent-badge badge-pitch">PITCH</span> Positioning &amp; Messaging</h2>
+
+  <div class="finding-card critical">
+    <div class="finding-header">
+      <span class="severity severity-critical">CRITICAL</span>
+      <span class="finding-title">"tonone" doesn't work as a brand name</span>
+    </div>
+    <div class="finding-body">
+      Not memorable, not searchable, pronunciation is ambiguous (toe-none? ton-one?). Reads as an inside joke or dev codename. The agent names (Apex, Forge, Relay, Spine, Vigil, Warden, Proof) are excellent, possibly the best AI agent names in the space. The parent brand doesn't match that quality.
+      <span class="fix">Either commit with a pronunciation guide + origin story, or rename before public launch. The agent names are an asset. The parent name is a liability.</span>
+    </div>
+  </div>
+
+  <div class="finding-card critical">
+    <div class="finding-header">
+      <span class="severity severity-critical">CRITICAL</span>
+      <span class="finding-title">"Replace your team" is wrong framing for the buyer</span>
+    </div>
+    <div class="finding-body">
+      The best-fit customer doesn't have a team to replace. They're a solo dev or early startup. "Replace" implies the buyer has something to replace. The honest, believable version: <strong>"Get a full-stack team when you don't have one, or can't afford one."</strong>
+      <span class="fix">Reframe from replacement to access/augmentation. Lead with the customer's reality (alone, context-switching, gaps in expertise), not a confrontational claim.</span>
+    </div>
+  </div>
+
+  <div class="finding-card warning">
+    <div class="finding-header">
+      <span class="severity severity-warning">WARNING</span>
+      <span class="finding-title">README leads with mechanics, not outcome</span>
+    </div>
+    <div class="finding-body">
+      "One session. Two commands. Full team. Zero meetings." leads with installation ease. That's a feature, not a value proposition. The Apex S/M/L scope dialogue is the most differentiated moment in all the copy, but it's buried in "The Leads" section.
+      <span class="fix">Rewrite first 50 words to name the customer and their problem. Move the Apex S/M/L dialogue above the fold. Tables are not copy.</span>
+    </div>
+  </div>
+
+  <div class="finding-card warning">
+    <div class="finding-header">
+      <span class="severity severity-warning">WARNING</span>
+      <span class="finding-title">No social proof or competitive framing</span>
+    </div>
+    <div class="finding-body">
+      Zero social proof. No "compared to" framing. Buyer will ask: why not just use Claude directly? Why not GitHub Copilot? The README doesn't answer. No community signal (stars, contributors, Discord).
+      <span class="fix">Add "built by [person who shipped X]." Add a "Why not just use Claude?" section. Seed community signals before launch.</span>
+    </div>
+  </div>
+
+  <details>
+    <summary>Launch channel recommendations</summary>
+    <div>
+      <p><strong>Beachhead:</strong> Solo technical founders on X/Twitter and Hacker News.</p>
+      <ol>
+        <li><strong>Show HN</strong> -- lead with the coordination problem, not agent count</li>
+        <li><strong>X thread</strong> -- show the Apex S/M/L dialogue as a screenshot, ask "which size would you pick?"</li>
+        <li><strong>Product Hunt</strong> -- category: Developer Tools. Hook: "23 specialists, two commands, zero meetings"</li>
+      </ol>
+      <p><strong>Viral asset:</strong> Record a demo of <code>/apex-takeover</code> on a real inherited codebase. That's the launch video.</p>
+    </div>
+  </details>
+</section>
+
+<!-- ============ GROWTH ============ -->
+<section id="growth">
+  <h2><span class="agent-badge badge-surge">SURGE</span> Growth Analysis</h2>
+
+  <div class="finding-card critical">
+    <div class="finding-header">
+      <span class="severity severity-critical">CRITICAL</span>
+      <span class="finding-title">Activation is undefined and unmeasured</span>
+    </div>
+    <div class="finding-body">
+      No activation event exists. No instrumentation. The closest proxy: user invokes a skill and gets output that would have taken 30+ minutes manually. Time-to-that-moment is under 5 minutes IF the user knows what to ask. But with 140+ skills and no hierarchy, a first-timer is lost.
+      <span class="fix">Ship <code>/tonone-start</code>: asks 3 questions (what are you building, your role, first need), routes to the right specialist. Target: 60%+ of installers invoke a second skill in the same session.</span>
+    </div>
+  </div>
+
+  <div class="finding-card warning">
+    <div class="finding-header">
+      <span class="severity severity-warning">WARNING</span>
+      <span class="finding-title">Viral mechanics are weak</span>
+    </div>
+    <div class="finding-body">
+      Estimated K-factor: 0.05-0.15. Not an engine. The natural share moment is showing a colleague <code>/apex-takeover</code> output, but it's passive. No built-in attribution in generated artifacts, no "share this output" prompt, no community showcase.
+      <span class="fix">Add one-liner attribution to every agent output: "Built with tonone -- tonone.ai". Seed a "Skills I wish existed" discussion thread. Pin an <code>/apex-takeover</code> showcase with real output.</span>
+    </div>
+  </div>
+
+  <div class="finding-card info">
+    <div class="finding-header">
+      <span class="severity severity-info">INFO</span>
+      <span class="finding-title">Retention habit loop is the strongest growth card</span>
+    </div>
+    <div class="finding-body">
+      Users who integrate agents into daily workflow (<code>/apex-plan</code> at project start, <code>/warden-audit</code> before PRs) develop genuine habit. The loop: task arises, agent handles it, user trusts output, agent becomes default. No mechanism currently accelerates this, but the loop structure is sound.
+    </div>
+  </div>
+
+  <details>
+    <summary>Growth sequencing</summary>
+    <div>
+      <ol>
+        <li><strong>This week:</strong> Fix activation with <code>/tonone-start</code> onboarding skill</li>
+        <li><strong>Next:</strong> Build the share moment. Attribution in output + showcase thread</li>
+        <li><strong>Then:</strong> Community scaffolding. "Good first skill" labels, public changelog</li>
+        <li><strong>Hold:</strong> Referral/viral investment until week-2 retention is proven</li>
+      </ol>
+      <p><strong>Do not:</strong> Build marketing expansion before you know the bucket isn't leaky.</p>
+    </div>
+  </details>
+</section>
+
+<!-- ============ DOCS ============ -->
+<section id="docs">
+  <h2><span class="agent-badge badge-atlas">ATLAS</span> Documentation Assessment</h2>
+
+  <div class="finding-card success">
+    <div class="finding-header">
+      <span class="severity severity-success">STRONG</span>
+      <span class="finding-title">README, architecture, and guides are solid</span>
+    </div>
+    <div class="finding-body">
+      README sells the project immediately. Architecture doc explains the two-location file strategy, plugin system, and agent model clearly. Agent guide and skill guide are thorough with mapping tables and inline examples. Naming guide and output kit are well-specified.
+    </div>
+  </div>
+
+  <div class="finding-card warning">
+    <div class="finding-header">
+      <span class="severity severity-warning">WARNING</span>
+      <span class="finding-title">Two-location file sync has no tooling</span>
+    </div>
+    <div class="finding-body">
+      The pattern (edit in <code>team/</code>, copy to root <code>agents/</code>) is documented in CONTRIBUTING and architecture, but there's no <code>sync.sh</code> or Makefile target to enforce it. Contributors will forget. Highest contributor friction point.
+      <span class="fix">Add a <code>make sync</code> target or pre-commit hook that copies agent definitions from <code>team/*/agents/</code> to root <code>agents/</code>.</span>
+    </div>
+  </div>
+
+  <div class="finding-card warning">
+    <div class="finding-header">
+      <span class="severity severity-warning">WARNING</span>
+      <span class="finding-title">Skill count mismatch: 125 claimed vs 138 actual</span>
+    </div>
+    <div class="finding-body">
+      README says 125 skills. Repo has 138. Either the README is stale or 13 skills are unlisted. Worth auditing.
+      <span class="fix">Run a count, update README, or determine if 13 skills should be pruned.</span>
+    </div>
+  </div>
+
+  <div class="finding-card info">
+    <div class="finding-header">
+      <span class="severity severity-info">INFO</span>
+      <span class="finding-title">Skill template is thinner than skill guide</span>
+    </div>
+    <div class="finding-body">
+      <code>templates/new-agent/skills/SKILL_NAME/SKILL.md</code> has 3 steps, no structure. A contributor following only the template would underspec their skill vs what <code>docs/skill-guide.md</code> prescribes. Expand the template to match the guide.
+    </div>
+  </div>
+</section>
+
+<!-- ============ ARCHITECTURE ============ -->
+<section id="architecture">
+  <h2>Architecture Overview</h2>
+  <div class="mermaid">
+graph TB
+    subgraph "Claude Code Plugin System"
+        ROOT[".claude-plugin/<br>Root Plugin Manifest"]
+    end
+
+    subgraph "Orchestration Layer"
+        APEX["Apex<br>Engineering Lead"]
+        HELM["Helm<br>Head of Product"]
+    end
+
+    subgraph "Engineering Team (13 specialists)"
+        FORGE["Forge<br>Infrastructure"]
+        RELAY["Relay<br>DevOps"]
+        SPINE["Spine<br>Backend"]
+        FLUX["Flux<br>Data"]
+        WARDEN["Warden<br>Security"]
+        VIGIL["Vigil<br>Observability"]
+        PRISM["Prism<br>Frontend"]
+        CORTEX["Cortex<br>ML/AI"]
+        TOUCH["Touch<br>Mobile"]
+        VOLT["Volt<br>IoT"]
+        ATLAS["Atlas<br>Knowledge"]
+        PROOF["Proof<br>QA"]
+        PAVE["Pave<br>Platform"]
+    end
+
+    subgraph "Product Team (7 specialists)"
+        ECHO["Echo<br>Research"]
+        LUMEN["Lumen<br>Analytics"]
+        DRAFT["Draft<br>UX"]
+        FORM["Form<br>Visual"]
+        CREST["Crest<br>Strategy"]
+        PITCH["Pitch<br>Marketing"]
+        SURGE["Surge<br>Growth"]
+    end
+
+    ROOT --> APEX
+    ROOT --> HELM
+    HELM -->|"6-field brief"| APEX
+    APEX --> FORGE
+    APEX --> RELAY
+    APEX --> SPINE
+    APEX --> FLUX
+    APEX --> WARDEN
+    APEX --> VIGIL
+    APEX --> PRISM
+    APEX --> CORTEX
+    APEX --> TOUCH
+    APEX --> VOLT
+    APEX --> ATLAS
+    APEX --> PROOF
+    APEX --> PAVE
+    HELM --> ECHO
+    HELM --> LUMEN
+    HELM --> DRAFT
+    HELM --> FORM
+    HELM --> CREST
+    HELM --> PITCH
+    HELM --> SURGE
+
+    style APEX fill:#3b82f6,color:#fff
+    style HELM fill:#a855f7,color:#fff
+    style ROOT fill:#334155,color:#e2e8f0
+  </div>
+</section>
+
+<!-- ============ RISKS ============ -->
+<section id="risks">
+  <h2>Critical Risks</h2>
+
+  <div class="finding-card critical">
+    <div class="finding-header">
+      <span class="severity severity-critical">CRITICAL</span>
+      <span class="finding-title">Platform dependency risk</span>
+      <span class="finding-source">CREST</span>
+    </div>
+    <div class="finding-body">
+      100% tied to Claude Code. If Anthropic ships a first-party team template or Claude Code loses market share, tonone's position compresses dramatically. No fallback distribution channel is production-ready.
+    </div>
+  </div>
+
+  <div class="finding-card critical">
+    <div class="finding-header">
+      <span class="severity severity-critical">CRITICAL</span>
+      <span class="finding-title">Activation cliff</span>
+      <span class="finding-source">SURGE + HELM</span>
+    </div>
+    <div class="finding-body">
+      Every agent independently flagged: there's no path from "installed" to "first value." 140+ skills with no hierarchy, no onboarding, no guided first step. This is the #1 thing that will kill adoption.
+    </div>
+  </div>
+
+  <div class="finding-card critical">
+    <div class="finding-header">
+      <span class="severity severity-critical">CRITICAL</span>
+      <span class="finding-title">Quality credibility gap</span>
+      <span class="finding-source">PITCH + HELM</span>
+    </div>
+    <div class="finding-body">
+      "AI team" raises quality expectations beyond "AI assistant." If any agent produces generic output, the entire frame collapses. The README shows structure but not output quality. Prospects have no way to verify the claim before installing.
+    </div>
+  </div>
+
+  <div class="finding-card warning">
+    <div class="finding-header">
+      <span class="severity severity-warning">WARNING</span>
+      <span class="finding-title">Brand name liability</span>
+      <span class="finding-source">PITCH</span>
+    </div>
+    <div class="finding-body">
+      "tonone" is not memorable, not searchable, and pronunciation is ambiguous. This matters for word-of-mouth, the primary distribution channel for dev tools.
+    </div>
+  </div>
+
+  <div class="finding-card warning">
+    <div class="finding-header">
+      <span class="severity severity-warning">WARNING</span>
+      <span class="finding-title">Copyability</span>
+      <span class="finding-source">CREST</span>
+    </div>
+    <div class="finding-body">
+      Prompt-only architecture means anyone can fork, rename, and republish. The moat is speed-to-market and community, not technical barriers. Clock is ticking.
+    </div>
+  </div>
+</section>
+
+<!-- ============ ACTIONS ============ -->
+<section id="actions">
+  <h2>Action Plan</h2>
+
+  <h3>This Week (Pre-Launch Critical)</h3>
+  <ol class="action-list">
+    <li>
+      <strong>Ship /tonone-start onboarding skill</strong>
+      Asks 3 questions (what are you building, your role, first need), routes to the right specialist. This is the single highest-impact change. Flagged by Helm, Surge, and Atlas independently.
+    </li>
+    <li>
+      <strong>Rewrite README first 50 words</strong>
+      Name the customer and their problem before describing the product. Move Apex S/M/L dialogue above the fold. Current copy leads with mechanics, not outcome.
+    </li>
+    <li>
+      <strong>Decide on the name</strong>
+      Either commit to "tonone" with pronunciation guide + origin story, or rename before public launch. This blocks all marketing materials.
+    </li>
+    <li>
+      <strong>Fix skill count mismatch</strong>
+      README says 125, repo has 138. Audit and reconcile. Small but erodes trust in a product that claims precision.
+    </li>
+  </ol>
+
+  <h3>Next Two Weeks (Launch Readiness)</h3>
+  <ol class="action-list" style="counter-reset: actions 4;">
+    <li>
+      <strong>Add product-task routing to CLAUDE.md</strong>
+      "New feature idea" to Helm, "pricing" to Pitch, "growth" to Surge, "user research" to Echo. Currently Apex-biased.
+    </li>
+    <li>
+      <strong>Sharpen Relay/Pave dispatch language</strong>
+      Relay = pipelines and deployment. Pave = local dev and internal tooling. Add disambiguation to agent defs and routing.
+    </li>
+    <li>
+      <strong>Add attribution to agent output</strong>
+      Every output: "Built with tonone -- tonone.ai". Passive viral mechanic. Low cost, compounds over time.
+    </li>
+    <li>
+      <strong>Build file sync tooling</strong>
+      <code>make sync</code> or pre-commit hook for the two-location agent definition pattern. Biggest contributor friction point.
+    </li>
+  </ol>
+
+  <h3>Before Launch (Quality Bar)</h3>
+  <ol class="action-list" style="counter-reset: actions 8;">
+    <li>
+      <strong>Add social proof and competitive framing to README</strong>
+      "Built by [person who shipped X]." "Why not just use Claude directly?" section. Community signals.
+    </li>
+    <li>
+      <strong>Record /apex-takeover demo on a real codebase</strong>
+      This is the launch video. Shows parallel recon, specialist depth, and coordination in one artifact.
+    </li>
+    <li>
+      <strong>Reframe positioning from "replace" to "access"</strong>
+      "Get a full-stack team when you don't have one" beats "replace your team with AI agents." The buyer doesn't have a team.
+    </li>
+  </ol>
+
+  <h3>Post-Launch (Iterate)</h3>
+  <ol class="action-list" style="counter-reset: actions 11;">
+    <li>
+      <strong>Add telemetry for skill usage</strong>
+      Track which skills get used. Kill the ones that don't. Double down on the ones that do. Can't iterate blind.
+    </li>
+    <li>
+      <strong>Clean up Python stubs</strong>
+      Either remove NotImplementedError files (own the prompt-only identity) or implement analyzers for Warden, Forge, Relay first.
+    </li>
+    <li>
+      <strong>Seed community</strong>
+      "Good first skill" issue labels, "Skills I wish existed" discussion, monthly changelog highlighting contributors.
+    </li>
+  </ol>
+</section>
+
+</main>
+
+<script>
+function toggleTheme() {
+  const html = document.documentElement;
+  const current = html.getAttribute('data-theme');
+  const next = current === 'dark' ? 'light' : 'dark';
+  html.setAttribute('data-theme', next);
+  document.querySelector('.theme-toggle').textContent = next === 'dark' ? '\u263E' : '\u2600';
+}
+
+// Sidebar active state
+const observer = new IntersectionObserver((entries) => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      document.querySelectorAll('.sidebar a').forEach(a => a.classList.remove('active'));
+      const link = document.querySelector(`.sidebar a[href="#${entry.target.id}"]`);
+      if (link) link.classList.add('active');
+    }
+  });
+}, { threshold: 0.3 });
+
+document.querySelectorAll('section[id]').forEach(s => observer.observe(s));
+
+// Copy buttons
+document.querySelectorAll('pre').forEach(pre => {
+  const btn = document.createElement('button');
+  btn.textContent = 'Copy';
+  btn.style.cssText = 'position:absolute;top:6px;right:6px;background:var(--bg-card);border:1px solid var(--border);color:var(--text-muted);padding:2px 8px;border-radius:4px;font-size:11px;cursor:pointer;';
+  btn.onclick = () => {
+    navigator.clipboard.writeText(pre.textContent.replace('Copy', '').trim());
+    btn.textContent = 'Copied!';
+    setTimeout(() => btn.textContent = 'Copy', 1500);
+  };
+  pre.style.position = 'relative';
+  pre.appendChild(btn);
+});
+</script>
+<script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+<script>
+try { mermaid.initialize({ startOnLoad: true, theme: 'dark', themeVariables: { primaryColor: '#3b82f6', primaryTextColor: '#e2e8f0', lineColor: '#64748b', secondaryColor: '#1e293b' }}); } catch(e) { document.querySelectorAll('.mermaid').forEach(el => { const pre = document.createElement('pre'); pre.textContent = el.textContent; el.replaceWith(pre); }); }
+</script>
+
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Tonone
 
-**One session. Two commands. Full team. Zero meetings.**
+**Your AI team, second to none.**
 
-23 specialists just showed up. Engineering executes. Product decides. 125 skills across every discipline. MIT licensed, two commands to install.
+23 specialists. Engineering executes. Product decides. One session, two commands, zero meetings. 125 skills across every discipline. MIT licensed.
 
 ## Why This Exists
 

--- a/docs/superpowers/plans/2026-04-12-statusline-redesign.md
+++ b/docs/superpowers/plans/2026-04-12-statusline-redesign.md
@@ -1,0 +1,843 @@
+# Statusline Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rewrite the two-line statusline into a three-line design with semantic grouping, micro-labels, static fields, subagent names, model routing display, and pace projection for rate limits.
+
+**Architecture:** Single-file rewrite of `hooks/tonone-statusline.js` (Node.js, reads JSON from stdin, outputs ANSI text). Small addition to `hooks/tonone-agent-tracker.js` to capture subagent model. New pace bridge file created at runtime in `/tmp/`.
+
+**Tech Stack:** Node.js (no dependencies), ANSI escape codes, child_process for git, fs for bridge files.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `hooks/tonone-agent-tracker.js` | Modify | Add `model` field from `tool_input.model` to agent entries |
+| `hooks/tonone-statusline.js` | Rewrite | Full rewrite: 3-line render, pace calculation, static fields |
+| `hooks/test-statusline.sh` | Create | Test runner — pipes JSON fixtures through statusline |
+
+---
+
+### Task 1: Add model field to agent tracker
+
+**Files:**
+- Modify: `hooks/tonone-agent-tracker.js:38-50`
+
+- [ ] **Step 1: Add model capture to agent start block**
+
+In `hooks/tonone-agent-tracker.js`, replace the `isStart` block (lines 38-50):
+
+```javascript
+    if (isStart) {
+      // New agent started
+      state = {
+        ...state,
+        agents: [
+          ...state.agents,
+          {
+            id: toolOutput.agentId,
+            desc: agentDesc,
+            started: Date.now(),
+            finished: null,
+          },
+        ],
+      };
+```
+
+With:
+
+```javascript
+    if (isStart) {
+      // New agent started
+      const agentModel = toolInput.model || null;
+      state = {
+        ...state,
+        agents: [
+          ...state.agents,
+          {
+            id: toolOutput.agentId,
+            desc: agentDesc,
+            model: agentModel,
+            started: Date.now(),
+            finished: null,
+          },
+        ],
+      };
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add hooks/tonone-agent-tracker.js
+git commit -m "feat(statusline): track subagent model in bridge file"
+```
+
+---
+
+### Task 2: Rewrite statusline — colors, formatters, and git helpers
+
+**Files:**
+- Modify: `hooks/tonone-statusline.js:1-104`
+
+- [ ] **Step 1: Replace the entire top section (lines 1-104) with updated helpers**
+
+Replace everything from line 1 through the end of `fmtRelativeTime` (line 104) with:
+
+```javascript
+#!/usr/bin/env node
+"use strict";
+
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+// ── ANSI helpers ─────────────────────────────────────────────────────────────
+
+const c = {
+  reset: "\x1b[0m",
+  dim: "\x1b[2m",
+  bold: "\x1b[1m",
+  blink: "\x1b[5m",
+  cyan: "\x1b[36m",
+  yellow: "\x1b[33m",
+  green: "\x1b[32m",
+  red: "\x1b[31m",
+  magenta: "\x1b[35m",
+  dimWhite: "\x1b[2;37m",
+};
+
+const SEP = ` ${c.dim}\u2502${c.reset} `;
+
+// ── Git helpers ──────────────────────────────────────────────────────────────
+
+function gitBranch(cwd) {
+  try {
+    return execSync("git rev-parse --abbrev-ref HEAD", {
+      cwd,
+      encoding: "utf8",
+      timeout: 1000,
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function gitDirtyCount(cwd) {
+  try {
+    const out = execSync("git status --porcelain", {
+      cwd,
+      encoding: "utf8",
+      timeout: 2000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return out.trim() ? out.trim().split("\n").length : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function gitAhead(cwd) {
+  try {
+    const out = execSync("git rev-list --count @{u}..HEAD", {
+      cwd,
+      encoding: "utf8",
+      timeout: 1000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return parseInt(out.trim(), 10) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+// ── Formatters ───────────────────────────────────────────────────────────────
+
+function fmtDir(dir) {
+  const home = os.homedir();
+  let d = dir.startsWith(home) ? "~" + dir.slice(home.length) : dir;
+  if (d.length > 40) {
+    const parts = d.split("/");
+    while (d.length > 40 && parts.length > 2) {
+      parts.shift();
+      d = "\u2026/" + parts.join("/");
+    }
+  }
+  return d;
+}
+
+function fmtCost(usd) {
+  if (usd == null || usd === 0) return "$0.00";
+  if (usd < 0.01) return `$${usd.toFixed(3)}`;
+  return `$${usd.toFixed(2)}`;
+}
+
+function fmtDuration(ms) {
+  if (ms == null || ms <= 0) return "0m";
+  const totalSec = Math.floor(ms / 1000);
+  if (totalSec < 60) return `${totalSec}s`;
+  const mins = Math.floor(totalSec / 60);
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.floor(mins / 60);
+  const rem = mins % 60;
+  return rem > 0 ? `${hrs}h${rem}m` : `${hrs}h`;
+}
+```
+
+- [ ] **Step 2: Verify syntax**
+
+```bash
+node -c hooks/tonone-statusline.js
+```
+
+Expected: no output (syntax ok) — this will fail because the bottom half still references removed functions. That's fine, we're replacing it in the next tasks.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add hooks/tonone-statusline.js
+git commit -m "feat(statusline): rewrite helpers — fmtDir, static fmtCost/fmtDuration, drop tokens formatter"
+```
+
+---
+
+### Task 3: Rewrite statusline — subagent reader, pace bridge, and pace computation
+
+**Files:**
+- Modify: `hooks/tonone-statusline.js:106-172` (replace old subagent reader, context bar, and rate limit renderer)
+
+- [ ] **Step 1: Replace lines 106-172 (old subagent reader, context bar, rate limit) with new sections**
+
+Replace everything from the `// ── Subagent bridge` comment through the end of `renderRateLimit` with:
+
+```javascript
+// ── Subagent bridge ──────────────────────────────────────────────────────────
+
+function readSubagents(sessionId) {
+  if (!sessionId || /[/\\]|\.\./.test(sessionId)) return [];
+  try {
+    const bridgePath = path.join(
+      os.tmpdir(),
+      `tonone-agents-${sessionId}.json`,
+    );
+    const data = JSON.parse(fs.readFileSync(bridgePath, "utf8"));
+    const cutoff = Date.now() - 300_000;
+    return (data.agents || []).filter((a) => a.started > cutoff && !a.finished);
+  } catch {
+    return [];
+  }
+}
+
+// ── Pace bridge ──────────────────────────────────────────────────────────────
+
+function readOrCreatePaceBridge(sessionId, fiveHourPct, sevenDayPct) {
+  if (!sessionId || /[/\\]|\.\./.test(sessionId)) return null;
+  const bridgePath = path.join(os.tmpdir(), `tonone-pace-${sessionId}.json`);
+  try {
+    const data = JSON.parse(fs.readFileSync(bridgePath, "utf8"));
+    if (data.session_id === sessionId) {
+      // Window reset during session — burn went negative, re-initialize
+      const fiveReset =
+        fiveHourPct != null && fiveHourPct < data.start_5h_pct;
+      const sevenReset =
+        sevenDayPct != null && sevenDayPct < data.start_7d_pct;
+      if (!fiveReset && !sevenReset) return data;
+    }
+  } catch {}
+  // Create fresh bridge file
+  const bridge = {
+    session_id: sessionId,
+    start_time: Date.now(),
+    start_5h_pct: fiveHourPct || 0,
+    start_7d_pct: sevenDayPct || 0,
+  };
+  try {
+    const tmpPath = bridgePath + ".tmp." + process.pid;
+    fs.writeFileSync(tmpPath, JSON.stringify(bridge));
+    fs.renameSync(tmpPath, bridgePath);
+  } catch {}
+  return bridge;
+}
+
+// ── Pace computation ─────────────────────────────────────────────────────────
+
+function computePace(currentPct, startPct, startTime, resetsAt) {
+  const now = Date.now();
+  const sessionElapsedHours = (now - startTime) / 3_600_000;
+
+  // Not enough data yet (< 2 minutes)
+  if (sessionElapsedHours < 2 / 60) {
+    return { verdict: "--", color: c.dim, multiplier: null };
+  }
+
+  // Missing or past reset time
+  if (!resetsAt) {
+    return { verdict: "--", color: c.dim, multiplier: null };
+  }
+  const resetsAtMs = new Date(resetsAt).getTime();
+  const timeRemainingHours = (resetsAtMs - now) / 3_600_000;
+  if (timeRemainingHours <= 0) {
+    return { verdict: "--", color: c.dim, multiplier: null };
+  }
+
+  const sessionBurn = Math.max(0, currentPct - startPct);
+  const burnRate = sessionBurn / sessionElapsedHours;
+
+  // Zero burn — session hasn't consumed any of this window
+  if (burnRate === 0) {
+    return { verdict: "ok", color: c.green, multiplier: 0.0 };
+  }
+
+  const projectedAdditional = burnRate * timeRemainingHours;
+  const projectedTotal = currentPct + projectedAdditional;
+
+  const safeRate = (100 - currentPct) / timeRemainingHours;
+  const multiplier = safeRate > 0 ? burnRate / safeRate : 99.9;
+
+  if (projectedTotal <= 80) {
+    return { verdict: "ok", color: c.green, multiplier };
+  }
+  if (projectedTotal <= 100) {
+    return { verdict: "tight", color: c.yellow, multiplier };
+  }
+
+  // Will overshoot — show time to impact
+  const hoursToImpact = (100 - currentPct) / burnRate;
+  const minsToImpact = Math.round(hoursToImpact * 60);
+  const timeStr =
+    minsToImpact >= 60
+      ? `~${Math.floor(minsToImpact / 60)}h`
+      : `~${minsToImpact}m`;
+  return { verdict: timeStr, color: c.red, multiplier };
+}
+
+function renderPace(label, currentPct, startPct, startTime, resetsAt) {
+  if (currentPct == null) {
+    return `${c.dim}${label}: 0% --${c.reset}`;
+  }
+  const pct = Math.round(currentPct);
+  const pace = computePace(currentPct, startPct, startTime, resetsAt);
+  if (pace.multiplier == null) {
+    return `${c.dim}${label}: ${pct}% --${c.reset}`;
+  }
+  const mulStr = `${pace.multiplier.toFixed(1)}\u00d7`;
+  return `${pace.color}${label}: ${pct}% ${pace.verdict} ${mulStr}${c.reset}`;
+}
+
+// ── Context bar ──────────────────────────────────────────────────────────────
+
+function renderContextBar(remaining) {
+  const EMPTY_BAR = "\u2591".repeat(10);
+  if (remaining == null) {
+    return `${c.dim}${EMPTY_BAR} 100%${c.reset}`;
+  }
+  const AUTO_COMPACT_BUFFER_PCT = 16.5;
+  const usableRemaining = Math.max(
+    0,
+    ((remaining - AUTO_COMPACT_BUFFER_PCT) / (100 - AUTO_COMPACT_BUFFER_PCT)) *
+      100,
+  );
+  const used = Math.max(0, Math.min(100, Math.round(100 - usableRemaining)));
+  const pctLeft = 100 - used;
+
+  const filled = Math.floor(used / 10);
+  const bar = "\u2588".repeat(filled) + "\u2591".repeat(10 - filled);
+
+  let warning = "";
+  let color;
+  if (pctLeft > 50) {
+    color = c.green;
+  } else if (pctLeft > 25) {
+    color = c.yellow;
+  } else if (pctLeft > 10) {
+    color = c.red;
+  } else {
+    color = `${c.blink}${c.red}`;
+    warning = " compact soon";
+  }
+  return `${color}${bar} ${pctLeft}%${warning}${c.reset}`;
+}
+
+// ── Model display ────────────────────────────────────────────────────────────
+
+function renderModel(mainDisplayName, activeSubagents) {
+  const name = mainDisplayName || "unknown";
+  const mainLower = name.toLowerCase();
+
+  // Collect unique sub models that differ from the main model
+  const subModels = [
+    ...new Set(
+      activeSubagents
+        .map((a) => a.model)
+        .filter((m) => m && !mainLower.includes(m.toLowerCase())),
+    ),
+  ];
+
+  if (subModels.length === 0) {
+    return `${c.dimWhite}${name}${c.reset}`;
+  }
+
+  // Capitalize sub model names, e.g. "sonnet" → "Sonnet"
+  const subStr = subModels
+    .map((m) => m.charAt(0).toUpperCase() + m.slice(1))
+    .join(", ");
+  // Shorten main to first word, e.g. "Opus 4.6" → "Opus"
+  const mainShort = name.split(" ")[0];
+  return `${c.dimWhite}${mainShort} ${c.dim}\u2192${c.reset} ${c.dimWhite}${subStr}${c.reset}`;
+}
+```
+
+- [ ] **Step 2: Verify syntax**
+
+```bash
+node -c hooks/tonone-statusline.js
+```
+
+Expected: still fails (render function not yet replaced). That's expected.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add hooks/tonone-statusline.js
+git commit -m "feat(statusline): add pace bridge, pace computation, model display, rewrite subagent reader"
+```
+
+---
+
+### Task 4: Rewrite statusline — render function and stdin reader
+
+**Files:**
+- Modify: `hooks/tonone-statusline.js:174-311` (replace old render function and stdin reader)
+
+- [ ] **Step 1: Replace everything from `// ── Main render` to end of file with new render function**
+
+Replace from line 174 (`// ── Main render`) through line 311 (end of file) with:
+
+```javascript
+// ── Main render ──────────────────────────────────────────────────────────────
+
+function render(data) {
+  const cwd = data.workspace?.current_dir || process.cwd();
+  const session = data.session_id || "";
+
+  // ── Line 1: Location & Git ──────────────────────────────────────────────
+  const dir = fmtDir(cwd);
+  const branch = gitBranch(cwd);
+  const ahead = gitAhead(cwd);
+  const dirty = gitDirtyCount(cwd);
+  const added = data.cost?.total_lines_added || 0;
+  const removed = data.cost?.total_lines_removed || 0;
+
+  const dirStr = `${c.dimWhite}${dir}${c.reset}`;
+
+  let branchStr = branch
+    ? `${c.cyan}${branch}${c.reset}`
+    : `${c.dim}no branch${c.reset}`;
+  if (branch && ahead > 0) {
+    branchStr += ` ${c.green}\u2191${ahead}${c.reset}`;
+  }
+
+  const dirtyStr =
+    dirty > 0
+      ? `${c.yellow}${dirty} dirty${c.reset}`
+      : `${c.dim}clean${c.reset}`;
+
+  const linesStr =
+    added > 0 || removed > 0
+      ? `${c.green}+${added}${c.reset} ${c.red}-${removed}${c.reset} ${c.dim}lines${c.reset}`
+      : `${c.dim}+0 -0 lines${c.reset}`;
+
+  const line1 = [dirStr, branchStr, dirtyStr, linesStr].join(SEP);
+
+  // ── Line 2: Session Activity ────────────────────────────────────────────
+  const agentName = data.agent?.name;
+  const subagents = readSubagents(session);
+
+  const agentStr = agentName
+    ? `${c.magenta}${c.bold}${agentName}${c.reset}`
+    : `${c.dim}idle${c.reset}`;
+
+  let subsStr;
+  if (subagents.length === 0) {
+    subsStr = `${c.dim}no subs${c.reset}`;
+  } else if (subagents.length <= 3) {
+    const names = subagents
+      .map((a) => (a.desc || "agent").slice(0, 20))
+      .join(", ");
+    subsStr = `${c.magenta}subs: ${names}${c.reset}`;
+  } else {
+    const names = subagents
+      .slice(0, 2)
+      .map((a) => (a.desc || "agent").slice(0, 20))
+      .join(", ");
+    subsStr = `${c.magenta}subs: ${names}, +${subagents.length - 2} more${c.reset}`;
+  }
+
+  const costVal = data.cost?.total_cost_usd || 0;
+  let costColor = c.dimWhite;
+  if (costVal > 5) costColor = c.red;
+  else if (costVal > 1) costColor = c.yellow;
+  const costStr = `${costColor}${fmtCost(costVal)}${c.reset}`;
+
+  const durStr = `${c.dimWhite}${fmtDuration(data.cost?.total_duration_ms)}${c.reset}`;
+
+  const line2 = [agentStr, subsStr, costStr, durStr].join(SEP);
+
+  // ── Line 3: Model & Runway ──────────────────────────────────────────────
+  const modelStr = renderModel(data.model?.display_name, subagents);
+  const ctxBar = renderContextBar(data.context_window?.remaining_percentage);
+
+  const fiveH = data.rate_limits?.five_hour;
+  const sevenD = data.rate_limits?.seven_day;
+  const paceBridge = readOrCreatePaceBridge(
+    session,
+    fiveH?.used_percentage,
+    sevenD?.used_percentage,
+  );
+  const startTime = paceBridge?.start_time || Date.now();
+
+  const fiveHStr = renderPace(
+    "5h",
+    fiveH?.used_percentage,
+    paceBridge?.start_5h_pct || 0,
+    startTime,
+    fiveH?.resets_at,
+  );
+
+  const sevenDStr = renderPace(
+    "7d",
+    sevenD?.used_percentage,
+    paceBridge?.start_7d_pct || 0,
+    startTime,
+    sevenD?.resets_at,
+  );
+
+  const line3 = [modelStr, ctxBar, fiveHStr, sevenDStr].join(SEP);
+
+  return `${line1}\n${line2}\n${line3}`;
+}
+
+// ── Stdin reader with 3s timeout guard ───────────────────────────────────────
+
+let input = "";
+const stdinTimeout = setTimeout(() => process.exit(0), 3000);
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  input += chunk;
+});
+process.stdin.on("end", () => {
+  clearTimeout(stdinTimeout);
+  try {
+    const data = JSON.parse(input);
+    process.stdout.write(render(data));
+  } catch (e) {}
+});
+```
+
+- [ ] **Step 2: Verify full file parses**
+
+```bash
+node -c hooks/tonone-statusline.js
+```
+
+Expected: no output (clean parse).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add hooks/tonone-statusline.js
+git commit -m "feat(statusline): 3-line render — location/git, session, model/runway with pace"
+```
+
+---
+
+### Task 5: Create test runner and verify all 7 states
+
+**Files:**
+- Create: `hooks/test-statusline.sh`
+
+- [ ] **Step 1: Create the test script**
+
+Create `hooks/test-statusline.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Test statusline rendering with JSON fixtures piped to stdin.
+# Usage: bash hooks/test-statusline.sh
+set -euo pipefail
+
+SCRIPT="hooks/tonone-statusline.js"
+PASS=0
+FAIL=0
+
+run_test() {
+  local name="$1"
+  local json="$2"
+  shift 2
+  local expected=("$@")
+
+  echo "── $name ──"
+  local output
+  output=$(echo "$json" | node "$SCRIPT" 2>/dev/null) || true
+  echo "$output"
+  echo ""
+
+  local ok=true
+  for pattern in "${expected[@]}"; do
+    # Strip ANSI codes for matching
+    local stripped
+    stripped=$(echo "$output" | sed 's/\x1b\[[0-9;]*m//g')
+    if ! echo "$stripped" | grep -qF "$pattern"; then
+      echo "  FAIL: expected '$pattern' not found"
+      ok=false
+    fi
+  done
+
+  if $ok; then
+    echo "  PASS"
+    ((PASS++))
+  else
+    ((FAIL++))
+  fi
+  echo ""
+}
+
+# State 1: Fresh session
+run_test "Fresh session" '{
+  "session_id": "test-fresh",
+  "workspace": {"current_dir": "'"$HOME"'/repos/tn/tonone"},
+  "model": {"display_name": "Opus 4.6"},
+  "cost": {}
+}' \
+  "~/repos/tn/tonone" \
+  "clean" \
+  "+0 -0 lines" \
+  "idle" \
+  "no subs" \
+  '$0.00' \
+  "0m" \
+  "Opus 4.6" \
+  "5h: 0% --" \
+  "7d: 0% --"
+
+# State 2: Active session with agent (no subs)
+run_test "Active session, no subs" '{
+  "session_id": "test-active",
+  "workspace": {"current_dir": "'"$HOME"'/repos/tn/tonone"},
+  "agent": {"name": "spine"},
+  "model": {"display_name": "Opus 4.6"},
+  "cost": {"total_cost_usd": 0.38, "total_duration_ms": 1380000, "total_lines_added": 156, "total_lines_removed": 23},
+  "context_window": {"remaining_percentage": 60},
+  "rate_limits": {
+    "five_hour": {"used_percentage": 24, "resets_at": "'"$(date -u -v+3H +%Y-%m-%dT%H:%M:%SZ)"'"},
+    "seven_day": {"used_percentage": 41, "resets_at": "'"$(date -u -v+4d +%Y-%m-%dT%H:%M:%SZ)"'"}
+  }
+}' \
+  "~/repos/tn/tonone" \
+  "spine" \
+  "no subs" \
+  '$0.38' \
+  "23m" \
+  "+156" \
+  "-23" \
+  "lines" \
+  "Opus 4.6" \
+  "5h: 24%" \
+  "7d: 41%"
+
+# State 3: Warning state (high usage)
+run_test "Warning state" '{
+  "session_id": "test-warn",
+  "workspace": {"current_dir": "'"$HOME"'/repos/tn/tonone"},
+  "agent": {"name": "spine"},
+  "model": {"display_name": "Opus 4.6"},
+  "cost": {"total_cost_usd": 6.20, "total_duration_ms": 2880000, "total_lines_added": 420, "total_lines_removed": 87},
+  "context_window": {"remaining_percentage": 30},
+  "rate_limits": {
+    "five_hour": {"used_percentage": 82, "resets_at": "'"$(date -u -v+2H +%Y-%m-%dT%H:%M:%SZ)"'"},
+    "seven_day": {"used_percentage": 68, "resets_at": "'"$(date -u -v+3d +%Y-%m-%dT%H:%M:%SZ)"'"}
+  }
+}' \
+  "spine" \
+  '$6.20' \
+  "48m" \
+  "+420" \
+  "-87" \
+  "5h: 82%" \
+  "7d: 68%"
+
+# State 4: Critical state (context almost gone)
+run_test "Critical state" '{
+  "session_id": "test-critical",
+  "workspace": {"current_dir": "'"$HOME"'/repos/tn/tonone"},
+  "agent": {"name": "spine"},
+  "model": {"display_name": "Opus 4.6"},
+  "cost": {"total_cost_usd": 8.40, "total_duration_ms": 4320000, "total_lines_added": 520, "total_lines_removed": 110},
+  "context_window": {"remaining_percentage": 18},
+  "rate_limits": {
+    "five_hour": {"used_percentage": 92, "resets_at": "'"$(date -u -v+1H +%Y-%m-%dT%H:%M:%SZ)"'"},
+    "seven_day": {"used_percentage": 78, "resets_at": "'"$(date -u -v+2d +%Y-%m-%dT%H:%M:%SZ)"'"}
+  }
+}' \
+  "spine" \
+  '$8.40' \
+  "1h12m" \
+  "compact soon" \
+  "5h: 92%" \
+  "7d: 78%"
+
+# State 5: Active session with subs on different model
+# Pre-populate the agent bridge file so readSubagents finds active subs
+AGENT_BRIDGE="$TMPDIR/tonone-agents-test-subs.json"
+NOW_MS=$(node -e "process.stdout.write(String(Date.now()))")
+cat > "$AGENT_BRIDGE" <<AGENT_EOF
+{"agents":[
+  {"id":"a1","desc":"audit pipeline","model":"sonnet","started":${NOW_MS},"finished":null},
+  {"id":"a2","desc":"check deps","model":"sonnet","started":${NOW_MS},"finished":null}
+]}
+AGENT_EOF
+
+run_test "Subs on different model" '{
+  "session_id": "test-subs",
+  "workspace": {"current_dir": "'"$HOME"'/repos/tn/tonone"},
+  "agent": {"name": "apex"},
+  "model": {"display_name": "Opus 4.6"},
+  "cost": {"total_cost_usd": 1.50, "total_duration_ms": 900000, "total_lines_added": 80, "total_lines_removed": 12},
+  "context_window": {"remaining_percentage": 55},
+  "rate_limits": {
+    "five_hour": {"used_percentage": 35, "resets_at": "'"$(date -u -v+4H +%Y-%m-%dT%H:%M:%SZ)"'"},
+    "seven_day": {"used_percentage": 20, "resets_at": "'"$(date -u -v+5d +%Y-%m-%dT%H:%M:%SZ)"'"}
+  }
+}' \
+  "apex" \
+  "subs: audit pipeline, check deps" \
+  "Opus" \
+  "Sonnet" \
+  '$1.50' \
+  "15m"
+
+rm -f "$AGENT_BRIDGE"
+
+# State 6: Window reset during session (pace bridge re-initialization)
+# Pre-populate pace bridge with start_5h_pct HIGHER than current — simulates window reset
+PACE_BRIDGE="$TMPDIR/tonone-pace-test-reset.json"
+cat > "$PACE_BRIDGE" <<PACE_EOF
+{"session_id":"test-reset","start_time":${NOW_MS},"start_5h_pct":60.0,"start_7d_pct":50.0}
+PACE_EOF
+
+run_test "Window reset during session" '{
+  "session_id": "test-reset",
+  "workspace": {"current_dir": "'"$HOME"'/repos/tn/tonone"},
+  "model": {"display_name": "Opus 4.6"},
+  "cost": {"total_duration_ms": 600000},
+  "rate_limits": {
+    "five_hour": {"used_percentage": 5, "resets_at": "'"$(date -u -v+5H +%Y-%m-%dT%H:%M:%SZ)"'"},
+    "seven_day": {"used_percentage": 10, "resets_at": "'"$(date -u -v+7d +%Y-%m-%dT%H:%M:%SZ)"'"}
+  }
+}' \
+  "5h: 5%" \
+  "7d: 10%"
+
+rm -f "$PACE_BRIDGE"
+
+# State 7: Long directory path (truncation)
+run_test "Long directory path" '{
+  "session_id": "test-longdir",
+  "workspace": {"current_dir": "'"$HOME"'/very/deeply/nested/project/directory/structure/src"},
+  "model": {"display_name": "Opus 4.6"},
+  "cost": {}
+}' \
+  "idle" \
+  "no subs" \
+  "Opus 4.6"
+
+# State 8: No rate limit data
+run_test "No rate limits" '{
+  "session_id": "test-norate",
+  "workspace": {"current_dir": "'"$HOME"'/repos/tn/tonone"},
+  "model": {"display_name": "Sonnet 4.6"},
+  "cost": {"total_cost_usd": 0.05, "total_duration_ms": 120000}
+}' \
+  "Sonnet 4.6" \
+  '$0.05' \
+  "5h: 0% --" \
+  "7d: 0% --"
+
+echo "═══════════════════════════"
+echo "Results: $PASS passed, $FAIL failed"
+echo "═══════════════════════════"
+
+[ "$FAIL" -eq 0 ] || exit 1
+```
+
+- [ ] **Step 2: Run the test script**
+
+```bash
+bash hooks/test-statusline.sh
+```
+
+Expected: All tests pass. Each test prints the rendered statusline (with ANSI colors visible) and checks that key strings appear in the output.
+
+- [ ] **Step 3: Fix any failures**
+
+If any test fails, check the `FAIL: expected '...' not found` output, read the relevant section of `hooks/tonone-statusline.js`, and fix.
+
+- [ ] **Step 4: Verify the 3-line structure**
+
+```bash
+echo '{"session_id":"x","workspace":{"current_dir":"'"$HOME"'/repos/tn/tonone"},"model":{"display_name":"Opus 4.6"},"cost":{}}' | node hooks/tonone-statusline.js | wc -l
+```
+
+Expected: `3` (three lines of output).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hooks/test-statusline.sh hooks/tonone-statusline.js
+git commit -m "test(statusline): add test runner, verify all 7 states"
+```
+
+---
+
+### Task 6: Final cleanup and integration commit
+
+- [ ] **Step 1: Verify the full statusline script parses cleanly**
+
+```bash
+node -c hooks/tonone-statusline.js && echo "OK"
+```
+
+Expected: `OK`
+
+- [ ] **Step 2: Run tests one final time**
+
+```bash
+bash hooks/test-statusline.sh
+```
+
+Expected: All pass.
+
+- [ ] **Step 3: Verify no leftover references to removed features**
+
+Check that old symbols (◆, ▲, ⊕, ◎), `fmtTokens`, `renderRateLimit`, and `readSubagentCount` are gone:
+
+```bash
+grep -nE '\\u25c6|\\u25b2|\\u2295|\\u25ce|fmtTokens|renderRateLimit|readSubagentCount' hooks/tonone-statusline.js
+```
+
+Expected: no output (no matches).
+
+- [ ] **Step 4: Confirm line count is reasonable**
+
+```bash
+wc -l hooks/tonone-statusline.js
+```
+
+Expected: ~280-320 lines (similar to before, reorganized).
+
+- [ ] **Step 5: Squash into feature commit if desired, or leave as incremental commits**
+
+The incremental commits from Tasks 1-5 tell a clean story. No squash needed unless preferred.

--- a/docs/superpowers/specs/2026-04-12-elephant-memory-design.md
+++ b/docs/superpowers/specs/2026-04-12-elephant-memory-design.md
@@ -1,0 +1,169 @@
+# Elephant — Persistent Memory System for tonone
+
+## Overview
+
+Persistent memory system. Auto-captures agent work, commits, skill runs. Manual entries for decisions. Caveman-compressed text. Startup recall block shows smart summary. Never deletes — compresses old routine entries.
+
+## File Layout
+
+```
+# Local (per repo)
+.elephant/
+└── memory.md
+
+# Global (cross-repo feed)
+~/.claude/elephant/
+└── memory.md
+```
+
+## Entry Format
+
+**Local `memory.md`:**
+```
+[!!] 2026-04-12 14:30 : chose JWT over sessions — stateless API need
+2026-04-12 14:45 : spine build auth API + 12 endpoints. tests pass.
+2026-04-12 15:10 : relay deploy staging done.
+2026-04-11 09:20 : proof write 42 tests. coverage 87%.
+```
+
+**Global `memory.md`:**
+```
+[!!] 2026-04-12 14:30 : tonone : chose JWT over sessions — stateless API need
+2026-04-12 14:45 : tonone : spine build auth API + 12 endpoints. tests pass.
+2026-04-12 16:00 : billing-app : fix webhook retry logic.
+```
+
+**Format rules:**
+- Local: `[!!]? YYYY-MM-DD HH:MM : text`
+- Global: `[!!]? YYYY-MM-DD HH:MM : repo : text`
+- `[!!]` prefix = important, never compress
+- No prefix = routine, eligible for compression
+- All text in caveman-compressed style (drop articles, fragments OK, short synonyms)
+- Newest entries on top
+
+## Writing to Memory
+
+### Auto-capture (hooks)
+
+Hook script: `hooks/elephant-writer.js`
+
+Triggers via PostToolUse hook on these events:
+
+| Event | Hook Matcher | Example Entry |
+|-------|-------------|---------------|
+| Agent completes | `Agent` | `spine build auth API. 12 endpoints.` |
+| Commit created | `Bash` (matches git commit) | `commit: add JWT auth middleware` |
+| Skill finishes | `Skill` | `ran /ship — PR #42 created` |
+
+**Hook flow:**
+1. Read tool result from stdin JSON (same pattern as existing `tonone-agent-tracker.js`)
+2. Compress description to caveman style (drop articles, truncate, short synonyms)
+3. Prepend line to local `.elephant/memory.md`
+4. Prepend line with repo name to global `~/.claude/elephant/memory.md`
+5. Create directories if they don't exist
+
+**Caveman compression in the hook (lightweight rules):**
+- Drop: a, an, the, just, really, basically, actually, simply
+- Drop: "I've", "I'll", "we've", "we'll", "it's been"
+- Shorten: "implemented" → "build", "successfully" → drop, "completed" → "done"
+- Truncate to ~100 chars max per entry
+- Preserve: code refs, file paths, numbers, proper nouns
+
+### Manual entries
+
+Skill: `/elephant`
+
+| Command | Action |
+|---------|--------|
+| `/elephant save <text>` | Write routine entry |
+| `/elephant save !! <text>` | Write important entry |
+| `/elephant show` | Print current memory contents |
+| `/elephant compact` | Compress old routine entries |
+
+## Startup Recall
+
+Hook script: `hooks/elephant-recall.js`
+
+Runs on SessionStart. Reads both memory files, builds smart summary, outputs as hook additional context.
+
+**Summary logic:**
+- Today's entries — show in full
+- Last 7 days — show in full, capped at 10 lines
+- Older than 7 days — only show `[!!]` entries
+- Other repos (from global) — last 3 entries max, one-liner each
+- Total block capped at 15 lines max
+
+**Output format:**
+```
+🐘 ELEPHANT RECALL
+├ [!!] 2026-04-12 14:30 : chose JWT over sessions — stateless API need
+├ 2026-04-12 14:45 : spine build auth API + 12 endpoints. tests pass.
+├ 2026-04-12 15:10 : relay deploy staging done.
+├ 2026-04-11 09:20 : proof write 42 tests. coverage 87%.
+├ ── other repos ──
+├ billing-app : fix webhook retry logic (04-12)
+└ 6 entries total │ 2 important │ oldest: 2026-04-05
+```
+
+**Empty state:**
+```
+🐘 ELEPHANT RECALL
+└ nothing yet. use /elephant save to start remembering.
+```
+
+**Style:** Box-drawing lines per tonone output-kit. Footer with counts.
+
+## Compression (`/elephant compact`)
+
+Merges old routine entries to save space:
+- Entries older than 7 days without `[!!]` get merged
+- Multiple entries from same day collapse into one line
+- Example: 3 entries from 04-05 → `2026-04-05 : spine auth + proof 42 tests + relay staging deploy`
+- `[!!]` entries never touched regardless of age
+- Applies to both local and global memory files
+
+## Hook Registration
+
+Added to `.claude-plugin/plugin.json` hooks:
+
+```json
+{
+  "SessionStart": [
+    { "hooks": [{ "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/elephant-recall.js\"" }] }
+  ],
+  "PostToolUse": [
+    { "matcher": "Agent", "hooks": [{ "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/elephant-writer.js\"", "timeout": 5 }] },
+    { "matcher": "Bash", "hooks": [{ "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/elephant-writer.js\"", "timeout": 5 }] },
+    { "matcher": "Skill", "hooks": [{ "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/elephant-writer.js\"", "timeout": 5 }] }
+  ]
+}
+```
+
+**Filtering logic inside `elephant-writer.js`:**
+- `Agent` matcher: always capture. Extract description from agent result.
+- `Bash` matcher: only capture if command contains `git commit`. Ignore all other Bash calls.
+- `Skill` matcher: always capture. Extract skill name from tool input.
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `hooks/elephant-recall.js` | SessionStart hook — reads memory, renders recap block |
+| `hooks/elephant-writer.js` | PostToolUse hook — auto-captures entries to both files |
+| `skills/elephant/SKILL.md` | Skill definition for manual commands |
+| `skills/elephant/.claude-plugin/plugin.json` | Plugin manifest for the skill |
+| `.elephant/.gitignore` | Ignore `memory.md` (local memory is per-machine) |
+
+## Integration with Existing Hooks
+
+- `elephant-recall.js` runs alongside `install-statusline.sh` on SessionStart
+- `elephant-writer.js` runs alongside `tonone-agent-tracker.js` on PostToolUse (Agent)
+- No conflicts — each hook reads stdin independently, writes to different files
+- Timeout of 5s per hook call (same as agent-tracker)
+
+## Repo Detection for Global Memory
+
+The writer hook determines repo name from:
+1. `cwd` field in stdin JSON
+2. Extract last path component (e.g., `/Users/f/repos/tn/tonone` → `tonone`)
+3. Use as repo identifier in global memory entries

--- a/docs/superpowers/specs/2026-04-12-statusline-redesign.md
+++ b/docs/superpowers/specs/2026-04-12-statusline-redesign.md
@@ -1,0 +1,184 @@
+# Statusline Redesign Spec
+
+Three-line CLI status bar for Claude Code sessions. Replaces the current two-line design that suffers from symbol soup, cognitive overload, and layout instability.
+
+## Layout
+
+Three lines, grouped by mental model:
+
+```
+Line 1  ~/repos/tn/tonone │ main ↑3 │ 2 dirty │ +156 -23 lines
+Line 2  spine │ subs: audit pipeline, check deps │ $0.38 │ 23m
+Line 3  Opus → Sonnet │ ████░░░░░░ 48% │ 5h: 24% ok 0.6× │ 7d: 41% ok 0.8×
+```
+
+| Line | Theme | Segments |
+|------|-------|----------|
+| 1 | **Where** — location & code state | directory, branch + ahead, dirty count, lines changed |
+| 2 | **What** — session activity | agent + subs, cost, duration |
+| 3 | **How much left** — runway gauges | model(s), context window, 5h pace, 7d pace |
+
+## Static Fields
+
+All segments are always visible. No progressive disclosure. When a value is zero or unavailable, show a dim placeholder instead of hiding the segment:
+
+| Segment | Active | Empty/Zero |
+|---------|--------|------------|
+| Directory | `~/repos/tn/tonone` | always present (from cwd) |
+| Branch | `main ↑3` | `main` (no ↑ when 0) |
+| Dirty | `2 dirty` (yellow) | `clean` (dim) |
+| Lines | `+156 -23 lines` (green/red) | `+0 -0 lines` (dim) |
+| Agent | `spine` (magenta bold) | `idle` (dim) |
+| Subs | `subs: audit, recon` (magenta) | `no subs` (dim) |
+| Cost | `$0.38` | `$0.00` (dim) |
+| Duration | `23m` | `0m` (dim) |
+| Model | `Opus → Sonnet` | `Opus 4.6` (just main, no arrow) |
+| Context bar | `████░░░░░░ 48%` | `░░░░░░░░░░ 100%` (dim) |
+| 5h pace | `5h: 24% ok 0.6×` | `5h: 0% --` (dim) |
+| 7d pace | `7d: 41% ok 0.8×` | `7d: 0% --` (dim) |
+
+## Segment Details
+
+### Line 1: Location & Git
+
+1. **Working directory** — `data.workspace.current_dir`. Replace `$HOME` prefix with `~`. If the result exceeds 40 characters, truncate from the left with `…/` prefix (e.g., `…/tn/tonone`). Dim white.
+2. **Branch + ahead** — `git rev-parse --abbrev-ref HEAD` + `git rev-list --count @{u}..HEAD`. Branch in cyan, `↑N` in green. Omit `↑` entirely when 0 (no dim placeholder for this sub-element — branch name alone is stable enough).
+3. **Dirty count** — `git status --porcelain` line count. Yellow `N dirty` when >0, dim `clean` when 0.
+4. **Lines changed** — `data.cost.total_lines_added` / `total_lines_removed`. Green `+N`, red `-N`, dim label `lines`. All dim when both are 0.
+
+### Line 2: Session Activity
+
+1. **Agent name** — `data.agent.name`. Magenta bold when active, dim `idle` when none.
+2. **Subagent list** — Read from bridge file `/tmp/tonone-agents-{session}.json`. Show active agent descriptions (truncated to 20 chars each). Format: `subs: desc1, desc2`. If >3 active: `subs: desc1, desc2, +N more`. Dim `no subs` when none. Magenta color. Also track `model` field in bridge file for Line 3 display.
+3. **Session cost** — `data.cost.total_cost_usd`. Dim white normally, yellow >$1, red >$5.
+4. **Session duration** — `data.cost.total_duration_ms`. Formats: `0m`, `23m`, `1h12m`. Dim white.
+
+### Line 3: Model & Runway
+
+1. **Model display** — `data.model.display_name` for main model. When subagents are active on a different model (read from bridge file), show `Main → Sub` (e.g., `Opus → Sonnet`). If subs use multiple different models: `Opus → Sonnet, Haiku`. When no subs or all subs on same model as main: just `Opus 4.6`. Dim white, arrow dim.
+2. **Context window bar** — `data.context_window.remaining_percentage`. 10-block meter. Color escalation: green >50%, yellow >25%, red >10%, blinking red ≤10%. Append `compact soon` text at ≤10%.
+3. **5-hour pace** — `data.rate_limits.five_hour`. Format: `5h: N% verdict X.X×`. See Pace Calculation below.
+4. **7-day pace** — `data.rate_limits.seven_day`. Same format: `7d: N% verdict X.X×`.
+
+## Pace Calculation
+
+### Bridge File
+
+New file: `/tmp/tonone-pace-{session}.json`
+
+Created by the statusline script itself (not a separate hook) on first render for a session. Format:
+
+```json
+{
+  "session_id": "abc123",
+  "start_time": 1712959264000,
+  "start_5h_pct": 18.0,
+  "start_7d_pct": 35.0
+}
+```
+
+### Algorithm
+
+For each rate limit window (5h and 7d):
+
+```
+session_elapsed_hours = (now - start_time) / 3_600_000
+session_burn = current_pct - start_pct
+burn_rate = session_burn / session_elapsed_hours    (% per hour)
+
+time_remaining_hours = (resets_at - now) / 3_600_000
+projected_additional = burn_rate * time_remaining_hours
+projected_total = current_pct + projected_additional
+
+pace_multiplier = burn_rate / safe_rate
+  where safe_rate = (100 - current_pct) / time_remaining_hours
+```
+
+### Verdict Logic
+
+| Condition | Verdict | Color |
+|-----------|---------|-------|
+| Session < 2 minutes | `--` | dim |
+| `projected_total ≤ 80` | `ok` | green |
+| `projected_total ≤ 100` | `tight` | yellow |
+| `projected_total > 100` | `~Xm` or `~Xh` (time to impact) | red |
+
+Time to impact = `(100 - current_pct) / burn_rate`, formatted as minutes or hours.
+
+Pace multiplier always shown next to verdict: `ok 0.6×`, `tight 1.4×`, `~18m 2.1×`. Same color as verdict.
+
+### Edge Cases
+
+- `burn_rate = 0` (session hasn't consumed any of this window): show `ok 0.0×` in green
+- `resets_at` missing or past: show `--` dim
+- `session_burn < 0` (window reset during session, start_pct was from old window): re-initialize bridge file with current values
+- Bridge file missing or corrupt: create fresh one, show `--` for first render
+
+## Agent Tracker Changes
+
+The existing `tonone-agent-tracker.js` bridge file needs a `model` field added to each agent entry:
+
+```json
+{
+  "agents": [
+    {
+      "id": "agentId",
+      "desc": "audit pipeline",
+      "model": "sonnet",
+      "started": 1712959264000,
+      "finished": null
+    }
+  ]
+}
+```
+
+Source: `data.tool_input.model` from the Agent tool call (falls back to `null` if not specified, meaning same as parent model).
+
+## Colors
+
+| Element | ANSI | Code |
+|---------|------|------|
+| Directory | dim white | `\x1b[2;37m` |
+| Branch | cyan | `\x1b[36m` |
+| ↑N | green | `\x1b[32m` |
+| Dirty count | yellow | `\x1b[33m` |
+| "clean" | dim | `\x1b[2m` |
+| Lines +N | green | `\x1b[32m` |
+| Lines -N | red | `\x1b[31m` |
+| Agent name | magenta bold | `\x1b[35m\x1b[1m` |
+| Sub names | magenta | `\x1b[35m` |
+| "idle", "no subs" | dim | `\x1b[2m` |
+| Cost normal | dim white | `\x1b[2;37m` |
+| Cost >$1 | yellow | `\x1b[33m` |
+| Cost >$5 | red | `\x1b[31m` |
+| Duration | dim white | `\x1b[2;37m` |
+| Model names | dim white | `\x1b[2;37m` |
+| Arrow → | dim | `\x1b[2m` |
+| Context bar >50% | green | `\x1b[32m` |
+| Context bar >25% | yellow | `\x1b[33m` |
+| Context bar >10% | red | `\x1b[31m` |
+| Context bar ≤10% | blink red | `\x1b[5m\x1b[31m` |
+| Pace ok | green | `\x1b[32m` |
+| Pace tight | yellow | `\x1b[33m` |
+| Pace ~Xm | red | `\x1b[31m` |
+| Pace -- | dim | `\x1b[2m` |
+| Separators │ | dim | `\x1b[2m` |
+
+## Files Modified
+
+1. `hooks/tonone-statusline.js` — full rewrite of `render()` function
+2. `hooks/tonone-agent-tracker.js` — add `model` field from `tool_input.model`
+
+## Files Created
+
+None. Pace bridge file is written at runtime to `/tmp/`.
+
+## States to Test
+
+1. Fresh session (all fields at zero/empty)
+2. Active session with agent + subs on different model
+3. Active session, no agent running
+4. Warning state (context <25%, rate limit >70%)
+5. Critical state (context <10%, rate limit >90%, pace showing time to impact)
+6. Window reset during session (bridge file re-initialization)
+7. Very long directory path (truncation behavior)

--- a/hooks/test-statusline.sh
+++ b/hooks/test-statusline.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Test statusline rendering with JSON fixtures piped to stdin.
+# Usage: bash hooks/test-statusline.sh
+set -euo pipefail
+
+SCRIPT="hooks/tonone-statusline.js"
+PASS=0
+FAIL=0
+
+run_test() {
+  local name="$1"
+  local json="$2"
+  shift 2
+  local expected=("$@")
+
+  echo "── $name ──"
+  local output
+  output=$(echo "$json" | node "$SCRIPT" 2>/dev/null) || true
+  echo "$output"
+  echo ""
+
+  local ok=true
+  for pattern in "${expected[@]}"; do
+    # Strip ANSI codes for matching
+    local stripped
+    stripped=$(echo "$output" | sed 's/\x1b\[[0-9;]*m//g')
+    if ! echo "$stripped" | grep -qF -- "$pattern"; then
+      echo "  FAIL: expected '$pattern' not found"
+      ok=false
+    fi
+  done
+
+  if $ok; then
+    echo "  PASS"
+    ((PASS++))
+  else
+    ((FAIL++))
+  fi
+  echo ""
+}
+
+# State 1: Fresh session
+run_test "Fresh session" '{
+  "session_id": "test-fresh",
+  "workspace": {"current_dir": "'"$HOME"'/repos/tn/tonone"},
+  "model": {"display_name": "Opus 4.6"},
+  "cost": {}
+}' \
+  "~/repos/tn/tonone" \
+  "+0 -0 lines" \
+  "idle" \
+  "no subs" \
+  '$0.00' \
+  "0m" \
+  "Opus 4.6" \
+  "5h: 0% --" \
+  "7d: 0% --"
+
+# State 2: Active session with agent (no subs)
+run_test "Active session, no subs" '{
+  "session_id": "test-active",
+  "workspace": {"current_dir": "'"$HOME"'/repos/tn/tonone"},
+  "agent": {"name": "spine"},
+  "model": {"display_name": "Opus 4.6"},
+  "cost": {"total_cost_usd": 0.38, "total_duration_ms": 1380000, "total_lines_added": 156, "total_lines_removed": 23},
+  "context_window": {"remaining_percentage": 60},
+  "rate_limits": {
+    "five_hour": {"used_percentage": 24, "resets_at": "'"$(date -u -v+3H +%Y-%m-%dT%H:%M:%SZ)"'"},
+    "seven_day": {"used_percentage": 41, "resets_at": "'"$(date -u -v+4d +%Y-%m-%dT%H:%M:%SZ)"'"}
+  }
+}' \
+  "~/repos/tn/tonone" \
+  "spine" \
+  "no subs" \
+  '$0.38' \
+  "23m" \
+  "+156" \
+  "-23" \
+  "lines" \
+  "Opus 4.6" \
+  "5h: 24%" \
+  "7d: 41%"
+
+# State 3: Warning state (high usage)
+run_test "Warning state" '{
+  "session_id": "test-warn",
+  "workspace": {"current_dir": "'"$HOME"'/repos/tn/tonone"},
+  "agent": {"name": "spine"},
+  "model": {"display_name": "Opus 4.6"},
+  "cost": {"total_cost_usd": 6.20, "total_duration_ms": 2880000, "total_lines_added": 420, "total_lines_removed": 87},
+  "context_window": {"remaining_percentage": 30},
+  "rate_limits": {
+    "five_hour": {"used_percentage": 82, "resets_at": "'"$(date -u -v+2H +%Y-%m-%dT%H:%M:%SZ)"'"},
+    "seven_day": {"used_percentage": 68, "resets_at": "'"$(date -u -v+3d +%Y-%m-%dT%H:%M:%SZ)"'"}
+  }
+}' \
+  "spine" \
+  '$6.20' \
+  "48m" \
+  "+420" \
+  "-87" \
+  "5h: 82%" \
+  "7d: 68%"
+
+# State 4: Critical state (context almost gone)
+run_test "Critical state" '{
+  "session_id": "test-critical",
+  "workspace": {"current_dir": "'"$HOME"'/repos/tn/tonone"},
+  "agent": {"name": "spine"},
+  "model": {"display_name": "Opus 4.6"},
+  "cost": {"total_cost_usd": 8.40, "total_duration_ms": 4320000, "total_lines_added": 520, "total_lines_removed": 110},
+  "context_window": {"remaining_percentage": 18},
+  "rate_limits": {
+    "five_hour": {"used_percentage": 92, "resets_at": "'"$(date -u -v+1H +%Y-%m-%dT%H:%M:%SZ)"'"},
+    "seven_day": {"used_percentage": 78, "resets_at": "'"$(date -u -v+2d +%Y-%m-%dT%H:%M:%SZ)"'"}
+  }
+}' \
+  "spine" \
+  '$8.40' \
+  "1h12m" \
+  "compact soon" \
+  "5h: 92%" \
+  "7d: 78%"
+
+# State 5: Active session with subs on different model
+AGENT_BRIDGE="$TMPDIR/tonone-agents-test-subs.json"
+NOW_MS=$(node -e "process.stdout.write(String(Date.now()))")
+cat > "$AGENT_BRIDGE" <<AGENT_EOF
+{"agents":[
+  {"id":"a1","desc":"audit pipeline","model":"sonnet","started":${NOW_MS},"finished":null},
+  {"id":"a2","desc":"check deps","model":"sonnet","started":${NOW_MS},"finished":null}
+]}
+AGENT_EOF
+
+run_test "Subs on different model" '{
+  "session_id": "test-subs",
+  "workspace": {"current_dir": "'"$HOME"'/repos/tn/tonone"},
+  "agent": {"name": "apex"},
+  "model": {"display_name": "Opus 4.6"},
+  "cost": {"total_cost_usd": 1.50, "total_duration_ms": 900000, "total_lines_added": 80, "total_lines_removed": 12},
+  "context_window": {"remaining_percentage": 55},
+  "rate_limits": {
+    "five_hour": {"used_percentage": 35, "resets_at": "'"$(date -u -v+4H +%Y-%m-%dT%H:%M:%SZ)"'"},
+    "seven_day": {"used_percentage": 20, "resets_at": "'"$(date -u -v+5d +%Y-%m-%dT%H:%M:%SZ)"'"}
+  }
+}' \
+  "apex" \
+  "subs: audit pipeline, check deps" \
+  "Opus" \
+  "Sonnet" \
+  '$1.50' \
+  "15m"
+
+rm -f "$AGENT_BRIDGE"
+
+# State 6: Window reset during session
+PACE_BRIDGE="$TMPDIR/tonone-pace-test-reset.json"
+cat > "$PACE_BRIDGE" <<PACE_EOF
+{"session_id":"test-reset","start_time":${NOW_MS},"start_5h_pct":60.0,"start_7d_pct":50.0}
+PACE_EOF
+
+run_test "Window reset during session" '{
+  "session_id": "test-reset",
+  "workspace": {"current_dir": "'"$HOME"'/repos/tn/tonone"},
+  "model": {"display_name": "Opus 4.6"},
+  "cost": {"total_duration_ms": 600000},
+  "rate_limits": {
+    "five_hour": {"used_percentage": 5, "resets_at": "'"$(date -u -v+5H +%Y-%m-%dT%H:%M:%SZ)"'"},
+    "seven_day": {"used_percentage": 10, "resets_at": "'"$(date -u -v+7d +%Y-%m-%dT%H:%M:%SZ)"'"}
+  }
+}' \
+  "5h: 5%" \
+  "7d: 10%"
+
+rm -f "$PACE_BRIDGE"
+
+# State 7: Long directory path (truncation)
+run_test "Long directory path" '{
+  "session_id": "test-longdir",
+  "workspace": {"current_dir": "'"$HOME"'/very/deeply/nested/project/directory/structure/src"},
+  "model": {"display_name": "Opus 4.6"},
+  "cost": {}
+}' \
+  "idle" \
+  "no subs" \
+  "Opus 4.6"
+
+# State 8: No rate limit data
+run_test "No rate limits" '{
+  "session_id": "test-norate",
+  "workspace": {"current_dir": "'"$HOME"'/repos/tn/tonone"},
+  "model": {"display_name": "Sonnet 4.6"},
+  "cost": {"total_cost_usd": 0.05, "total_duration_ms": 120000}
+}' \
+  "Sonnet 4.6" \
+  '$0.05' \
+  "5h: 0% --" \
+  "7d: 0% --"
+
+echo "═══════════════════════════"
+echo "Results: $PASS passed, $FAIL failed"
+echo "═══════════════════════════"
+
+[ "$FAIL" -eq 0 ] || exit 1

--- a/hooks/tonone-agent-tracker.js
+++ b/hooks/tonone-agent-tracker.js
@@ -37,6 +37,7 @@ process.stdin.on("end", () => {
 
     if (isStart) {
       // New agent started
+      const agentModel = toolInput.model || null;
       state = {
         ...state,
         agents: [
@@ -44,6 +45,7 @@ process.stdin.on("end", () => {
           {
             id: toolOutput.agentId,
             desc: agentDesc,
+            model: agentModel,
             started: Date.now(),
             finished: null,
           },

--- a/hooks/tonone-statusline.js
+++ b/hooks/tonone-statusline.js
@@ -6,7 +6,7 @@ const fs = require("fs");
 const path = require("path");
 const os = require("os");
 
-// ── ANSI color helpers ────────────────────────────────────────────────────────
+// ── ANSI helpers ─────────────────────────────────────────────────────────────
 
 const c = {
   reset: "\x1b[0m",
@@ -18,11 +18,12 @@ const c = {
   green: "\x1b[32m",
   red: "\x1b[31m",
   magenta: "\x1b[35m",
-  orange: "\x1b[38;5;208m",
   dimWhite: "\x1b[2;37m",
 };
 
-// ── Git helpers ───────────────────────────────────────────────────────────────
+const SEP = ` ${c.dim}\u2502${c.reset} `;
+
+// ── Git helpers ──────────────────────────────────────────────────────────────
 
 function gitBranch(cwd) {
   try {
@@ -65,24 +66,29 @@ function gitAhead(cwd) {
   }
 }
 
-// ── Formatters ────────────────────────────────────────────────────────────────
+// ── Formatters ───────────────────────────────────────────────────────────────
 
-function fmtTokens(n) {
-  if (n == null || n === 0) return null;
-  if (n < 1000) return `${n} tk`;
-  if (n < 1_000_000) return `${(n / 1000).toFixed(1).replace(/\.0$/, "")}k tk`;
-  return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}M tk`;
+function fmtDir(dir) {
+  const home = os.homedir();
+  let d = dir.startsWith(home) ? "~" + dir.slice(home.length) : dir;
+  if (d.length > 40) {
+    const parts = d.split("/");
+    while (d.length > 40 && parts.length > 2) {
+      parts.shift();
+      d = "\u2026/" + parts.join("/");
+    }
+  }
+  return d;
 }
 
 function fmtCost(usd) {
-  if (usd == null) return null;
-  if (usd === 0) return null;
+  if (usd == null || usd === 0) return "$0.00";
   if (usd < 0.01) return `$${usd.toFixed(3)}`;
   return `$${usd.toFixed(2)}`;
 }
 
 function fmtDuration(ms) {
-  if (ms == null || ms <= 0) return null;
+  if (ms == null || ms <= 0) return "0m";
   const totalSec = Math.floor(ms / 1000);
   if (totalSec < 60) return `${totalSec}s`;
   const mins = Math.floor(totalSec / 60);
@@ -92,21 +98,10 @@ function fmtDuration(ms) {
   return rem > 0 ? `${hrs}h${rem}m` : `${hrs}h`;
 }
 
-function fmtRelativeTime(isoTimestamp) {
-  if (!isoTimestamp) return "";
-  const diff = new Date(isoTimestamp).getTime() - Date.now();
-  if (diff <= 0) return "now";
-  const mins = Math.ceil(diff / 60000);
-  if (mins < 60) return `${mins}m`;
-  const hrs = Math.floor(mins / 60);
-  const rem = mins % 60;
-  return rem > 0 ? `${hrs}h${rem}m` : `${hrs}h`;
-}
+// ── Subagent bridge ──────────────────────────────────────────────────────────
 
-// ── Subagent bridge ───────────────────────────────────────────────────────────
-
-function readSubagentCount(sessionId) {
-  if (!sessionId || /[/\\]|\.\./.test(sessionId)) return 0;
+function readSubagents(sessionId) {
+  if (!sessionId || /[/\\]|\.\./.test(sessionId)) return [];
   try {
     const bridgePath = path.join(
       os.tmpdir(),
@@ -114,19 +109,115 @@ function readSubagentCount(sessionId) {
     );
     const data = JSON.parse(fs.readFileSync(bridgePath, "utf8"));
     const cutoff = Date.now() - 300_000;
-    const active = (data.agents || []).filter(
-      (a) => a.started > cutoff && !a.finished,
-    );
-    return active.length;
+    return (data.agents || []).filter((a) => a.started > cutoff && !a.finished);
   } catch {
-    return 0;
+    return [];
   }
 }
 
-// ── Context bar ───────────────────────────────────────────────────────────────
+// ── Pace bridge ──────────────────────────────────────────────────────────────
+
+function readOrCreatePaceBridge(sessionId, fiveHourPct, sevenDayPct) {
+  if (!sessionId || /[/\\]|\.\./.test(sessionId)) return null;
+  const bridgePath = path.join(os.tmpdir(), `tonone-pace-${sessionId}.json`);
+  try {
+    const data = JSON.parse(fs.readFileSync(bridgePath, "utf8"));
+    if (data.session_id === sessionId) {
+      // Window reset during session — burn went negative, re-initialize
+      const fiveReset =
+        fiveHourPct != null && fiveHourPct < data.start_5h_pct;
+      const sevenReset =
+        sevenDayPct != null && sevenDayPct < data.start_7d_pct;
+      if (!fiveReset && !sevenReset) return data;
+    }
+  } catch {}
+  // Create fresh bridge file
+  const bridge = {
+    session_id: sessionId,
+    start_time: Date.now(),
+    start_5h_pct: fiveHourPct || 0,
+    start_7d_pct: sevenDayPct || 0,
+  };
+  try {
+    const tmpPath = bridgePath + ".tmp." + process.pid;
+    fs.writeFileSync(tmpPath, JSON.stringify(bridge));
+    fs.renameSync(tmpPath, bridgePath);
+  } catch {}
+  return bridge;
+}
+
+// ── Pace computation ─────────────────────────────────────────────────────────
+
+function computePace(currentPct, startPct, startTime, resetsAt) {
+  const now = Date.now();
+  const sessionElapsedHours = (now - startTime) / 3_600_000;
+
+  // Not enough data yet (< 2 minutes)
+  if (sessionElapsedHours < 2 / 60) {
+    return { verdict: "--", color: c.dim, multiplier: null };
+  }
+
+  // Missing or past reset time
+  if (!resetsAt) {
+    return { verdict: "--", color: c.dim, multiplier: null };
+  }
+  const resetsAtMs = new Date(resetsAt).getTime();
+  const timeRemainingHours = (resetsAtMs - now) / 3_600_000;
+  if (timeRemainingHours <= 0) {
+    return { verdict: "--", color: c.dim, multiplier: null };
+  }
+
+  const sessionBurn = Math.max(0, currentPct - startPct);
+  const burnRate = sessionBurn / sessionElapsedHours;
+
+  // Zero burn — session hasn't consumed any of this window
+  if (burnRate === 0) {
+    return { verdict: "ok", color: c.green, multiplier: 0.0 };
+  }
+
+  const projectedAdditional = burnRate * timeRemainingHours;
+  const projectedTotal = currentPct + projectedAdditional;
+
+  const safeRate = (100 - currentPct) / timeRemainingHours;
+  const multiplier = safeRate > 0 ? burnRate / safeRate : 99.9;
+
+  if (projectedTotal <= 80) {
+    return { verdict: "ok", color: c.green, multiplier };
+  }
+  if (projectedTotal <= 100) {
+    return { verdict: "tight", color: c.yellow, multiplier };
+  }
+
+  // Will overshoot — show time to impact
+  const hoursToImpact = (100 - currentPct) / burnRate;
+  const minsToImpact = Math.round(hoursToImpact * 60);
+  const timeStr =
+    minsToImpact >= 60
+      ? `~${Math.floor(minsToImpact / 60)}h`
+      : `~${minsToImpact}m`;
+  return { verdict: timeStr, color: c.red, multiplier };
+}
+
+function renderPace(label, currentPct, startPct, startTime, resetsAt) {
+  if (currentPct == null) {
+    return `${c.dim}${label}: 0% --${c.reset}`;
+  }
+  const pct = Math.round(currentPct);
+  const pace = computePace(currentPct, startPct, startTime, resetsAt);
+  if (pace.multiplier == null) {
+    return `${c.dim}${label}: ${pct}% --${c.reset}`;
+  }
+  const mulStr = `${pace.multiplier.toFixed(1)}\u00d7`;
+  return `${pace.color}${label}: ${pct}% ${pace.verdict} ${mulStr}${c.reset}`;
+}
+
+// ── Context bar ──────────────────────────────────────────────────────────────
 
 function renderContextBar(remaining) {
-  if (remaining == null) return "";
+  const EMPTY_BAR = "\u2591".repeat(10);
+  if (remaining == null) {
+    return `${c.dim}${EMPTY_BAR} 100%${c.reset}`;
+  }
   const AUTO_COMPACT_BUFFER_PCT = 16.5;
   const usableRemaining = Math.max(
     0,
@@ -147,150 +238,142 @@ function renderContextBar(remaining) {
     color = c.yellow;
   } else if (pctLeft > 10) {
     color = c.red;
-    warning = " \u26a0";
   } else {
     color = `${c.blink}${c.red}`;
-    warning = " \u26a0 compact soon";
+    warning = " compact soon";
   }
   return `${color}${bar} ${pctLeft}%${warning}${c.reset}`;
 }
 
-// ── Rate limit ────────────────────────────────────────────────────────────────
+// ── Model display ────────────────────────────────────────────────────────────
 
-function renderRateLimit(rateLimits) {
-  if (!rateLimits?.five_hour) return "";
-  const used = rateLimits.five_hour.used_percentage;
-  if (used == null || used < 50) return "";
-  const resetsAt = rateLimits.five_hour.resets_at;
-  const rel = fmtRelativeTime(resetsAt);
-  let color;
-  if (used < 70) color = c.green;
-  else if (used < 90) color = c.yellow;
-  else color = `${c.blink}${c.red}`;
-  const resetStr = used >= 70 && rel ? ` \u21bb${rel}` : "";
-  return `${color}\u25ce${Math.round(used)}%${resetStr}${c.reset}`;
+function renderModel(mainDisplayName, activeSubagents) {
+  const name = mainDisplayName || "unknown";
+  const mainLower = name.toLowerCase();
+
+  // Collect unique sub models that differ from the main model
+  const subModels = [
+    ...new Set(
+      activeSubagents
+        .map((a) => a.model)
+        .filter((m) => m && !mainLower.includes(m.toLowerCase())),
+    ),
+  ];
+
+  if (subModels.length === 0) {
+    return `${c.dimWhite}${name}${c.reset}`;
+  }
+
+  // Capitalize sub model names, e.g. "sonnet" → "Sonnet"
+  const subStr = subModels
+    .map((m) => m.charAt(0).toUpperCase() + m.slice(1))
+    .join(", ");
+  // Shorten main to first word, e.g. "Opus 4.6" → "Opus"
+  const mainShort = name.split(" ")[0];
+  return `${c.dimWhite}${mainShort} ${c.dim}\u2192${c.reset} ${c.dimWhite}${subStr}${c.reset}`;
 }
 
-// ── Main render ───────────────────────────────────────────────────────────────
+// ── Main render ──────────────────────────────────────────────────────────────
 
 function render(data) {
   const cwd = data.workspace?.current_dir || process.cwd();
   const session = data.session_id || "";
-  const segments = [];
 
-  // 1. Branch + ahead count (cyan, always shown)
+  // ── Line 1: Location & Git ──────────────────────────────────────────────
+  const dir = fmtDir(cwd);
   const branch = gitBranch(cwd);
-  if (branch) {
-    const ahead = gitAhead(cwd);
-    const aheadStr = ahead > 0 ? ` ${c.green}\u2191${ahead}${c.reset}` : "";
-    segments.push(`${c.cyan}\u25c6 ${branch}${c.reset}${aheadStr}`);
-  }
-
-  // 2. Dirty count (yellow, hidden when clean)
+  const ahead = gitAhead(cwd);
   const dirty = gitDirtyCount(cwd);
-  if (dirty > 0) segments.push(`${c.yellow}\u25b2${dirty}${c.reset}`);
-
-  // 3. Agent name (magenta, hidden when no agent active)
-  const agentName = data.agent?.name;
-  if (agentName) {
-    segments.push(`${c.magenta}${c.bold}${agentName}${c.reset}`);
-  }
-
-  // 4. Subagent count (hidden when 0, independent of agent name)
-  const subCount = readSubagentCount(session);
-  if (subCount > 0) {
-    const label = agentName ? `\u2295${subCount}` : `\u2295${subCount} agents`;
-    segments.push(`${c.magenta}${label}${c.reset}`);
-  }
-
-  // 5. Tokens (hidden when 0)
-  const totalTokens =
-    (data.total_input_tokens || 0) + (data.total_output_tokens || 0);
-  const tokenStr = fmtTokens(totalTokens);
-  if (tokenStr) segments.push(`${c.dimWhite}${tokenStr}${c.reset}`);
-
-  // 6. Cost (hidden when $0, yellow >$1, red >$5)
-  const cost = fmtCost(data.cost?.total_cost_usd);
-  if (cost) {
-    const costVal = data.cost.total_cost_usd;
-    let costColor = c.dimWhite;
-    if (costVal > 5) costColor = c.red;
-    else if (costVal > 1) costColor = c.yellow;
-    segments.push(`${costColor}${cost}${c.reset}`);
-  }
-
-  // 7. Context bar (always shown)
-  const ctxBar = renderContextBar(data.context_window?.remaining_percentage);
-  if (ctxBar) segments.push(ctxBar);
-
-  // 8. Rate limit (hidden when <50%)
-  const rateLimit = renderRateLimit(data.rate_limits);
-  if (rateLimit) segments.push(rateLimit);
-
-  const line1 = segments.join(` ${c.dim}\u2502${c.reset} `);
-
-  // ── Line 2: model + usage windows ──────────────────────────────────────────
-  const line2Parts = [];
-
-  // Model name (always shown when available)
-  const modelName = data.model?.display_name;
-  if (modelName) {
-    line2Parts.push(`${c.dimWhite}${modelName}${c.reset}`);
-  }
-
-  // Session duration
-  const duration = fmtDuration(data.cost?.total_duration_ms);
-  if (duration) {
-    line2Parts.push(`${c.dimWhite}${duration}${c.reset}`);
-  }
-
-  // Lines changed (+N -N)
   const added = data.cost?.total_lines_added || 0;
   const removed = data.cost?.total_lines_removed || 0;
-  if (added > 0 || removed > 0) {
-    let linesStr = "";
-    if (added > 0) linesStr += `${c.green}+${added}${c.reset}`;
-    if (added > 0 && removed > 0) linesStr += " ";
-    if (removed > 0) linesStr += `${c.red}-${removed}${c.reset}`;
-    line2Parts.push(linesStr);
+
+  const dirStr = `${c.dimWhite}${dir}${c.reset}`;
+
+  let branchStr = branch
+    ? `${c.cyan}${branch}${c.reset}`
+    : `${c.dim}no branch${c.reset}`;
+  if (branch && ahead > 0) {
+    branchStr += ` ${c.green}\u2191${ahead}${c.reset}`;
   }
 
-  // Cost per line (wow metric — hidden when no lines or no cost)
-  const totalLines = added + removed;
-  const totalCost = data.cost?.total_cost_usd || 0;
-  if (totalLines > 0 && totalCost > 0) {
-    const cpl = totalCost / totalLines;
-    const cplStr =
-      cpl < 0.001
-        ? `$${(cpl * 1000).toFixed(1)}\u00d710\u207b\u00b3`
-        : `$${cpl.toFixed(3)}`;
-    line2Parts.push(`${c.dimWhite}${cplStr}/line${c.reset}`);
+  const dirtyStr =
+    dirty > 0
+      ? `${c.yellow}${dirty} dirty${c.reset}`
+      : `${c.dim}clean${c.reset}`;
+
+  const linesStr =
+    added > 0 || removed > 0
+      ? `${c.green}+${added}${c.reset} ${c.red}-${removed}${c.reset} ${c.dim}lines${c.reset}`
+      : `${c.dim}+0 -0 lines${c.reset}`;
+
+  const line1 = [dirStr, branchStr, dirtyStr, linesStr].join(SEP);
+
+  // ── Line 2: Session Activity ────────────────────────────────────────────
+  const agentName = data.agent?.name;
+  const subagents = readSubagents(session);
+
+  const agentStr = agentName
+    ? `${c.magenta}${c.bold}${agentName}${c.reset}`
+    : `${c.dim}idle${c.reset}`;
+
+  let subsStr;
+  if (subagents.length === 0) {
+    subsStr = `${c.dim}no subs${c.reset}`;
+  } else if (subagents.length <= 3) {
+    const names = subagents
+      .map((a) => (a.desc || "agent").slice(0, 20))
+      .join(", ");
+    subsStr = `${c.magenta}subs: ${names}${c.reset}`;
+  } else {
+    const names = subagents
+      .slice(0, 2)
+      .map((a) => (a.desc || "agent").slice(0, 20))
+      .join(", ");
+    subsStr = `${c.magenta}subs: ${names}, +${subagents.length - 2} more${c.reset}`;
   }
 
-  // 5-hour usage
+  const costVal = data.cost?.total_cost_usd || 0;
+  let costColor = c.dimWhite;
+  if (costVal > 5) costColor = c.red;
+  else if (costVal > 1) costColor = c.yellow;
+  const costStr = `${costColor}${fmtCost(costVal)}${c.reset}`;
+
+  const durStr = `${c.dimWhite}${fmtDuration(data.cost?.total_duration_ms)}${c.reset}`;
+
+  const line2 = [agentStr, subsStr, costStr, durStr].join(SEP);
+
+  // ── Line 3: Model & Runway ──────────────────────────────────────────────
+  const modelStr = renderModel(data.model?.display_name, subagents);
+  const ctxBar = renderContextBar(data.context_window?.remaining_percentage);
+
   const fiveH = data.rate_limits?.five_hour;
-  if (fiveH?.used_percentage != null) {
-    const pct = Math.round(fiveH.used_percentage);
-    let col = c.dimWhite;
-    if (pct >= 90) col = `${c.blink}${c.red}`;
-    else if (pct >= 70) col = c.yellow;
-    line2Parts.push(`${col}5h: ${pct}%${c.reset}`);
-  }
-
-  // 7-day (weekly) usage
   const sevenD = data.rate_limits?.seven_day;
-  if (sevenD?.used_percentage != null) {
-    const pct = Math.round(sevenD.used_percentage);
-    let col = c.dimWhite;
-    if (pct >= 90) col = `${c.blink}${c.red}`;
-    else if (pct >= 70) col = c.yellow;
-    line2Parts.push(`${col}7d: ${pct}%${c.reset}`);
-  }
+  const paceBridge = readOrCreatePaceBridge(
+    session,
+    fiveH?.used_percentage,
+    sevenD?.used_percentage,
+  );
+  const startTime = paceBridge?.start_time || Date.now();
 
-  if (line2Parts.length === 0) return line1;
+  const fiveHStr = renderPace(
+    "5h",
+    fiveH?.used_percentage,
+    paceBridge?.start_5h_pct || 0,
+    startTime,
+    fiveH?.resets_at,
+  );
 
-  const line2 = line2Parts.join(` ${c.dim}\u2502${c.reset} `);
-  return `${line1}\n${line2}`;
+  const sevenDStr = renderPace(
+    "7d",
+    sevenD?.used_percentage,
+    paceBridge?.start_7d_pct || 0,
+    startTime,
+    sevenD?.resets_at,
+  );
+
+  const line3 = [modelStr, ctxBar, fiveHStr, sevenDStr].join(SEP);
+
+  return `${line1}\n${line2}\n${line3}`;
 }
 
 // ── Stdin reader with 3s timeout guard ───────────────────────────────────────


### PR DESCRIPTION
## Summary
- **3-line layout** grouped by mental model: Location & Git → Session Activity → Model & Runway
- **Static fields** — all segments always visible with dim placeholders (no more layout shift from progressive disclosure)
- **Micro-labels** replacing symbol soup: `2 dirty` not `▲2`, `+1 sub` not `⊕1`, `idle`/`clean`/`no subs` for empty states
- **Pace projection** for rate limits: `ok 0.6×` / `tight 1.4×` / `~18m 2.1×` — shows if you'll hit the wall before the window resets
- **Model routing display**: `Opus → Sonnet` when subagents run on a different model
- **Working directory** shown on Line 1 with `~` shortening and 40-char truncation
- **Subagent names** surfaced from bridge file (truncated, max 3 shown)

## Before / After

**Before (2 lines, symbol soup):**
```
◆ main ↑3 │ ▲2 │ spine ⊕1 │ 50k tk │ $0.38 │ ████░░░░░░ 52% │ ◎65% ↻2h
Opus 4.6 │ 23m │ +156 -23 │ $0.010/line │ 5h: 24% │ 7d: 41%
```

**After (3 lines, labeled and grouped):**
```
~/repos/tn/tonone │ main ↑3 │ 2 dirty │ +156 -23 lines
spine │ subs: audit pipeline, check deps │ $0.38 │ 23m
Opus → Sonnet │ ████░░░░░░ 48% │ 5h: 24% ok 0.6× │ 7d: 41% ok 0.8×
```

## Files Changed
- `hooks/tonone-statusline.js` — full rewrite: 3-line render, pace bridge, model routing
- `hooks/tonone-agent-tracker.js` — added `model` field to subagent bridge entries
- `hooks/test-statusline.sh` — test runner covering 8 states (fresh, active, warning, critical, subs on different model, window reset, long path, no rate limits)
- `docs/superpowers/specs/` and `plans/` — design spec and implementation plan

## Test plan
- [x] 8 test states passing via `bash hooks/test-statusline.sh`
- [x] `node -c` syntax validation
- [x] No leftover old symbols (◆ ▲ ⊕ ◎) or removed functions
- [x] 3-line output verified with `wc -l`
- [ ] Live test in Claude Code session (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)