### PR TITLE
chore: CHANGELOG v0.7.0 + Atlas changelog artifacts

### DIFF
--- a/.changelog/CHANGELOG.md
+++ b/.changelog/CHANGELOG.md
@@ -1,0 +1,33 @@
+## 2026-04-12
+
+### pave — Wire eager session worktrees, remove gate, update CLAUDE.md
+
+- Replaced deferred `tonone-worktree-gate.js` + `tonone-worktree-create.js` with eager `tonone-worktree-session.js` — worktree created at `SessionStart`, not on first edit
+- Human-readable branch names via `.claude/branch-slug` (e.g. `feat/auth-fixes` instead of UUID)
+- Deleted 246 lines of gate/create hook code; `plugin.json` re-wired
+- Files: `hooks/tonone-worktree-session.js`, `.claude-plugin/plugin.json`, `CLAUDE.md`
+
+### surge — Add PR attribution for viral K-factor growth
+
+- `hooks/tonone-pr-attribution.js` appends team credits block to every PR body
+- Registered `session-tracker` and `pr-attribution` hooks in `plugin.json`
+- Files: `hooks/tonone-pr-attribution.js`, `hooks/tonone-session-tracker.js`, `.claude-plugin/plugin.json`
+
+### prism — Add shoutouts and statusline session goal (Line 4)
+
+- Line 4 of 3-line statusline now displays session goal
+- Shoutout rendering added alongside statusline update
+- Files: `hooks/tonone-statusline.js`
+
+### pave — Add elephant persistent memory system
+
+- Writer hook auto-captures agent completions, commits, skill runs to `.elephant/`
+- Recall hook surfaces startup summary from local + global memory
+- `/elephant` skill: `save`, `show`, `compact`, `takeover` commands
+- `takeover` cold-starts memory from git history for repos with no prior data
+- Files: `hooks/tonone-elephant-writer.js`, `hooks/tonone-elephant-recall.js`, `skills/elephant.md`
+
+### pave — Fix statusline resets_at Unix seconds parsing
+
+- `resets_at` was parsed as milliseconds; corrected to seconds — fixes pace projection
+- Files: `hooks/tonone-statusline.js`

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ pip-wheel-metadata/
 .claude/skills/
 .claude/worktrees/
 .claude/skip-worktree
+.claude/branch-slug
 
 # External tools
 .superpowers/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.0] — 2026-04-12
+
+### Added
+
+- **Eager worktree sessions** — `hooks/tonone-worktree-session.js` fires on `SessionStart` and auto-creates a worktree immediately, before any edits. Replaces the deferred gate approach. `plugin.json` wired; old `tonone-worktree-create.js` and `tonone-worktree-gate.js` deleted.
+- **Human-readable branch names** — `.claude/branch-slug` maps session IDs to short slugs (e.g. `feat/auth-fixes`) so worktree branches are readable at a glance instead of UUID-based.
+- **PR attribution** — `hooks/tonone-pr-attribution.js` appends a "Built by Tonone team" credits block to every PR body, listing the agents involved. Boosts K-factor via team credit visibility. Registered in `plugin.json`.
+- **Elephant memory** — persistent caveman-compressed memory system: `hooks/tonone-elephant-writer.js` auto-captures agent completions, commits, and skill runs; `hooks/tonone-elephant-recall.js` surfaces a startup summary. `/elephant` skill adds `save`, `show`, and `compact` commands.
+- **Elephant takeover** — `/elephant takeover` cold-starts the memory system from git history, bootstrapping recall for repos with no prior elephant data.
+- **Statusline session goal** — Line 4 of the 3-line statusline redesign now shows the session goal. Shoutouts added.
+
+### Fixed
+
+- **Statusline** — `resets_at` now parsed as Unix seconds (not milliseconds), fixing incorrect pace projection display.
+- **Worktree session hook** — removed unused `fs` import.
+
 ## [0.6.9] — 2026-04-12
 
 ### Added


### PR DESCRIPTION
## Summary

- **CHANGELOG.md** — adds `## [0.7.0]` entry covering eager worktree sessions, PR attribution hook, elephant memory system, statusline session goal (Line 4), and statusline fix for `resets_at` Unix seconds parsing
- **.changelog/CHANGELOG.md** — structured Atlas changelog artifact from same session
- **.gitignore** — adds `.claude/branch-slug` (local session state, shouldn't be tracked)

## Test plan
- [ ] CHANGELOG renders correctly on GitHub
- [ ] `.claude/branch-slug` no longer appears as untracked in new sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)