### PR TITLE
feat: shoutouts + statusline session goal (Line 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,18 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) to get started — improve skills, propos
 | [Agent Guide](docs/agent-guide.md)   | Creating new agents          |
 | [Naming Guide](docs/naming-guide.md) | Agent naming conventions     |
 
+## Shoutouts
+
+Tonone stands on the shoulders of giants. Big thanks to the plugins that shaped how this team thinks and works:
+
+| Plugin | What it brought |
+| ------ | --------------- |
+| **superpowers** | Structured skill workflows, brainstorming loops, TDD discipline, and the worktree-native development model that Tonone runs on |
+| **impeccable** | Design critique vocabulary and the polish-first mindset baked into Form and Draft |
+| **frontend-design** | Frontend implementation patterns that Prism and Touch draw from |
+| **ui-ux-pro-max** | 161 color palettes, 84 UI styles, 57 font pairings, 99 UX guidelines, and the BM25 design search engine now powering `lib/uiux` |
+| **caveman** | The communication mode that cuts every response to its bones — no fluff, all signal |
+
 ## License
 
 MIT. Fork it. Ship it. Use it anywhere. [LICENSE](LICENSE)

--- a/docs/superpowers/specs/2026-04-12-statusline-redesign.md
+++ b/docs/superpowers/specs/2026-04-12-statusline-redesign.md
@@ -17,6 +17,7 @@ Line 3  Opus → Sonnet │ ████░░░░░░ 48% │ 5h: 24% ok 0.
 | 1 | **Where** — location & code state | directory, branch + ahead, dirty count, lines changed |
 | 2 | **What** — session activity | agent + subs, cost, duration |
 | 3 | **How much left** — runway gauges | model(s), context window, 5h pace, 7d pace |
+| 4 | **Why** — session purpose | goal (optional, from `.claude/session-goal` or `.claude/branch-slug`) |
 
 ## Static Fields
 
@@ -164,9 +165,25 @@ Source: `data.tool_input.model` from the Agent tool call (falls back to `null` i
 | Pace -- | dim | `\x1b[2m` |
 | Separators │ | dim | `\x1b[2m` |
 
+### Line 4: Session Goal (optional)
+
+Reads from `.claude/session-goal` first, falls back to `.claude/branch-slug`. Hyphens converted to spaces. Line 4 is omitted entirely when neither file exists.
+
+Format: `goal: <text>` — dim label, cyan text.
+
+Users set this by writing the branch-slug before a session (already the project convention):
+```bash
+echo "fix-auth-bug" > .claude/branch-slug
+```
+
+Or a more descriptive one-liner:
+```bash
+echo "add session goal to statusline" > .claude/session-goal
+```
+
 ## Files Modified
 
-1. `hooks/tonone-statusline.js` — full rewrite of `render()` function
+1. `hooks/tonone-statusline.js` — added `readSessionGoal()`, Line 4 in `render()`
 2. `hooks/tonone-agent-tracker.js` — add `model` field from `tool_input.model`
 
 ## Files Created

--- a/hooks/test-statusline.sh
+++ b/hooks/test-statusline.sh
@@ -185,7 +185,23 @@ run_test "Long directory path" '{
   "no subs" \
   "Opus 4.6"
 
-# State 8: No rate limit data
+# State 8: Session goal from branch-slug
+SLUG_PATH="$HOME/repos/tn/tonone/.claude/branch-slug"
+SLUG_EXISTED=false
+[ -f "$SLUG_PATH" ] && SLUG_EXISTED=true
+echo "add-the-session-goal-row" > "$SLUG_PATH"
+
+run_test "Session goal from branch-slug" '{
+  "session_id": "test-goal",
+  "workspace": {"current_dir": "'"$HOME"'/repos/tn/tonone"},
+  "model": {"display_name": "Opus 4.6"},
+  "cost": {}
+}' \
+  "goal: add session goal row"
+
+$SLUG_EXISTED || rm -f "$SLUG_PATH"
+
+# State 9: No rate limit data
 run_test "No rate limits" '{
   "session_id": "test-norate",
   "workspace": {"current_dir": "'"$HOME"'/repos/tn/tonone"},

--- a/hooks/tonone-statusline.js
+++ b/hooks/tonone-statusline.js
@@ -98,6 +98,33 @@ function fmtDuration(ms) {
   return rem > 0 ? `${hrs}h${rem}m` : `${hrs}h`;
 }
 
+// ── Session goal ─────────────────────────────────────────────────────────────
+
+const FILLER = /\b(a|an|the|just|really|basically|actually|simply|some|very)\b/gi;
+
+function caveman(text) {
+  return text
+    .replace(/-/g, " ")
+    .replace(FILLER, "")
+    .replace(/\s{2,}/g, " ")
+    .trim()
+    .slice(0, 40);
+}
+
+function readSessionGoal(cwd) {
+  const candidates = [
+    path.join(cwd, ".claude", "session-goal"),
+    path.join(cwd, ".claude", "branch-slug"),
+  ];
+  for (const p of candidates) {
+    try {
+      const raw = fs.readFileSync(p, "utf8").trim();
+      if (raw) return caveman(raw);
+    } catch {}
+  }
+  return null;
+}
+
 // ── Subagent bridge ──────────────────────────────────────────────────────────
 
 function readSubagents(sessionId) {
@@ -373,7 +400,12 @@ function render(data) {
 
   const line3 = [modelStr, ctxBar, fiveHStr, sevenDStr].join(SEP);
 
-  return `${line1}\n${line2}\n${line3}`;
+  // ── Line 4: Session Goal ────────────────────────────────────────────────
+  const goal = readSessionGoal(cwd);
+  if (!goal) return `${line1}\n${line2}\n${line3}`;
+
+  const line4 = `${c.dim}goal:${c.reset} ${c.cyan}${goal}${c.reset}`;
+  return `${line1}\n${line2}\n${line3}\n${line4}`;
 }
 
 // ── Stdin reader with 3s timeout guard ───────────────────────────────────────


### PR DESCRIPTION
## Summary

- **README shoutouts** — new `## Shoutouts` section crediting the plugins that shaped Tonone: superpowers, impeccable, frontend-design, ui-ux-pro-max, and caveman
- **Statusline Line 4** — optional session goal row sourced from `.claude/session-goal` (first) or `.claude/branch-slug` (fallback); omitted entirely when neither file exists
- **caveman normalizer** — strips hyphens, filler words, trims to 40 chars before display

## Test plan

- [ ] Run `bash hooks/test-statusline.sh` — State 8 (session goal from branch-slug) passes
- [ ] Verify Line 4 appears in live statusline when `.claude/branch-slug` is set
- [ ] Verify Line 4 is absent when neither goal file exists
- [ ] README shoutouts render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)