### PR TITLE
refactor(statusline): simplify readSessionGoal to single candidate

### DIFF
--- a/hooks/tonone-statusline.js
+++ b/hooks/tonone-statusline.js
@@ -112,16 +112,10 @@ function caveman(text) {
 }
 
 function readSessionGoal(cwd) {
-  const candidates = [
-    path.join(cwd, ".claude", "session-goal"),
-    path.join(cwd, ".claude", "branch-slug"),
-  ];
-  for (const p of candidates) {
-    try {
-      const raw = fs.readFileSync(p, "utf8").trim();
-      if (raw) return caveman(raw);
-    } catch {}
-  }
+  try {
+    const raw = fs.readFileSync(path.join(cwd, ".claude", "session-goal"), "utf8").trim();
+    if (raw) return caveman(raw);
+  } catch {}
   return null;
 }
 


### PR DESCRIPTION
## Summary
- Drop `branch-slug` fallback from `readSessionGoal` — only `session-goal` is used now
- Reduces code surface and removes dead path

## Test plan
- [ ] Verify statusline displays session goal correctly in active session
- [ ] Verify statusline handles missing `session-goal` file gracefully (returns null)

🤖 Generated with [Claude Code](https://claude.com/claude-code)