### PR TITLE
feat(worktree): human-readable branch names via .claude/branch-slug

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -102,6 +102,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/tonone-git-gate.js\"",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "Stop": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,18 @@ cd team/forge/scripts && bash setup.sh
 .venv/bin/python -m pytest ../tests/
 ```
 
+## Worktree branch naming
+
+Before making the first edit in an implementation session, write a short kebab-case description of the task to `.claude/branch-slug`. The worktree hooks read this file to name the branch.
+
+```bash
+# Example — do this before any file edit:
+echo "fix-auth-bug" > .claude/branch-slug
+echo "add-worktree-git-gate" > .claude/branch-slug
+```
+
+No slashes. Lowercase. Max 50 chars. If omitted, branch falls back to `impl-YYYYMMDD-HHMMSS`.
+
 ## Skill routing
 
 When the user's request matches an available skill, ALWAYS invoke it using the Skill

--- a/docs/superpowers/plans/2026-04-12-worktree-git-gate.md
+++ b/docs/superpowers/plans/2026-04-12-worktree-git-gate.md
@@ -1,0 +1,340 @@
+# Worktree Git Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Block `git commit` and `git push` on main via a new Bash PreToolUse hook, closing the last gap in worktree isolation.
+
+**Architecture:** New `hooks/tonone-git-gate.js` mirrors the existing `tonone-worktree-gate.js` pattern — parse stdin, check opt-out, check worktree status, block or pass. Registered in `.claude-plugin/plugin.json` under `PreToolUse` with matcher `Bash`. Tests added to `tests/test_hooks.py` following existing hook test conventions.
+
+**Tech Stack:** Node.js (hook), Python pytest (tests), JSON (plugin.json)
+
+---
+
+### Task 1: Write failing tests for `tonone-git-gate.js`
+
+**Files:**
+- Modify: `tests/test_hooks.py`
+
+- [ ] **Step 1: Add GIT_GATE path constant and tests at the bottom of `tests/test_hooks.py`**
+
+Append after the last line of `tests/test_hooks.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# tonone-git-gate.js
+# ---------------------------------------------------------------------------
+
+GIT_GATE = REPO / "hooks" / "tonone-git-gate.js"
+
+
+def test_git_gate_file_exists():
+    """Git gate hook file must exist."""
+    assert GIT_GATE.exists(), f"Missing: {GIT_GATE}"
+
+
+def test_git_gate_is_valid_js():
+    """tonone-git-gate.js must be syntactically valid Node.js."""
+    result = subprocess.run(
+        ["node", "--check", str(GIT_GATE)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_git_gate_allows_non_git_commands():
+    """Gate exits 0 for Bash commands that are not git commit/push."""
+    for cmd in ["npm test", "echo hello", "git status", "git log", "git add ."]:
+        rc, _, _ = run_hook(GIT_GATE, {
+            "tool_name": "Bash",
+            "tool_input": {"command": cmd},
+        })
+        assert rc == 0, f"Expected exit 0 for command={cmd!r}, got {rc}"
+
+
+def test_git_gate_allows_non_bash_tools():
+    """Gate exits 0 for tools other than Bash."""
+    for tool in ["Edit", "Write", "Read", "Agent"]:
+        rc, _, _ = run_hook(GIT_GATE, {
+            "tool_name": tool,
+            "tool_input": {"command": "git commit -m 'test'"},
+        })
+        assert rc == 0, f"Expected exit 0 for tool={tool}, got {rc}"
+
+
+def test_git_gate_handles_invalid_json():
+    """Git gate exits 0 on invalid stdin — must never block user on a crash."""
+    proc = subprocess.run(
+        ["node", str(GIT_GATE)],
+        input="not json",
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert proc.returncode == 0
+
+
+def test_git_gate_message_is_actionable():
+    """When git gate blocks, source must contain GIT_GATE, EnterWorktree, and skip-worktree."""
+    source = GIT_GATE.read_text()
+    assert "GIT_GATE" in source
+    assert "EnterWorktree" in source
+    assert ".claude/skip-worktree" in source
+    assert "process.exit(1)" in source
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail (file doesn't exist yet)**
+
+```bash
+cd /Users/f/repos/tn/tonone && python -m pytest tests/test_hooks.py::test_git_gate_file_exists tests/test_hooks.py::test_git_gate_is_valid_js -v
+```
+
+Expected: FAIL — `Missing: .../hooks/tonone-git-gate.js`
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add tests/test_hooks.py
+git commit -m "test(worktree): add failing tests for tonone-git-gate.js"
+```
+
+---
+
+### Task 2: Implement `hooks/tonone-git-gate.js`
+
+**Files:**
+- Create: `hooks/tonone-git-gate.js`
+
+- [ ] **Step 1: Create the hook file**
+
+```javascript
+#!/usr/bin/env node
+// tonone-git-gate — PreToolUse hook for Bash
+//
+// Blocks `git commit` and `git push` when on main (not in a worktree).
+// Ensures all commits stay on the worktree branch until explicitly shipped.
+//
+// Opt-out: write .claude/skip-worktree (valid 2 hours) for deliberate main
+// operations (docs, CHANGELOG, version bumps).
+
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+let input = "";
+const timeout = setTimeout(() => process.exit(0), 3000);
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => (input += chunk));
+process.stdin.on("end", () => {
+  clearTimeout(timeout);
+  try {
+    const data = JSON.parse(input);
+    const command = (data.tool_input && data.tool_input.command) || "";
+
+    // Only gate git commit and git push
+    if (!/\bgit\s+(commit|push)\b/.test(command)) process.exit(0);
+
+    // Check opt-out marker (valid 2 hours)
+    const skipMarker = ".claude/skip-worktree";
+    if (fs.existsSync(skipMarker)) {
+      const stat = fs.statSync(skipMarker);
+      if (Date.now() - stat.mtimeMs < 2 * 60 * 60 * 1000) process.exit(0);
+    }
+
+    // Check if already in a worktree
+    let gitDir, commonDir;
+    try {
+      gitDir = execSync("git rev-parse --git-dir", { encoding: "utf8" }).trim();
+      commonDir = execSync("git rev-parse --git-common-dir", {
+        encoding: "utf8",
+      }).trim();
+    } catch {
+      process.exit(0); // Not a git repo — allow
+    }
+
+    if (gitDir !== commonDir) process.exit(0); // Already in worktree — allow
+
+    // On main. Find the most-recent pre-created worktree.
+    const worktreesDir = ".claude/worktrees";
+    let worktreePath = null;
+    let branchName = null;
+
+    try {
+      if (fs.existsSync(worktreesDir)) {
+        const entries = fs
+          .readdirSync(worktreesDir)
+          .filter((e) => e.startsWith("impl-"))
+          .sort()
+          .reverse();
+        for (const entry of entries) {
+          const candidate = path.join(worktreesDir, entry);
+          if (fs.existsSync(candidate)) {
+            worktreePath = candidate;
+            branchName = entry;
+            break;
+          }
+        }
+      }
+    } catch {}
+
+    const redirect = worktreePath
+      ? `Call EnterWorktree("${worktreePath}") first, then retry your command.\nBranch: ${branchName}`
+      : `No worktree found. Edit a file first to auto-create one, then retry.`;
+
+    process.stdout.write(
+      `\nGIT_GATE: Commits and pushes are blocked on main.\n` +
+        `${redirect}\n\n` +
+        `To commit on main intentionally (docs, CHANGELOG, version bumps), ` +
+        `write .claude/skip-worktree first, then retry.\n`,
+    );
+    process.exit(1);
+  } catch {
+    // Silent fail — never block the user's workflow on a hook crash
+    process.exit(0);
+  }
+});
+```
+
+- [ ] **Step 2: Run all git gate tests**
+
+```bash
+cd /Users/f/repos/tn/tonone && python -m pytest tests/test_hooks.py -k git_gate -v
+```
+
+Expected: all PASS
+
+- [ ] **Step 3: Run the full test suite to check for regressions**
+
+```bash
+cd /Users/f/repos/tn/tonone && python -m pytest tests/ -v
+```
+
+Expected: all PASS
+
+- [ ] **Step 4: Commit the hook**
+
+```bash
+git add hooks/tonone-git-gate.js
+git commit -m "feat(worktree): add tonone-git-gate — block git commit/push on main"
+```
+
+---
+
+### Task 3: Register hook in `plugin.json`
+
+**Files:**
+- Modify: `.claude-plugin/plugin.json`
+
+- [ ] **Step 1: Add the Bash PreToolUse entry**
+
+In `.claude-plugin/plugin.json`, inside the `"PreToolUse"` array (after the existing `Edit|Write|NotebookEdit` entry), add:
+
+```json
+{
+  "matcher": "Bash",
+  "hooks": [
+    {
+      "type": "command",
+      "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/tonone-git-gate.js\"",
+      "timeout": 5
+    }
+  ]
+}
+```
+
+The full `"PreToolUse"` section should look like:
+
+```json
+"PreToolUse": [
+  {
+    "matcher": "Edit|Write|NotebookEdit",
+    "hooks": [
+      {
+        "type": "command",
+        "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/tonone-worktree-gate.js\"",
+        "timeout": 5
+      }
+    ]
+  },
+  {
+    "matcher": "Bash",
+    "hooks": [
+      {
+        "type": "command",
+        "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/tonone-git-gate.js\"",
+        "timeout": 5
+      }
+    ]
+  }
+]
+```
+
+- [ ] **Step 2: Validate plugin.json is valid JSON**
+
+```bash
+node -e "JSON.parse(require('fs').readFileSync('.claude-plugin/plugin.json','utf8')); console.log('valid')"
+```
+
+Expected: `valid`
+
+- [ ] **Step 3: Copy hook to plugin cache so it's live immediately**
+
+```bash
+cp hooks/tonone-git-gate.js /Users/f/.claude/plugins/cache/tonone-ai/tonone/0.6.9/hooks/tonone-git-gate.js
+cp .claude-plugin/plugin.json /Users/f/.claude/plugins/cache/tonone-ai/tonone/0.6.9/.claude-plugin/plugin.json
+```
+
+- [ ] **Step 4: Run full test suite one final time**
+
+```bash
+cd /Users/f/repos/tn/tonone && python -m pytest tests/ -v
+```
+
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .claude-plugin/plugin.json
+git commit -m "feat(worktree): register git gate in plugin.json PreToolUse Bash"
+```
+
+---
+
+### Task 4: Smoke test
+
+- [ ] **Step 1: Reload plugins in Claude Code**
+
+Run `/reload-plugins` in Claude Code. Verify the new hook is listed.
+
+- [ ] **Step 2: Verify git gate blocks on main**
+
+From the main repo (not a worktree), try:
+
+```bash
+git commit --allow-empty -m "smoke test"
+```
+
+Expected: hook fires, Claude sees `GIT_GATE: Commits and pushes are blocked on main.` with `EnterWorktree(...)` instruction. Command blocked (exit 1).
+
+- [ ] **Step 3: Verify git gate allows in worktree**
+
+Enter the existing worktree and verify commit works:
+
+```bash
+# Claude calls EnterWorktree(".claude/worktrees/impl-20260412-134252-50041")
+# Then:
+git commit --allow-empty -m "smoke test from worktree"
+```
+
+Expected: commits successfully to `impl-20260412-134252-50041` branch.
+
+- [ ] **Step 4: Verify opt-out works**
+
+```bash
+touch .claude/skip-worktree
+git commit --allow-empty -m "deliberate main commit"
+rm .claude/skip-worktree
+```
+
+Expected: commit succeeds on main when skip-worktree exists.

--- a/docs/superpowers/specs/2026-04-12-worktree-enforcement-design.md
+++ b/docs/superpowers/specs/2026-04-12-worktree-enforcement-design.md
@@ -1,0 +1,73 @@
+# Worktree Enforcement — Design Spec
+
+**Date:** 2026-04-12  
+**Status:** Approved
+
+## Problem
+
+Work from different tasks gets mixed on `main`. The existing edit gate (`tonone-worktree-gate.js`) redirects file edits to an isolated worktree branch, but `git commit` and `git push` via Bash bypass the gate entirely. Commits land on main directly, defeating the isolation.
+
+## Goal
+
+Once an agent starts editing, all work — file changes AND git writes — stays on the worktree branch. `main` is untouchable until the PR is merged.
+
+## Trigger
+
+**First edit**, not session start. Read-only sessions (explore, research) don't need a worktree.
+
+## Design
+
+### New hook: `hooks/tonone-git-gate.js`
+
+`PreToolUse` hook on `Bash`. Guards `git commit` and `git push`.
+
+**Logic:**
+1. Parse `tool_input.command`. If no `git commit` or `git push` match, pass through.
+2. Check `.claude/skip-worktree` opt-out marker (2hr TTL). If valid, pass through.
+3. `git rev-parse --git-dir` vs `--git-common-dir`. If they differ, already in worktree — pass.
+4. On main: find most-recent `impl-*` dir under `.claude/worktrees/`.
+   - If found: block (exit 1), instruct Claude to `EnterWorktree(path)` then retry.
+   - If not found: block, instruct Claude to edit a file first (triggers edit gate → creates worktree), then retry.
+
+### Registration in `.claude-plugin/plugin.json`
+
+Add to `PreToolUse`:
+
+```json
+{
+  "matcher": "Bash",
+  "hooks": [{
+    "type": "command",
+    "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/tonone-git-gate.js\"",
+    "timeout": 5
+  }]
+}
+```
+
+### Ship flow (conversational, no new skill)
+
+When work is done, Claude asks: "Ready to push? I'll create a PR from `<branch>` → `main`."
+
+On user confirm, Claude (from inside the worktree):
+1. `git push -u origin <branch>`
+2. `gh pr create --title "..." --body "..."`
+3. Returns PR URL
+
+Worktree cleanup (prune + delete branch) happens after the PR is merged by the user.
+
+## Escape hatch
+
+Write `.claude/skip-worktree` to allow deliberate main operations (docs, CHANGELOG, version bumps). Valid 2 hours. Same mechanism as the edit gate.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `hooks/tonone-git-gate.js` | New — Bash PreToolUse git guard |
+| `.claude-plugin/plugin.json` | Add PreToolUse Bash matcher |
+
+## What this does NOT do
+
+- Does not block `git add` (low risk, no isolation concern)
+- Does not auto-merge PRs
+- Does not gate Bash file writes (cp, echo >) — out of scope; worktree gate covers Edit/Write tools which is the primary agent interface

--- a/hooks/tonone-git-gate.js
+++ b/hooks/tonone-git-gate.js
@@ -57,14 +57,16 @@ process.stdin.on("end", () => {
       if (fs.existsSync(worktreesDir)) {
         const entries = fs
           .readdirSync(worktreesDir)
-          .filter((e) => e.startsWith("impl-"))
-          .sort()
-          .reverse();
-        for (const entry of entries) {
-          const candidate = path.join(worktreesDir, entry);
-          if (fs.existsSync(candidate)) {
-            worktreePath = candidate;
-            branchName = entry;
+          .map((e) => {
+            const p = path.join(worktreesDir, e);
+            try { return { name: e, mtime: fs.statSync(p).mtimeMs, p }; } catch { return null; }
+          })
+          .filter(Boolean)
+          .sort((a, b) => b.mtime - a.mtime);
+        for (const { name, p } of entries) {
+          if (fs.existsSync(p)) {
+            worktreePath = p;
+            branchName = name;
             break;
           }
         }

--- a/hooks/tonone-git-gate.js
+++ b/hooks/tonone-git-gate.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// tonone-git-gate — PreToolUse hook for Bash
+//
+// Blocks `git commit` and `git push` when on main (not in a worktree).
+// Ensures all commits stay on the worktree branch until explicitly shipped.
+//
+// Opt-out: write .claude/skip-worktree (valid 2 hours) for deliberate main
+// operations (docs, CHANGELOG, version bumps).
+
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+let input = "";
+const timeout = setTimeout(() => process.exit(0), 3000);
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => (input += chunk));
+process.stdin.on("end", () => {
+  clearTimeout(timeout);
+  try {
+    const data = JSON.parse(input);
+    const toolName = data.tool_name || "";
+    const command = (data.tool_input && data.tool_input.command) || "";
+
+    // Only gate Bash tool calls
+    if (toolName !== "Bash") process.exit(0);
+
+    // Only gate git commit and git push
+    if (!/\bgit\s+(commit|push)\b/.test(command)) process.exit(0);
+
+    // Check opt-out marker (valid 2 hours)
+    const skipMarker = ".claude/skip-worktree";
+    if (fs.existsSync(skipMarker)) {
+      const stat = fs.statSync(skipMarker);
+      if (Date.now() - stat.mtimeMs < 2 * 60 * 60 * 1000) process.exit(0);
+    }
+
+    // Check if already in a worktree
+    let gitDir, commonDir;
+    try {
+      gitDir = execSync("git rev-parse --git-dir", { encoding: "utf8" }).trim();
+      commonDir = execSync("git rev-parse --git-common-dir", {
+        encoding: "utf8",
+      }).trim();
+    } catch {
+      process.exit(0); // Not a git repo — allow
+    }
+
+    if (gitDir !== commonDir) process.exit(0); // Already in worktree — allow
+
+    // On main. Find the most-recent pre-created worktree.
+    const worktreesDir = ".claude/worktrees";
+    let worktreePath = null;
+    let branchName = null;
+
+    try {
+      if (fs.existsSync(worktreesDir)) {
+        const entries = fs
+          .readdirSync(worktreesDir)
+          .filter((e) => e.startsWith("impl-"))
+          .sort()
+          .reverse();
+        for (const entry of entries) {
+          const candidate = path.join(worktreesDir, entry);
+          if (fs.existsSync(candidate)) {
+            worktreePath = candidate;
+            branchName = entry;
+            break;
+          }
+        }
+      }
+    } catch {}
+
+    const redirect = worktreePath
+      ? `Call EnterWorktree("${branchName}") first, then retry your command.\nBranch: ${branchName}`
+      : `No worktree found. Edit a file first to auto-create one, then retry.`;
+
+    process.stdout.write(
+      `\nGIT_GATE: Commits and pushes are blocked on main.\n` +
+        `${redirect}\n\n` +
+        `To commit on main intentionally (docs, CHANGELOG, version bumps), ` +
+        `write .claude/skip-worktree first, then retry.\n`,
+    );
+    process.exit(1);
+  } catch {
+    // Silent fail — never block the user's workflow on a hook crash
+    process.exit(0);
+  }
+});

--- a/hooks/tonone-worktree-create.js
+++ b/hooks/tonone-worktree-create.js
@@ -12,7 +12,18 @@
 // tries to make its first file edit.
 
 const { execSync, spawnSync } = require("child_process");
+const fs = require("fs");
 const path = require("path");
+
+/** Read .claude/branch-slug and return sanitized kebab-case name, or fallback. */
+function branchBase(fallback) {
+  try {
+    const raw = fs.readFileSync(".claude/branch-slug", "utf8").trim();
+    const slug = raw.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 50);
+    if (slug) return slug;
+  } catch {}
+  return fallback;
+}
 
 let input = "";
 const timeout = setTimeout(() => process.exit(0), 5000);
@@ -41,12 +52,12 @@ process.stdin.on("end", () => {
       process.exit(0); // Already in a worktree — nothing to do
     }
 
-    // Build a race-safe branch name: impl-YYYYMMDD-HHMMSS-PID
+    // Build branch name: from .claude/branch-slug if set, else impl-YYYYMMDD-HHMMSS-PID
     const now = new Date();
     const pad = (n) => String(n).padStart(2, "0");
     const dateStr = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}`;
     const timeStr = `${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
-    const base = `impl-${dateStr}-${timeStr}-${process.pid}`;
+    const base = branchBase(`impl-${dateStr}-${timeStr}-${process.pid}`);
 
     // Try to create the worktree (with collision retry)
     let worktreePath = null;

--- a/hooks/tonone-worktree-gate.js
+++ b/hooks/tonone-worktree-gate.js
@@ -11,6 +11,32 @@ const { execSync, spawnSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 
+/** Read .claude/branch-slug and return sanitized kebab-case name, or fallback. */
+function branchBase(fallback) {
+  try {
+    const raw = fs.readFileSync(".claude/branch-slug", "utf8").trim();
+    const slug = raw.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 50);
+    if (slug) return slug;
+  } catch {}
+  return fallback;
+}
+
+/** List .claude/worktrees entries sorted by mtime descending (most recent first). */
+function latestWorktree(worktreesDir) {
+  if (!fs.existsSync(worktreesDir)) return null;
+  const entries = fs.readdirSync(worktreesDir)
+    .map((e) => {
+      const p = path.join(worktreesDir, e);
+      try { return { name: e, mtime: fs.statSync(p).mtimeMs, p }; } catch { return null; }
+    })
+    .filter(Boolean)
+    .sort((a, b) => b.mtime - a.mtime);
+  for (const { name, p } of entries) {
+    if (fs.existsSync(p)) return { worktreePath: p, branchName: name };
+  }
+  return null;
+}
+
 let input = "";
 const timeout = setTimeout(() => process.exit(0), 3000);
 process.stdin.setEncoding("utf8");
@@ -65,22 +91,8 @@ process.stdin.on("end", () => {
     let branchName = null;
 
     try {
-      if (fs.existsSync(worktreesDir)) {
-        // Lexicographic descending = most-recent impl-YYYYMMDD-HHMMSS-PID first
-        const entries = fs
-          .readdirSync(worktreesDir)
-          .filter((e) => e.startsWith("impl-"))
-          .sort()
-          .reverse();
-        for (const entry of entries) {
-          const candidate = path.join(worktreesDir, entry);
-          if (fs.existsSync(candidate)) {
-            worktreePath = candidate;
-            branchName = entry;
-            break;
-          }
-        }
-      }
+      const found = latestWorktree(worktreesDir);
+      if (found) ({ worktreePath, branchName } = found);
     } catch {}
 
     // No pre-existing worktree — create one now.
@@ -89,7 +101,7 @@ process.stdin.on("end", () => {
       const pad = (n) => String(n).padStart(2, "0");
       const dateStr = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}`;
       const timeStr = `${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
-      const base = `impl-${dateStr}-${timeStr}-${process.pid}`;
+      const base = branchBase(`impl-${dateStr}-${timeStr}-${process.pid}`);
 
       for (let i = 0; i < 5; i++) {
         const suffix = i === 0 ? "" : `-${i + 1}`;
@@ -120,6 +132,8 @@ process.stdin.on("end", () => {
         `Branch: ${branchName}\n\n` +
         `Call EnterWorktree("${worktreePath}") now, then retry your edit. ` +
         `This keeps your changes isolated from other concurrent sessions.\n` +
+        `\nTip: set a human-readable branch name by writing a kebab-case slug to ` +
+        `.claude/branch-slug before your first edit (e.g. "fix-auth-bug").\n` +
         `\nTo edit on main intentionally (docs, CHANGELOG, version bumps), ` +
         `write .claude/skip-worktree first, then retry.\n`,
     );

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -148,3 +148,66 @@ def test_gate_message_is_actionable():
 # environment-dependent (requires: not in a worktree AND a recent ~/.gstack plan).
 # It is validated in the smoke test (Task 7 of the implementation plan) rather
 # than here, where we can only inspect the source code for correctness.
+
+
+# ---------------------------------------------------------------------------
+# tonone-git-gate.js
+# ---------------------------------------------------------------------------
+
+GIT_GATE = REPO / "hooks" / "tonone-git-gate.js"
+
+
+def test_git_gate_file_exists():
+    """Git gate hook file must exist."""
+    assert GIT_GATE.exists(), f"Missing: {GIT_GATE}"
+
+
+def test_git_gate_is_valid_js():
+    """tonone-git-gate.js must be syntactically valid Node.js."""
+    result = subprocess.run(
+        ["node", "--check", str(GIT_GATE)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_git_gate_allows_non_git_commands():
+    """Gate exits 0 for Bash commands that are not git commit/push."""
+    for cmd in ["npm test", "echo hello", "git status", "git log", "git add ."]:
+        rc, _, _ = run_hook(GIT_GATE, {
+            "tool_name": "Bash",
+            "tool_input": {"command": cmd},
+        })
+        assert rc == 0, f"Expected exit 0 for command={cmd!r}, got {rc}"
+
+
+def test_git_gate_allows_non_bash_tools():
+    """Gate exits 0 for tools other than Bash."""
+    for tool in ["Edit", "Write", "Read", "Agent"]:
+        rc, _, _ = run_hook(GIT_GATE, {
+            "tool_name": tool,
+            "tool_input": {"command": "git commit -m 'test'"},
+        })
+        assert rc == 0, f"Expected exit 0 for tool={tool}, got {rc}"
+
+
+def test_git_gate_handles_invalid_json():
+    """Git gate exits 0 on invalid stdin — must never block user on a crash."""
+    proc = subprocess.run(
+        ["node", str(GIT_GATE)],
+        input="not json",
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert proc.returncode == 0
+
+
+def test_git_gate_message_is_actionable():
+    """When git gate blocks, source must contain GIT_GATE, EnterWorktree, and skip-worktree."""
+    source = GIT_GATE.read_text()
+    assert "GIT_GATE" in source
+    assert "EnterWorktree" in source
+    assert ".claude/skip-worktree" in source
+    assert "process.exit(1)" in source


### PR DESCRIPTION
## Summary

- Worktree hooks now read `.claude/branch-slug` to name the branch instead of `impl-YYYYMMDD-HHMMSS-PID`
- Falls back to timestamp name if slug not set
- Worktree scanner now uses mtime sort (no `impl-` prefix filter) — works with any branch name
- CLAUDE.md documents the convention: write slug before first edit

## How it works

```bash
# Before first edit in a session:
echo "fix-auth-bug" > .claude/branch-slug
```

Worktree is created as `fix-auth-bug` instead of `impl-20260412-134252-50041`.

## Test plan

- [ ] All 16 hook tests pass (`pytest tests/test_hooks.py`)
- [ ] Write `.claude/branch-slug` with a slug, trigger first edit → worktree created with that name
- [ ] Without `.claude/branch-slug` → falls back to `impl-YYYYMMDD-HHMMSS`
- [ ] Mtime-based scanner picks up non-`impl-` worktrees correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)