### PR TITLE
feat(worktree): auto-create worktree on first edit

### DIFF
--- a/docs/superpowers/plans/2026-04-12-auto-worktree-on-edit.md
+++ b/docs/superpowers/plans/2026-04-12-auto-worktree-on-edit.md
@@ -1,0 +1,255 @@
+# Auto-Worktree on First Edit — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Any Edit/Write on main auto-creates an isolated worktree and redirects Claude there — zero user friction, no plan-mode prerequisite.
+
+**Architecture:** Rewrite `tonone-worktree-gate.js` to drop the `hasRecentPlan` gstack check and add inline worktree creation. On first file-modifying tool call on main: create (or reuse) a worktree, exit 1 with `WORKTREE_READY` stdout so Claude calls `EnterWorktree` and retries. Silent fallthrough on creation failure. `tonone-worktree-create.js` and `plugin.json` unchanged.
+
+**Tech Stack:** Node.js (no dependencies), Python/pytest for tests
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `hooks/tonone-worktree-gate.js` | Rewrite |
+| `tests/test_hooks.py` | Update 1 test |
+| `/Users/f/.claude/plugins/cache/tonone-ai/tonone/0.6.9/hooks/tonone-worktree-gate.js` | Sync after rewrite |
+
+---
+
+## Task 1: Update failing test (TDD — red first)
+
+**Files:**
+- Modify: `tests/test_hooks.py:138-144`
+
+- [ ] **Step 1: Update the source-inspection test**
+
+Replace `test_gate_block_message_is_actionable` with a version that expects `WORKTREE_READY` (not `WORKTREE_REQUIRED`) on stdout (not stderr):
+
+```python
+def test_gate_message_is_actionable():
+    """When gate blocks, stdout must contain WORKTREE_READY, EnterWorktree, and skip-worktree opt-out."""
+    source = GATE.read_text()
+    assert "WORKTREE_READY" in source
+    assert "EnterWorktree" in source
+    assert ".claude/skip-worktree" in source
+    assert "process.exit(1)" in source
+```
+
+- [ ] **Step 2: Run test — confirm it fails**
+
+```bash
+cd /Users/f/repos/tn/tonone
+python -m pytest tests/test_hooks.py::test_gate_message_is_actionable -v
+```
+
+Expected: `FAILED` — `WORKTREE_READY` not in source (current source has `WORKTREE_REQUIRED`).
+
+---
+
+## Task 2: Rewrite `tonone-worktree-gate.js`
+
+**Files:**
+- Modify: `hooks/tonone-worktree-gate.js`
+
+- [ ] **Step 1: Replace the file with the new implementation**
+
+Write `hooks/tonone-worktree-gate.js`:
+
+```javascript
+#!/usr/bin/env node
+// tonone-worktree-gate — PreToolUse hook for Edit/Write/NotebookEdit
+//
+// On any file-modifying tool call while on main: auto-creates (or reuses) an
+// isolated worktree and tells Claude to enter it before proceeding.
+//
+// Opt-out: write .claude/skip-worktree (valid 2 hours) for deliberate main
+// edits (docs, CHANGELOG, version bumps).
+
+const { execSync, spawnSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+let input = "";
+const timeout = setTimeout(() => process.exit(0), 3000);
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => (input += chunk));
+process.stdin.on("end", () => {
+  clearTimeout(timeout);
+  try {
+    const data = JSON.parse(input);
+    const toolName = data.tool_name || "";
+    const toolInput = data.tool_input || {};
+
+    // Only gate file-modifying tools
+    const GATED = ["Edit", "Write", "NotebookEdit"];
+    if (!GATED.includes(toolName)) process.exit(0);
+
+    // Whitelist: always allow creating the opt-out marker itself
+    const filePath = toolInput.file_path || toolInput.notebook_path || "";
+    if (
+      filePath === ".claude/skip-worktree" ||
+      filePath.endsWith("/.claude/skip-worktree")
+    ) {
+      process.exit(0);
+    }
+
+    // Check for opt-out marker (valid for 2 hours)
+    const skipMarker = ".claude/skip-worktree";
+    if (fs.existsSync(skipMarker)) {
+      const stat = fs.statSync(skipMarker);
+      if (Date.now() - stat.mtimeMs < 2 * 60 * 60 * 1000) {
+        process.exit(0);
+      }
+    }
+
+    // Check if already in a worktree
+    let gitDir, commonDir;
+    try {
+      gitDir = execSync("git rev-parse --git-dir", { encoding: "utf8" }).trim();
+      commonDir = execSync("git rev-parse --git-common-dir", {
+        encoding: "utf8",
+      }).trim();
+    } catch {
+      process.exit(0); // Not a git repo — allow
+    }
+
+    if (gitDir !== commonDir) {
+      process.exit(0); // Already in a worktree — allow
+    }
+
+    // On main. Try to reuse a worktree pre-created by tonone-worktree-create.
+    const worktreesDir = ".claude/worktrees";
+    let worktreePath = null;
+    let branchName = null;
+
+    try {
+      if (fs.existsSync(worktreesDir)) {
+        // Lexicographic descending = most-recent impl-YYYYMMDD-HHMMSS-PID first
+        const entries = fs
+          .readdirSync(worktreesDir)
+          .filter((e) => e.startsWith("impl-"))
+          .sort()
+          .reverse();
+        if (entries.length > 0) {
+          worktreePath = path.join(worktreesDir, entries[0]);
+          branchName = entries[0];
+        }
+      }
+    } catch {}
+
+    // No pre-existing worktree — create one now.
+    if (!worktreePath) {
+      const now = new Date();
+      const pad = (n) => String(n).padStart(2, "0");
+      const dateStr = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}`;
+      const timeStr = `${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+      const base = `impl-${dateStr}-${timeStr}-${process.pid}`;
+
+      for (let i = 0; i < 5; i++) {
+        const suffix = i === 0 ? "" : `-${i + 1}`;
+        const candidate = base + suffix;
+        const wPath = path.join(worktreesDir, candidate);
+        const result = spawnSync(
+          "git",
+          ["worktree", "add", wPath, "-b", candidate],
+          { encoding: "utf8" },
+        );
+        if (result.status === 0) {
+          worktreePath = wPath;
+          branchName = candidate;
+          break;
+        }
+      }
+    }
+
+    // Creation failed — silent fallthrough, allow edit on main.
+    if (!worktreePath) {
+      process.exit(0);
+    }
+
+    // Block and redirect to worktree.
+    process.stdout.write(
+      `\nWORKTREE_READY: An isolated workspace is ready for this session.\n` +
+        `Path: ${worktreePath}\n` +
+        `Branch: ${branchName}\n\n` +
+        `Call EnterWorktree("${worktreePath}") now, then retry your edit. ` +
+        `This keeps your changes isolated from other concurrent sessions.\n` +
+        `\nTo edit on main intentionally (docs, CHANGELOG, version bumps), ` +
+        `write .claude/skip-worktree first, then retry.\n`,
+    );
+    process.exit(1);
+  } catch {
+    process.exit(0);
+  }
+});
+```
+
+- [ ] **Step 2: Run full test suite**
+
+```bash
+cd /Users/f/repos/tn/tonone
+python -m pytest tests/test_hooks.py -v
+```
+
+Expected output — all pass:
+```
+tests/test_hooks.py::test_hook_files_exist PASSED
+tests/test_hooks.py::test_worktree_create_is_valid_js PASSED
+tests/test_hooks.py::test_worktree_gate_is_valid_js PASSED
+tests/test_hooks.py::test_create_ignores_non_exit_plan_mode PASSED
+tests/test_hooks.py::test_create_handles_invalid_json PASSED
+tests/test_hooks.py::test_gate_allows_non_gated_tools PASSED
+tests/test_hooks.py::test_gate_allows_skip_marker_creation PASSED
+tests/test_hooks.py::test_gate_allows_skip_marker_with_absolute_path PASSED
+tests/test_hooks.py::test_gate_handles_invalid_json PASSED
+tests/test_hooks.py::test_gate_message_is_actionable PASSED
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add hooks/tonone-worktree-gate.js tests/test_hooks.py
+git commit -m "feat(worktree): auto-create worktree on first edit — drop plan gate, inline creation"
+```
+
+---
+
+## Task 3: Sync to plugin cache
+
+**Files:**
+- Modify: `/Users/f/.claude/plugins/cache/tonone-ai/tonone/0.6.9/hooks/tonone-worktree-gate.js`
+
+- [ ] **Step 1: Copy rewritten hook to plugin cache**
+
+```bash
+cp /Users/f/repos/tn/tonone/hooks/tonone-worktree-gate.js \
+   /Users/f/.claude/plugins/cache/tonone-ai/tonone/0.6.9/hooks/tonone-worktree-gate.js
+```
+
+- [ ] **Step 2: Smoke test — trigger Edit on main and confirm WORKTREE_READY fires**
+
+Run a manual test: pipe an Edit payload to the cached hook from a non-worktree directory:
+
+```bash
+cd /Users/f/repos/tn/tonone
+echo '{"tool_name":"Edit","tool_input":{"file_path":"hooks/tonone-worktree-gate.js"}}' \
+  | node /Users/f/.claude/plugins/cache/tonone-ai/tonone/0.6.9/hooks/tonone-worktree-gate.js
+echo "exit: $?"
+```
+
+Expected: stdout contains `WORKTREE_READY`, exit code 1.
+
+Note: a worktree will be created at `.claude/worktrees/impl-*`. Clean it up afterward:
+
+```bash
+# List created worktrees
+git worktree list
+
+# Remove test worktree (replace <name> with the impl-* name)
+git worktree remove .claude/worktrees/<name> --force
+git branch -d <name>
+```

--- a/docs/superpowers/specs/2026-04-12-auto-worktree-on-edit.md
+++ b/docs/superpowers/specs/2026-04-12-auto-worktree-on-edit.md
@@ -1,0 +1,83 @@
+# Auto-Worktree on First Edit
+
+**Date:** 2026-04-12  
+**Status:** Approved
+
+## Problem
+
+The auto-worktree system triggers only on `ExitPlanMode`. Ad-hoc sessions that skip plan mode (quick bug fixes, small changes) always run on main. No worktree is created, no isolation happens.
+
+## Goal
+
+Any edit on main automatically redirects to an isolated worktree. Zero user friction — Claude handles the transition invisibly.
+
+## Design
+
+### Gate hook — `tonone-worktree-gate.js`
+
+**Trigger:** `PreToolUse` on `Edit | Write | NotebookEdit`
+
+**Flow:**
+
+```
+Edit attempted on main
+  │
+  ├─ Already in worktree? → exit 0 (allow)
+  ├─ .claude/skip-worktree present and < 2h old? → exit 0 (allow)
+  ├─ Writing .claude/skip-worktree itself? → exit 0 (allow)
+  │
+  └─ On main with no opt-out
+       │
+       ├─ Pre-existing worktree in .claude/worktrees/impl-*? → use it
+       ├─ No pre-existing? → create impl-YYYYMMDD-HHMMSS-PID
+       │
+       ├─ Creation succeeded? → exit 1, stdout:
+       │    "WORKTREE_READY: Worktree created at <path>.
+       │     Call EnterWorktree('<path>') then retry your edit."
+       │
+       └─ Creation failed? → exit 0 (silent fallthrough, allow on main)
+```
+
+**Removed:** `hasRecentPlan` check (gstack plan gate). Gate now fires unconditionally on main.
+
+**Worktree reuse:** If `.claude/worktrees/` already has `impl-*` entries (pre-created by `tonone-worktree-create.js` on `ExitPlanMode`), the gate picks the most recent one (lexicographic sort descending) instead of creating a new one.
+
+### Create hook — `tonone-worktree-create.js`
+
+No changes. Still fires on `ExitPlanMode` to pre-create a worktree proactively. When a plan exits, the worktree is ready before the first edit fires.
+
+### Exit message tone
+
+Current gate message is alarming ("WORKTREE_REQUIRED: You have an active implementation plan but are editing files directly on main. This can conflict..."). New message is instructional and neutral:
+
+```
+WORKTREE_READY: Isolated workspace created for this session.
+Path: .claude/worktrees/impl-20260412-143022-12345
+Branch: impl-20260412-143022-12345
+
+Call EnterWorktree(".claude/worktrees/impl-20260412-143022-12345") now, then retry your edit.
+```
+
+### Opt-out
+
+`.claude/skip-worktree` — write this file to allow deliberate main-branch edits (CHANGELOG, version bumps, docs). Valid for 2 hours from last modification.
+
+## Tests
+
+**Remove:** `test_gate_block_message_is_actionable` — references old `hasRecentPlan` behavior and is environment-dependent.
+
+**Add:**
+- `test_gate_exits_0_if_already_in_worktree` — mock `git rev-parse --git-dir` ≠ `--git-common-dir`
+- `test_gate_exits_0_on_skip_marker` — existing behavior, keep
+- `test_gate_message_format_on_main` — check stdout contains `WORKTREE_READY` and `EnterWorktree`
+
+Note: full blocking behavior (exit 1) remains environment-dependent (requires real git repo not in worktree). Tests cover message format and opt-out paths; integration behavior is validated manually.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `hooks/tonone-worktree-gate.js` | Rewrite: drop plan check, add inline worktree creation, update message |
+| `tests/test_hooks.py` | Remove 1 test, add 2 tests |
+| `.claude-plugin/plugin.json` | No change |
+| `hooks/tonone-worktree-create.js` | No change |

--- a/hooks/tonone-worktree-gate.js
+++ b/hooks/tonone-worktree-gate.js
@@ -1,16 +1,15 @@
 #!/usr/bin/env node
 // tonone-worktree-gate — PreToolUse hook for Edit/Write/NotebookEdit
 //
-// Safety net: if an agent tries to edit files while on main AND a recent
-// implementation plan exists, block and tell the agent to call EnterWorktree.
+// On any file-modifying tool call while on main: auto-creates (or reuses) an
+// isolated worktree and tells Claude to enter it before proceeding.
 //
-// Opt-out: agent creates .claude/skip-worktree (valid for 2 hours) to allow
-// deliberate main-branch edits (docs, CHANGELOG, version bumps, etc).
+// Opt-out: write .claude/skip-worktree (valid 2 hours) for deliberate main
+// edits (docs, CHANGELOG, version bumps).
 
-const { execSync } = require("child_process");
+const { execSync, spawnSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
-const os = require("os");
 
 let input = "";
 const timeout = setTimeout(() => process.exit(0), 3000);
@@ -28,8 +27,7 @@ process.stdin.on("end", () => {
     if (!GATED.includes(toolName)) process.exit(0);
 
     // Whitelist: always allow creating the opt-out marker itself
-    const filePath =
-      toolInput.file_path || toolInput.notebook_path || "";
+    const filePath = toolInput.file_path || toolInput.notebook_path || "";
     if (
       filePath === ".claude/skip-worktree" ||
       filePath.endsWith("/.claude/skip-worktree")
@@ -41,11 +39,9 @@ process.stdin.on("end", () => {
     const skipMarker = ".claude/skip-worktree";
     if (fs.existsSync(skipMarker)) {
       const stat = fs.statSync(skipMarker);
-      const ageMs = Date.now() - stat.mtimeMs;
-      if (ageMs < 2 * 60 * 60 * 1000) {
-        process.exit(0); // Valid opt-out — allow
+      if (Date.now() - stat.mtimeMs < 2 * 60 * 60 * 1000) {
+        process.exit(0);
       }
-      // Stale marker (>2h) — fall through to check
     }
 
     // Check if already in a worktree
@@ -63,56 +59,72 @@ process.stdin.on("end", () => {
       process.exit(0); // Already in a worktree — allow
     }
 
-    // Check for a recent gstack plan (modified within last 24h) as implementation signal.
-    // gstack is the office-hours/planning tool (github.com/... — see ~/.claude/skills/gstack/).
-    // ceo-plans/ stores approved design docs. If gstack is not installed, hasRecentPlan stays
-    // false and the gate never fires — the feature degrades gracefully to a no-op.
-    const gstackProjects = path.join(os.homedir(), ".gstack", "projects");
-    let hasRecentPlan = false;
-    try {
-      const result = execSync(
-        `find "${gstackProjects}" -name "*.md" -path "*/ceo-plans/*" -mtime -1 2>/dev/null`,
-        { encoding: "utf8" },
-      ).trim();
-      hasRecentPlan = result.length > 0;
-    } catch {
-      hasRecentPlan = false;
-    }
+    // On main. Try to reuse a worktree pre-created by tonone-worktree-create.
+    const worktreesDir = ".claude/worktrees";
+    let worktreePath = null;
+    let branchName = null;
 
-    if (!hasRecentPlan) {
-      process.exit(0); // No recent plan = exploratory session, allow
-    }
-
-    // Check for a pre-created worktree to guide Claude
-    let worktreeHint = "";
     try {
-      const worktreesDir = ".claude/worktrees";
       if (fs.existsSync(worktreesDir)) {
-        // Sort lexicographically reversed: impl-YYYYMMDD-HHMMSS-PID names are chronologically
-        // ordered by their string value, so this surfaces the most recently created worktree.
+        // Lexicographic descending = most-recent impl-YYYYMMDD-HHMMSS-PID first
         const entries = fs
           .readdirSync(worktreesDir)
           .filter((e) => e.startsWith("impl-"))
           .sort()
           .reverse();
-        if (entries.length > 0) {
-          worktreeHint = `\nA pre-created worktree is available: .claude/worktrees/${entries[0]}`;
+        for (const entry of entries) {
+          const candidate = path.join(worktreesDir, entry);
+          if (fs.existsSync(candidate)) {
+            worktreePath = candidate;
+            branchName = entry;
+            break;
+          }
         }
       }
     } catch {}
 
-    // Block with actionable message
-    process.stderr.write(
-      `WORKTREE_REQUIRED: You have an active implementation plan but are editing files directly on main.\n` +
-        `This can conflict with other concurrent sessions.\n\n` +
-        `Options:\n` +
-        `(a) Call EnterWorktree to create an isolated workspace.${worktreeHint}\n` +
-        `(b) If this edit is intentionally on main (docs, CHANGELOG, version bumps),\n` +
-        `    write .claude/skip-worktree first, then retry the edit.\n`,
+    // No pre-existing worktree — create one now.
+    if (!worktreePath) {
+      const now = new Date();
+      const pad = (n) => String(n).padStart(2, "0");
+      const dateStr = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}`;
+      const timeStr = `${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+      const base = `impl-${dateStr}-${timeStr}-${process.pid}`;
+
+      for (let i = 0; i < 5; i++) {
+        const suffix = i === 0 ? "" : `-${i + 1}`;
+        const candidate = base + suffix;
+        const wPath = path.join(worktreesDir, candidate);
+        const result = spawnSync(
+          "git",
+          ["worktree", "add", wPath, "-b", candidate],
+          { encoding: "utf8" },
+        );
+        if (result.status === 0) {
+          worktreePath = wPath;
+          branchName = candidate;
+          break;
+        }
+      }
+    }
+
+    // Creation failed — silent fallthrough, allow edit on main.
+    if (!worktreePath) {
+      process.exit(0);
+    }
+
+    // Block and redirect to worktree.
+    process.stdout.write(
+      `\nWORKTREE_READY: An isolated workspace is ready for this session.\n` +
+        `Path: ${worktreePath}\n` +
+        `Branch: ${branchName}\n\n` +
+        `Call EnterWorktree("${worktreePath}") now, then retry your edit. ` +
+        `This keeps your changes isolated from other concurrent sessions.\n` +
+        `\nTo edit on main intentionally (docs, CHANGELOG, version bumps), ` +
+        `write .claude/skip-worktree first, then retry.\n`,
     );
     process.exit(1);
   } catch {
-    // Silent fail — never block the user on a hook crash
     process.exit(0);
   }
 });

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -135,10 +135,10 @@ def test_gate_handles_invalid_json():
     assert proc.returncode == 0
 
 
-def test_gate_block_message_is_actionable():
-    """When gate blocks, stderr must contain both action options."""
+def test_gate_message_is_actionable():
+    """When gate blocks, stdout must contain WORKTREE_READY, EnterWorktree, and skip-worktree opt-out."""
     source = GATE.read_text()
-    assert "WORKTREE_REQUIRED" in source
+    assert "WORKTREE_READY" in source
     assert "EnterWorktree" in source
     assert ".claude/skip-worktree" in source
     assert "process.exit(1)" in source


### PR DESCRIPTION
## Summary

- Drop `hasRecentPlan` gstack gate — worktree now triggers on **any** Edit/Write on main, not just after a plan exits
- Gate auto-creates (or reuses) an isolated worktree inline and redirects Claude with `WORKTREE_READY` + `EnterWorktree` call — zero user friction
- Stale worktree reuse guarded: iterates candidates, `fs.existsSync` check, falls through to creation if none valid
- Silent fallthrough on creation failure — never blocks workflow

## Test Plan

- [x] 10/10 tests passing (`tests/test_hooks.py`)
- [x] Smoke tested: Edit payload → `WORKTREE_READY` on stdout, exit 1
- [ ] Trigger an ad-hoc edit session without plan mode — confirm worktree auto-created

🤖 Generated with [Claude Code](https://claude.com/claude-code)