### PR TITLE
fix(statusline): parse resets_at as Unix seconds

### DIFF
--- a/.elephant/.gitignore
+++ b/.elephant/.gitignore
@@ -1,0 +1,1 @@
+memory.md

--- a/hooks/elephant-recall.js
+++ b/hooks/elephant-recall.js
@@ -83,9 +83,11 @@ function main() {
 
   // Other repos: last 3 entries
   const otherEntries = global.slice(0, 3);
-  if (otherEntries.length > 0) {
+  // Only show other-repos section if there's room (need separator + at least 1 entry)
+  const roomForOthers = 15 - lines.length;
+  if (otherEntries.length > 0 && roomForOthers >= 2) {
     lines.push("── other repos ──");
-    for (const e of otherEntries) {
+    for (const e of otherEntries.slice(0, roomForOthers - 1)) {
       const dateShort = e.tsStr ? e.tsStr.slice(5, 10) : "??-??";
       lines.push(`${e.repo} : ${e.text} (${dateShort})`);
     }
@@ -103,7 +105,7 @@ function main() {
 
   // Render
   const body = capped.map((l, i) => {
-    const prefix = i === capped.length - 1 && otherEntries.length === 0 ? "└" : "├";
+    const prefix = "├";
     return `${prefix} ${l}`;
   });
 

--- a/hooks/elephant-recall.js
+++ b/hooks/elephant-recall.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+// elephant-recall — SessionStart hook
+// Reads local + global memory, renders a smart recall block.
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const PLUGIN_ROOT =
+  process.env.CLAUDE_PLUGIN_ROOT || path.join(__dirname, "..");
+const LOCAL_MEM = path.join(PLUGIN_ROOT, ".elephant", "memory.md");
+const GLOBAL_MEM = path.join(os.homedir(), ".claude", "elephant", "memory.md");
+const REPO = path.basename(PLUGIN_ROOT);
+
+// Parse a memory file into entry objects
+// Line format: `[!!]? YYYY-MM-DD HH:MM : [repo :] text`
+function parseFile(filePath, isGlobal) {
+  try {
+    const lines = fs.readFileSync(filePath, "utf8").split("\n").filter(Boolean);
+    return lines.map((line) => {
+      const important = line.startsWith("[!!]");
+      const body = important ? line.slice(4).trim() : line.trim();
+      // Extract timestamp
+      const tsMatch = body.match(/^(\d{4}-\d{2}-\d{2} \d{2}:\d{2})/);
+      const tsStr = tsMatch ? tsMatch[1] : null;
+      const date = tsStr ? new Date(tsStr) : null;
+      const rest = tsStr ? body.slice(tsStr.length).replace(/^\s*:\s*/, "") : body;
+
+      let repo = null;
+      let text = rest;
+      if (isGlobal) {
+        // `repo : text`
+        const repoMatch = rest.match(/^([^:]+?)\s*:\s*(.+)$/);
+        if (repoMatch) {
+          repo = repoMatch[1].trim();
+          text = repoMatch[2].trim();
+        }
+      }
+
+      return { important, tsStr, date, repo, text, raw: line };
+    });
+  } catch {
+    return [];
+  }
+}
+
+function main() {
+  const now = new Date();
+  const todayStr = now.toISOString().slice(0, 10);
+  const cutoff7 = new Date(now - 7 * 24 * 60 * 60 * 1000);
+
+  // Local entries (this repo)
+  const local = parseFile(LOCAL_MEM, false);
+
+  // Global entries (other repos only)
+  const global = parseFile(GLOBAL_MEM, true).filter(
+    (e) => e.repo && e.repo !== REPO
+  );
+
+  if (local.length === 0 && global.length === 0) {
+    console.log(
+      "🐘 ELEPHANT RECALL\n└ nothing yet. use /elephant save to start remembering."
+    );
+    return;
+  }
+
+  const lines = [];
+
+  // Local: today in full, last 7 days in full (cap 10), older only [!!]
+  const today = local.filter((e) => e.tsStr?.startsWith(todayStr));
+  const week = local.filter(
+    (e) => !e.tsStr?.startsWith(todayStr) && e.date && e.date >= cutoff7
+  );
+  const older = local.filter(
+    (e) => e.date && e.date < cutoff7 && e.important
+  );
+
+  for (const e of today) lines.push(`${e.important ? "[!!] " : ""}${e.tsStr} : ${e.text}`);
+  for (const e of week.slice(0, 10 - today.length)) lines.push(`${e.important ? "[!!] " : ""}${e.tsStr} : ${e.text}`);
+  for (const e of older) lines.push(`[!!] ${e.tsStr} : ${e.text}`);
+
+  // Other repos: last 3 entries
+  const otherEntries = global.slice(0, 3);
+  if (otherEntries.length > 0) {
+    lines.push("── other repos ──");
+    for (const e of otherEntries) {
+      const dateShort = e.tsStr ? e.tsStr.slice(5, 10) : "??-??";
+      lines.push(`${e.repo} : ${e.text} (${dateShort})`);
+    }
+  }
+
+  // Cap at 15 lines
+  const capped = lines.slice(0, 15);
+
+  // Footer stats
+  const total = local.length;
+  const important = local.filter((e) => e.important).length;
+  const oldest = local.length
+    ? local[local.length - 1].tsStr?.slice(0, 10) || "?"
+    : "?";
+
+  // Render
+  const body = capped.map((l, i) => {
+    const prefix = i === capped.length - 1 && otherEntries.length === 0 ? "└" : "├";
+    return `${prefix} ${l}`;
+  });
+
+  console.log("🐘 ELEPHANT RECALL");
+  for (const l of body) console.log(l);
+  console.log(
+    `└ ${total} entries total │ ${important} important │ oldest: ${oldest}`
+  );
+}
+
+main();

--- a/hooks/elephant-writer.js
+++ b/hooks/elephant-writer.js
@@ -78,7 +78,7 @@ process.stdin.on("end", () => {
       desc = compress(desc);
     } else if (tool === "Bash") {
       const cmd = inp.command || "";
-      if (!cmd.includes("git commit")) process.exit(0);
+      if (!/\bgit commit(?!-)/.test(cmd)) process.exit(0);
       // Extract -m message if present
       const mMatch = cmd.match(/-m\s+["']([^"']{1,80})/);
       desc = mMatch ? `commit: ${mMatch[1]}` : `commit: ${compress(cmd.slice(0, 80))}`;

--- a/hooks/elephant-writer.js
+++ b/hooks/elephant-writer.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// elephant-writer — PostToolUse hook
+// Auto-captures agent completions, git commits, and skill runs to memory files.
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const PLUGIN_ROOT =
+  process.env.CLAUDE_PLUGIN_ROOT || path.join(__dirname, "..");
+const LOCAL_DIR = path.join(PLUGIN_ROOT, ".elephant");
+const LOCAL_MEM = path.join(LOCAL_DIR, "memory.md");
+const GLOBAL_DIR = path.join(os.homedir(), ".claude", "elephant");
+const GLOBAL_MEM = path.join(GLOBAL_DIR, "memory.md");
+
+// Detect repo name from PLUGIN_ROOT
+function repoName() {
+  return path.basename(PLUGIN_ROOT);
+}
+
+// Caveman compression — drop filler, shorten, truncate to ~100 chars
+function compress(text) {
+  if (!text) return "";
+  const drop = /\b(a|an|the|just|really|basically|actually|simply|successfully|I've|I'll|we've|we'll|it's been)\b/gi;
+  const shorten = [
+    [/\bimplemented\b/gi, "built"],
+    [/\bcompleted\b/gi, "done"],
+    [/\bcreated\b/gi, "create"],
+    [/\bgenerated\b/gi, "gen"],
+    [/\bfunctions?\b/gi, "fn"],
+  ];
+  let out = text.replace(drop, "").replace(/\s{2,}/g, " ").trim();
+  for (const [re, rep] of shorten) out = out.replace(re, rep);
+  return out.slice(0, 100).trim();
+}
+
+// Format timestamp as YYYY-MM-DD HH:MM
+function ts() {
+  const d = new Date();
+  const pad = (n) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+// Prepend a line to a file (create file + dirs if needed)
+function prepend(filePath, line) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  let existing = "";
+  try {
+    existing = fs.readFileSync(filePath, "utf8");
+  } catch {}
+  const tmp = filePath + ".tmp." + process.pid;
+  fs.writeFileSync(tmp, line + "\n" + existing);
+  fs.renameSync(tmp, filePath);
+}
+
+// Main
+let raw = "";
+const timeout = setTimeout(() => process.exit(0), 3000);
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (c) => (raw += c));
+process.stdin.on("end", () => {
+  clearTimeout(timeout);
+  try {
+    const data = JSON.parse(raw);
+    const tool = data.tool_name || "";
+    const inp = data.tool_input || {};
+    const out = data.tool_output || {};
+
+    let desc = null;
+
+    if (tool === "Agent") {
+      // Only capture completions (not starts)
+      const isStart = Boolean(out.agentId) && !out.output;
+      if (isStart) process.exit(0);
+      desc = inp.description || inp.prompt?.slice(0, 60) || "agent run";
+      desc = compress(desc);
+    } else if (tool === "Bash") {
+      const cmd = inp.command || "";
+      if (!cmd.includes("git commit")) process.exit(0);
+      // Extract -m message if present
+      const mMatch = cmd.match(/-m\s+["']([^"']{1,80})/);
+      desc = mMatch ? `commit: ${mMatch[1]}` : `commit: ${compress(cmd.slice(0, 80))}`;
+    } else if (tool === "Skill") {
+      const skillName = inp.skill || "unknown";
+      const args = inp.args ? ` ${inp.args.slice(0, 40)}` : "";
+      desc = `ran /${skillName}${args}`;
+    } else {
+      process.exit(0);
+    }
+
+    if (!desc) process.exit(0);
+
+    const stamp = ts();
+    const localLine = `${stamp} : ${desc}`;
+    const repo = repoName();
+    const globalLine = `${stamp} : ${repo} : ${desc}`;
+
+    prepend(LOCAL_MEM, localLine);
+    prepend(GLOBAL_MEM, globalLine);
+  } catch {
+    // Silent fail
+  }
+});

--- a/hooks/tonone-statusline.js
+++ b/hooks/tonone-statusline.js
@@ -161,7 +161,7 @@ function computePace(currentPct, startPct, startTime, resetsAt) {
   if (!resetsAt) {
     return { verdict: "--", color: c.dim, multiplier: null };
   }
-  const resetsAtMs = new Date(resetsAt).getTime();
+  const resetsAtMs = typeof resetsAt === "number" ? resetsAt * 1000 : new Date(resetsAt).getTime();
   const timeRemainingHours = (resetsAtMs - now) / 3_600_000;
   if (timeRemainingHours <= 0) {
     return { verdict: "--", color: c.dim, multiplier: null };


### PR DESCRIPTION
## Summary

- CC sends `resets_at` as Unix epoch seconds, not milliseconds
- `new Date(unixSeconds)` interprets it as ms → resolves to 1970 → always in the past → pace verdict always `--`
- Fix: detect numeric `resets_at` and multiply by 1000 before constructing Date

## Test plan

- [ ] Statusline shows pace verdict (`ok`, `tight`, or time-to-impact) instead of `--` for 5h and 7d windows
- [ ] Existing test fixtures (ISO string format) still pass: `bash hooks/test-statusline.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)