### PR TITLE
feat(elephant): /elephant takeover — cold-start memory bootstrap from git history

### DIFF
--- a/skills/elephant/SKILL.md
+++ b/skills/elephant/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: elephant
-description: Persistent memory commands. /elephant save <text> — write entry. /elephant save !! <text> — write important entry. /elephant show — print memory. /elephant compact — compress old entries.
+description: Persistent memory commands. /elephant save <text> — write entry. /elephant save !! <text> — write important entry. /elephant show — print memory. /elephant compact — compress old entries. /elephant takeover [N] — seed memory from git history (cold start bootstrap).
 allowed-tools: Read, Write, Edit, Bash
-version: 1.0.0
+version: 1.1.0
 author: tonone-ai <hello@tonone.ai>
 license: MIT
 ---
@@ -59,3 +59,56 @@ Compress old routine entries (older than 7 days, no `[!!]` prefix).
 5. Write compacted file back (use a temp file + rename for atomicity)
 6. Do same for `~/.claude/elephant/memory.md` (filter to this repo's entries only when compacting)
 7. Report: `compacted N entries into M lines`
+
+### `/elephant takeover [N]`
+
+Bootstrap memory from git history. Solves cold-start: empty memory → no recall. Seeds backdated entries from real commit history.
+
+Default N = 60 commits. User can pass a number: `/elephant takeover 100`.
+
+Steps:
+
+1. Check if `.elephant/memory.md` exists. If it does and has entries, print warning:
+   `⚠ memory already seeded (N entries). re-run to append git history below existing entries.`
+   Then continue (don't abort — append git entries below existing).
+
+2. Run: `git log --format="%ci|||%s|||%H" -N` via Bash.
+   - `%ci` = ISO 8601 date: `2026-04-12 13:58:23 +0000`
+   - `%s` = subject line
+   - `%H` = full hash (used only to detect merge commits)
+
+   If git fails (not a git repo): print `not a git repo. nothing to seed.` and stop.
+
+   Skip bare upstream sync commits: lines where subject matches `^Merge branch '.+' of https?://` — these are `git pull` noise with no content value.
+
+3. For each remaining commit line, parse:
+   - **Timestamp**: take first 16 chars of `%ci` → `YYYY-MM-DD HH:MM`
+   - **Subject**: caveman-compress (drop a/an/the/just/really/basically/actually/simply, max 100 chars)
+   - **Important?**: mark `[!!]` if subject matches any of:
+     - starts with `feat`, `fix`, `breaking`, `release`, `deploy`, `revert`
+     - contains `Merge pull request` or `Merge branch`
+     - conventional commit with `!` (e.g. `feat!:`, `fix!:`)
+     - subject contains `(#` (PR reference = likely significant)
+
+4. Format entries (newest first, matching git log default order):
+   ```
+   [!!] 2026-04-12 13:58 : feat: elephant memory system
+   2026-04-12 12:00 : fix typo in output kit
+   ```
+
+5. Write to `.elephant/memory.md`:
+   - If file didn't exist: create dir + file, write all entries.
+   - If file existed: prepend nothing new to existing entries; instead append git entries BELOW (so existing human entries stay at top).
+   - Use a temp file + rename for atomicity.
+
+6. For each entry, also append to `~/.claude/elephant/memory.md` (repo-prefixed):
+   ```
+   [!!] 2026-04-12 13:58 : tonone : feat: elephant memory system
+   ```
+   Append only entries not already present (match on timestamp + text).
+
+7. Report:
+   ```
+   seeded N entries (YYYY-MM-DD → YYYY-MM-DD) — M marked [!!]
+   tip: run /elephant compact to merge old routine entries
+   ```


### PR DESCRIPTION
## Summary

Adds `/elephant takeover [N]` subcommand to the elephant skill. Solves the cold-start problem: when starting fresh in a repo, `.elephant/memory.md` is empty and the startup recall block shows nothing useful.

**What it does:**
- Reads last N commits from `git log` (default 60, configurable)
- Skips bare upstream sync commits (`Merge branch 'main' of <remote>`) — noise with no content value
- Marks commits as `[!!]` if they are: `feat`/`fix`/`breaking`/`release`/`deploy`, PR references `(#N)`, `feat!:` style, or `Merge pull request`
- Caveman-compresses all subjects (drops articles/filler, max 100 chars)
- Appends git entries below any existing human entries (preserves those at top)
- Updates global `~/.claude/elephant/memory.md` with repo-prefixed entries, deduplicating against existing content

**Result:** After `/elephant takeover`, next session startup shows a full recall block with real project history instead of "nothing yet."

## Changes

- `skills/elephant/SKILL.md` — added `### /elephant takeover [N]` section, bumped version to 1.1.0, updated frontmatter description

## Test plan

- [ ] Run `/elephant takeover` in a repo with no `.elephant/memory.md` → file created with git entries
- [ ] Run `/elephant takeover` in a repo with existing entries → git entries appended below, existing preserved at top
- [ ] Verify bare upstream merges are excluded
- [ ] Verify `feat:`/`fix:`/PR-ref commits get `[!!]` prefix
- [ ] Verify global `~/.claude/elephant/memory.md` updated with repo-prefixed entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)