### PR TITLE
feat(growth): PR attribution — append team credits to boost K-factor

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -68,6 +68,11 @@
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/elephant-writer.js\"",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/tonone-pr-attribution.js\"",
+            "timeout": 10
           }
         ]
       },
@@ -77,6 +82,11 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/elephant-writer.js\"",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/tonone-session-tracker.js\"",
             "timeout": 5
           }
         ]

--- a/hooks/tonone-pr-attribution.js
+++ b/hooks/tonone-pr-attribution.js
@@ -95,12 +95,12 @@ process.stdin.on("end", () => {
 
     const agents = readAgents();
     const attributionLine = formatAttribution(agents);
-    clearAgents();
 
     const prUrl = getPrUrl(data.tool_output);
     if (!prUrl) process.exit(0);
 
     appendAttribution(prUrl, attributionLine);
+    clearAgents();
   } catch {
     // Silent fail
   }

--- a/hooks/tonone-pr-attribution.js
+++ b/hooks/tonone-pr-attribution.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+// tonone-pr-attribution — PostToolUse Bash hook
+// Detects `gh pr create`, appends agent credits to the PR description.
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { execSync } = require("child_process");
+
+const SESSION_FILE = path.join(".claude", "session-agents");
+const TONONE_URL = "https://second.tonone.ai";
+const MAX_AGENTS = 5;
+
+function titleCase(s) {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function formatAttribution(agents) {
+  if (!agents || agents.length === 0) {
+    return `*— [tonone](${TONONE_URL})*`;
+  }
+  const sorted = [...agents].sort();
+  let names;
+  if (sorted.length <= MAX_AGENTS) {
+    names = sorted.map(titleCase).join(" · ");
+  } else {
+    const shown = sorted.slice(0, MAX_AGENTS).map(titleCase).join(" · ");
+    const remaining = sorted.length - MAX_AGENTS;
+    names = `${shown} and ${remaining} more`;
+  }
+  return `*${names} — [tonone](${TONONE_URL})*`;
+}
+
+function readAgents() {
+  try {
+    const content = fs.readFileSync(SESSION_FILE, "utf8");
+    return [...new Set(content.trim().split("\n").filter(Boolean))];
+  } catch {
+    return [];
+  }
+}
+
+function clearAgents() {
+  try { fs.writeFileSync(SESSION_FILE, ""); } catch {}
+}
+
+function getPrUrl(toolOutput) {
+  const raw = (toolOutput && (toolOutput.output || toolOutput)) || "";
+  const urlMatch = String(raw).match(/https:\/\/github\.com\/[^\s]+\/pull\/\d+/);
+  if (urlMatch) return urlMatch[0];
+  try {
+    const url = execSync("gh pr view --json url -q .url", { encoding: "utf8", timeout: 5000 }).trim();
+    if (url.startsWith("http")) return url;
+  } catch {}
+  return null;
+}
+
+function appendAttribution(prUrl, attributionLine) {
+  const tmpFile = path.join(os.tmpdir(), `tonone-pr-body-${process.pid}.md`);
+  try {
+    const currentBody = execSync(`gh pr view "${prUrl}" --json body -q .body`, { encoding: "utf8", timeout: 5000 }).trim();
+    const newBody = `${currentBody}\n\n---\n${attributionLine}`;
+    fs.writeFileSync(tmpFile, newBody);
+    execSync(`gh pr edit "${prUrl}" --body-file "${tmpFile}"`, { timeout: 10000 });
+  } finally {
+    try { fs.unlinkSync(tmpFile); } catch {}
+  }
+}
+
+if (require.main !== module) {
+  module.exports = { formatAttribution };
+  return;
+}
+
+let input = "";
+const timeout = setTimeout(() => process.exit(0), 3000);
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", chunk => (input += chunk));
+process.stdin.on("end", () => {
+  clearTimeout(timeout);
+  try {
+    const data = JSON.parse(input);
+
+    if (data.tool_name !== "Bash") process.exit(0);
+
+    const command = (data.tool_input && data.tool_input.command) || "";
+    if (!/\bgh\s+pr\s+create\b/.test(command)) process.exit(0);
+
+    const agents = readAgents();
+    const attributionLine = formatAttribution(agents);
+    clearAgents();
+
+    const prUrl = getPrUrl(data.tool_output);
+    if (!prUrl) process.exit(0);
+
+    appendAttribution(prUrl, attributionLine);
+  } catch {
+    // Silent fail
+  }
+});

--- a/hooks/tonone-pr-attribution.js
+++ b/hooks/tonone-pr-attribution.js
@@ -5,7 +5,7 @@
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
-const { execSync } = require("child_process");
+const { execSync, spawnSync } = require("child_process");
 
 const SESSION_FILE = path.join(".claude", "session-agents");
 const TONONE_URL = "https://second.tonone.ai";
@@ -46,7 +46,7 @@ function clearAgents() {
 
 function getPrUrl(toolOutput) {
   const raw = (toolOutput && (toolOutput.output || toolOutput)) || "";
-  const urlMatch = String(raw).match(/https:\/\/github\.com\/[^\s]+\/pull\/\d+/);
+  const urlMatch = String(raw).match(/https:\/\/github\.com\/[\w.\-]+\/[\w.\-]+\/pull\/\d+/);
   if (urlMatch) return urlMatch[0];
   try {
     const url = execSync("gh pr view --json url -q .url", { encoding: "utf8", timeout: 5000 }).trim();
@@ -58,10 +58,17 @@ function getPrUrl(toolOutput) {
 function appendAttribution(prUrl, attributionLine) {
   const tmpFile = path.join(os.tmpdir(), `tonone-pr-body-${process.pid}.md`);
   try {
-    const currentBody = execSync(`gh pr view "${prUrl}" --json body -q .body`, { encoding: "utf8", timeout: 5000 }).trim();
+    const viewResult = spawnSync(
+      "gh", ["pr", "view", prUrl, "--json", "body", "-q", ".body"],
+      { encoding: "utf8", timeout: 5000 }
+    );
+    const currentBody = (viewResult.stdout || "").trim();
     const newBody = `${currentBody}\n\n---\n${attributionLine}`;
     fs.writeFileSync(tmpFile, newBody);
-    execSync(`gh pr edit "${prUrl}" --body-file "${tmpFile}"`, { timeout: 10000 });
+    spawnSync(
+      "gh", ["pr", "edit", prUrl, "--body-file", tmpFile],
+      { timeout: 10000 }
+    );
   } finally {
     try { fs.unlinkSync(tmpFile); } catch {}
   }

--- a/hooks/tonone-session-tracker.js
+++ b/hooks/tonone-session-tracker.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// tonone-session-tracker — PostToolUse Skill hook
+// Tracks which tonone agents were invoked in this session.
+// Appends agent name to .claude/session-agents for PR attribution.
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const TONONE_AGENTS = new Set([
+  "apex", "forge", "relay", "spine", "flux", "warden", "vigil",
+  "prism", "cortex", "touch", "volt", "atlas", "lens", "proof",
+  "pave", "helm", "echo", "lumen", "draft", "form", "crest",
+  "pitch", "surge",
+]);
+
+const SESSION_FILE = path.join(".claude", "session-agents");
+
+function appendAgent(agentName) {
+  // Read existing agents
+  let existing = new Set();
+  try {
+    const content = fs.readFileSync(SESSION_FILE, "utf8");
+    content.trim().split("\n").filter(Boolean).forEach(l => existing.add(l));
+  } catch {}
+
+  if (existing.has(agentName)) return; // Already tracked
+
+  existing.add(agentName);
+
+  // Atomic write
+  fs.mkdirSync(path.dirname(SESSION_FILE), { recursive: true });
+  const tmp = SESSION_FILE + ".tmp." + process.pid;
+  fs.writeFileSync(tmp, [...existing].join("\n") + "\n");
+  fs.renameSync(tmp, SESSION_FILE);
+}
+
+let input = "";
+const timeout = setTimeout(() => process.exit(0), 3000);
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", chunk => (input += chunk));
+process.stdin.on("end", () => {
+  clearTimeout(timeout);
+  try {
+    const data = JSON.parse(input);
+
+    if (data.tool_name !== "Skill") process.exit(0);
+
+    const skillName = (data.tool_input && data.tool_input.skill) || "";
+    if (!skillName) process.exit(0);
+
+    // Extract agent name: "spine-api" → "spine", "superpowers:brainstorming" → skip
+    const base = skillName.includes(":") ? "" : skillName.split("-")[0];
+    if (!base || !TONONE_AGENTS.has(base)) process.exit(0);
+
+    appendAgent(base);
+  } catch {
+    // Silent fail — never block workflow
+  }
+});

--- a/hooks/tonone-session-tracker.js
+++ b/hooks/tonone-session-tracker.js
@@ -3,8 +3,6 @@
 // Tracks which tonone agents were invoked in this session.
 // Appends agent name to .claude/session-agents for PR attribution.
 
-"use strict";
-
 const fs = require("fs");
 const path = require("path");
 

--- a/tests/hooks/test-pr-attribution.js
+++ b/tests/hooks/test-pr-attribution.js
@@ -1,0 +1,101 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const HOOK = path.join(__dirname, "../../hooks/tonone-pr-attribution.js");
+
+function runHook(input, cwd) {
+  return spawnSync("node", [HOOK], {
+    input: JSON.stringify(input),
+    encoding: "utf8",
+    cwd,
+    timeout: 5000,
+  });
+}
+
+function makeTempDir(agents) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pr-attr-"));
+  fs.mkdirSync(path.join(dir, ".claude"), { recursive: true });
+  if (agents && agents.length > 0) {
+    fs.writeFileSync(path.join(dir, ".claude", "session-agents"), agents.join("\n") + "\n");
+  }
+  return dir;
+}
+
+function cleanup(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+}
+
+// Load formatAttribution for pure function tests
+const hook = require(HOOK);
+
+test("formatAttribution — single agent, title-cased, includes tonone link", () => {
+  const line = hook.formatAttribution(["spine"]);
+  assert.ok(line.includes("Spine"), line);
+  assert.ok(line.includes("https://second.tonone.ai"), line);
+  assert.ok(line.includes("[tonone]"), line);
+});
+
+test("formatAttribution — multiple agents, alphabetical, title-cased", () => {
+  const line = hook.formatAttribution(["warden", "spine", "proof"]);
+  assert.ok(line.includes("Proof · Spine · Warden"), line);
+});
+
+test("formatAttribution — more than 5 agents, truncated with count", () => {
+  const line = hook.formatAttribution(["apex", "atlas", "forge", "lens", "proof", "spine", "warden"]);
+  assert.ok(line.includes("and 2 more"), line);
+});
+
+test("formatAttribution — empty agents list, minimal attribution with link", () => {
+  const line = hook.formatAttribution([]);
+  assert.ok(line.includes("[tonone]"), line);
+  assert.ok(line.includes("https://second.tonone.ai"), line);
+});
+
+test("non gh-pr-create command — exits 0, session-agents not cleared", () => {
+  const dir = makeTempDir(["spine"]);
+  try {
+    const result = runHook(
+      { tool_name: "Bash", tool_input: { command: "git status" }, tool_output: {} },
+      dir
+    );
+    assert.strictEqual(result.status, 0, result.stderr);
+    // session-agents file should still exist (not cleared)
+    assert.ok(fs.existsSync(path.join(dir, ".claude", "session-agents")));
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("gh pr create — session-agents cleared after run (regardless of gh success)", () => {
+  const dir = makeTempDir(["spine", "warden"]);
+  try {
+    runHook(
+      {
+        tool_name: "Bash",
+        tool_input: { command: "gh pr create --title test --body test" },
+        tool_output: { output: "https://github.com/owner/repo/pull/1" },
+      },
+      dir
+    );
+    // session-agents should be cleared regardless of gh success/failure
+    const content = fs.existsSync(path.join(dir, ".claude", "session-agents"))
+      ? fs.readFileSync(path.join(dir, ".claude", "session-agents"), "utf8")
+      : "";
+    assert.strictEqual(content.trim(), "", `expected empty session-agents, got: ${content}`);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("malformed JSON input — exits 0 silently", () => {
+  const result = spawnSync("node", [HOOK], {
+    input: "not-json",
+    encoding: "utf8",
+    timeout: 5000,
+  });
+  assert.strictEqual(result.status, 0);
+});

--- a/tests/hooks/test-session-tracker.js
+++ b/tests/hooks/test-session-tracker.js
@@ -1,0 +1,109 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const HOOK = path.join(__dirname, "../../hooks/tonone-session-tracker.js");
+
+function runHook(input, cwd) {
+  return spawnSync("node", [HOOK], {
+    input: JSON.stringify(input),
+    encoding: "utf8",
+    cwd,
+    timeout: 5000,
+  });
+}
+
+function makeTempDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sess-tracker-"));
+  fs.mkdirSync(path.join(dir, ".claude"), { recursive: true });
+  return dir;
+}
+
+function cleanup(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+}
+
+test("tonone skill — appends agent name to .claude/session-agents", () => {
+  const dir = makeTempDir();
+  try {
+    const result = runHook(
+      { tool_name: "Skill", tool_input: { skill: "spine-api" } },
+      dir
+    );
+    assert.strictEqual(result.status, 0, result.stderr);
+    const content = fs.readFileSync(path.join(dir, ".claude", "session-agents"), "utf8");
+    assert.ok(content.includes("spine"), `expected 'spine' in: ${content}`);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("non-tonone skill — ignored, file not written", () => {
+  const dir = makeTempDir();
+  try {
+    const result = runHook(
+      { tool_name: "Skill", tool_input: { skill: "superpowers:brainstorming" } },
+      dir
+    );
+    assert.strictEqual(result.status, 0, result.stderr);
+    const filePath = path.join(dir, ".claude", "session-agents");
+    assert.ok(!fs.existsSync(filePath), "file should not be created for non-tonone skill");
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("same agent invoked twice — deduplication, appears once", () => {
+  const dir = makeTempDir();
+  try {
+    runHook({ tool_name: "Skill", tool_input: { skill: "warden-audit" } }, dir);
+    runHook({ tool_name: "Skill", tool_input: { skill: "warden-harden" } }, dir);
+    const content = fs.readFileSync(path.join(dir, ".claude", "session-agents"), "utf8");
+    const lines = content.trim().split("\n").filter(Boolean);
+    const wardenLines = lines.filter(l => l === "warden");
+    assert.strictEqual(wardenLines.length, 1, `expected 1 warden line, got: ${content}`);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("multiple different agents — all appended", () => {
+  const dir = makeTempDir();
+  try {
+    runHook({ tool_name: "Skill", tool_input: { skill: "spine-api" } }, dir);
+    runHook({ tool_name: "Skill", tool_input: { skill: "atlas-map" } }, dir);
+    runHook({ tool_name: "Skill", tool_input: { skill: "proof-audit" } }, dir);
+    const content = fs.readFileSync(path.join(dir, ".claude", "session-agents"), "utf8");
+    assert.ok(content.includes("spine"), content);
+    assert.ok(content.includes("atlas"), content);
+    assert.ok(content.includes("proof"), content);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("non-Skill tool event — exits 0, no file written", () => {
+  const dir = makeTempDir();
+  try {
+    const result = runHook(
+      { tool_name: "Bash", tool_input: { command: "ls" } },
+      dir
+    );
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.ok(!fs.existsSync(path.join(dir, ".claude", "session-agents")));
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("malformed JSON input — exits 0 silently", () => {
+  const result = spawnSync("node", [HOOK], {
+    input: "not-json",
+    encoding: "utf8",
+    timeout: 5000,
+  });
+  assert.strictEqual(result.status, 0);
+});


### PR DESCRIPTION
## Summary

- Adds `tonone-session-tracker.js` — PostToolUse Skill hook that records which tonone agents ran to `.claude/session-agents`
- Adds `tonone-pr-attribution.js` — PostToolUse Bash hook that detects `gh pr create` and appends agent credits to the PR description via `gh pr edit`
- Registers both hooks in `.claude-plugin/plugin.json`

Attribution format: `*Atlas · Spine · Warden — [tonone](https://second.tonone.ai)*`

## Why

K-factor 0.05–0.15. No attribution in output means tonone is invisible to everyone except the person running it. PRs are the highest-visibility artifact in any repo — teammates, leads, and reviewers all read them. This puts the team in the artifact.

## Test Plan

- [ ] 13/13 unit tests pass (`node --test tests/hooks/test-session-tracker.js && node --test tests/hooks/test-pr-attribution.js`)
- [ ] Run a tonone skill, verify `.claude/session-agents` contains the agent name
- [ ] Create a PR, verify attribution block appears at the bottom
- [ ] Verify `.claude/session-agents` is cleared after PR creation

🤖 Relay — tonone Engineering Team