### PR TITLE
fix(elephant): rename to atlas-elephant, fix 7 skill compliance failures

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tonone",
   "description": "Engineering + Product team — 23 agents as Claude Code specialists. Infrastructure, DevOps, backend, security, ML/AI, mobile, UX, analytics, growth, strategy, and more.",
-  "version": "0.6.10",
+  "version": "0.7.1",
   "author": {
     "name": "tonone-ai",
     "url": "https://tonone.ai"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.1] — 2026-04-12
+
+### Fixed
+
+- **atlas-elephant skill** — renamed from `skills/elephant` to `skills/atlas-elephant` to satisfy 7 skill compliance checks: kebab-case naming, valid agent prefix (`atlas`), description trigger phrases, output-kit reference, atlas-report overflow clause, identity line, and structured workflow steps.
+
 ## [0.7.0] — 2026-04-12
 
 ### Added

--- a/skills/atlas-elephant/SKILL.md
+++ b/skills/atlas-elephant/SKILL.md
@@ -1,15 +1,21 @@
 ---
-name: elephant
-description: Persistent memory commands. /elephant save <text> — write entry. /elephant save !! <text> — write important entry. /elephant show — print memory. /elephant compact — compress old entries. /elephant takeover [N] — seed memory from git history (cold start bootstrap).
+name: atlas-elephant
+description: Persistent memory commands for session recall. Use when asked to "/elephant save", "/elephant show", "/elephant compact", or "/elephant takeover" to manage memory entries.
 allowed-tools: Read, Write, Edit, Bash
-version: 1.1.0
+version: 1.2.0
 author: tonone-ai <hello@tonone.ai>
 license: MIT
 ---
 
 # Elephant — Manual Memory Commands
 
-Manage the elephant memory system. Local file: `.elephant/memory.md`. Global file: `~/.claude/elephant/memory.md`.
+You are Atlas — the knowledge engineer on the Engineering Team. Manage the elephant memory system.
+
+Follow the output format defined in docs/output-kit.md — 40-line CLI max, box-drawing skeleton, unified severity indicators, compressed prose.
+
+Local file: `.elephant/memory.md`. Global file: `~/.claude/elephant/memory.md`.
+
+If output exceeds 40 lines, route full content through atlas-report.
 
 ## Entry Format
 
@@ -29,12 +35,12 @@ Parse the args provided to this skill invocation:
 
 Write a routine entry.
 
-1. Get current timestamp: run `date "+%Y-%m-%d %H:%M"` via Bash
-2. Compress text: drop a/an/the/just/really/basically/actually/simply, max 100 chars
-3. Format line: `YYYY-MM-DD HH:MM : <compressed text>`
-4. Prepend to `.elephant/memory.md` (create dir + file if needed)
-5. Prepend `YYYY-MM-DD HH:MM : <repo> : <compressed text>` to `~/.claude/elephant/memory.md`
-6. Confirm: output `saved: <line>`
+1. **Get timestamp** — run `date "+%Y-%m-%d %H:%M"` via Bash
+2. **Compress text** — drop a/an/the/just/really/basically/actually/simply, max 100 chars
+3. **Format line** — `YYYY-MM-DD HH:MM : <compressed text>`
+4. **Prepend to `.elephant/memory.md`** — create dir + file if needed
+5. **Prepend to global** — `YYYY-MM-DD HH:MM : <repo> : <compressed text>` to `~/.claude/elephant/memory.md`
+6. **Confirm** — output `saved: <line>`
 
 Repo name = last component of current working directory path.
 
@@ -52,13 +58,13 @@ If file missing: print `nothing yet.`
 
 Compress old routine entries (older than 7 days, no `[!!]` prefix).
 
-1. Read `.elephant/memory.md`
-2. Group non-`[!!]` entries older than 7 days by date (YYYY-MM-DD)
-3. Per day: merge all entries → single line: `YYYY-MM-DD : <entry1 text> + <entry2 text> + ...`
-4. Keep `[!!]` entries and entries ≤ 7 days old untouched
-5. Write compacted file back (use a temp file + rename for atomicity)
-6. Do same for `~/.claude/elephant/memory.md` (filter to this repo's entries only when compacting)
-7. Report: `compacted N entries into M lines`
+1. **Read file** — `.elephant/memory.md`
+2. **Group entries** — non-`[!!]` entries older than 7 days, grouped by date (YYYY-MM-DD)
+3. **Merge per day** — `YYYY-MM-DD : <entry1 text> + <entry2 text> + ...`
+4. **Preserve** — `[!!]` entries and entries ≤ 7 days old untouched
+5. **Write back** — use a temp file + rename for atomicity
+6. **Compact global** — do same for `~/.claude/elephant/memory.md` (filter to this repo's entries only)
+7. **Report** — `compacted N entries into M lines`
 
 ### `/elephant takeover [N]`
 
@@ -66,13 +72,11 @@ Bootstrap memory from git history. Solves cold-start: empty memory → no recall
 
 Default N = 60 commits. User can pass a number: `/elephant takeover 100`.
 
-Steps:
+1. **Check existing memory** — if `.elephant/memory.md` exists and has entries, warn:
+   `memory already seeded (N entries). re-run to append git history below existing entries.`
+   Continue (don't abort — append git entries below existing).
 
-1. Check if `.elephant/memory.md` exists. If it does and has entries, print warning:
-   `⚠ memory already seeded (N entries). re-run to append git history below existing entries.`
-   Then continue (don't abort — append git entries below existing).
-
-2. Run: `git log --format="%ci|||%s|||%H" -N` via Bash.
+2. **Run git log** — `git log --format="%ci|||%s|||%H" -N` via Bash.
    - `%ci` = ISO 8601 date: `2026-04-12 13:58:23 +0000`
    - `%s` = subject line
    - `%H` = full hash (used only to detect merge commits)
@@ -81,7 +85,7 @@ Steps:
 
    Skip bare upstream sync commits: lines where subject matches `^Merge branch '.+' of https?://` — these are `git pull` noise with no content value.
 
-3. For each remaining commit line, parse:
+3. **Parse each commit line**:
    - **Timestamp**: take first 16 chars of `%ci` → `YYYY-MM-DD HH:MM`
    - **Subject**: caveman-compress (drop a/an/the/just/really/basically/actually/simply, max 100 chars)
    - **Important?**: mark `[!!]` if subject matches any of:
@@ -90,24 +94,24 @@ Steps:
      - conventional commit with `!` (e.g. `feat!:`, `fix!:`)
      - subject contains `(#` (PR reference = likely significant)
 
-4. Format entries (newest first, matching git log default order):
+4. **Format entries** (newest first, matching git log default order):
    ```
    [!!] 2026-04-12 13:58 : feat: elephant memory system
    2026-04-12 12:00 : fix typo in output kit
    ```
 
-5. Write to `.elephant/memory.md`:
+5. **Write to `.elephant/memory.md`**:
    - If file didn't exist: create dir + file, write all entries.
    - If file existed: prepend nothing new to existing entries; instead append git entries BELOW (so existing human entries stay at top).
    - Use a temp file + rename for atomicity.
 
-6. For each entry, also append to `~/.claude/elephant/memory.md` (repo-prefixed):
+6. **Append to global** `~/.claude/elephant/memory.md` (repo-prefixed):
    ```
    [!!] 2026-04-12 13:58 : tonone : feat: elephant memory system
    ```
    Append only entries not already present (match on timestamp + text).
 
-7. Report:
+7. **Report**:
    ```
    seeded N entries (YYYY-MM-DD → YYYY-MM-DD) — M marked [!!]
    tip: run /elephant compact to merge old routine entries


### PR DESCRIPTION
## Summary

**Compliance fixes** — `skills/elephant` renamed to `skills/atlas-elephant` to satisfy all 7 failing `test_skill_compliance.py` checks.

**Skill** — `atlas-elephant` (memory management, under Atlas = Knowledge Engineering agent)

Changes:
- Renamed `skills/elephant/SKILL.md` → `skills/atlas-elephant/SKILL.md`
- Updated frontmatter: `name: atlas-elephant`, version bumped to `1.2.0`
- Added `You are Atlas —` identity line
- Added description with 2 quoted trigger phrases (`"/elephant save"`, `"/elephant show"`)
- Added output-kit integration line
- Added atlas-report overflow clause
- Reformatted numbered steps as `1. **bold**` for structured workflow compliance

## Test Coverage

All new code = skill markdown content (no application logic paths to audit).

Tests: 52 → 52 (no change, all passing)

## Pre-Landing Review

No issues found. Single skill rename + compliance metadata — no SQL, auth, security-relevant, or side-effect code.

## Scope Drift

Scope Check: CLEAN
Intent: fix 7 failing skill compliance tests
Delivered: renamed skill directory + updated content to pass all 7 tests

## Test plan
- [x] All 52 pytest tests pass (52/52, 0 failures)
- [x] All 14 `test_skill_compliance.py` tests pass (previously 7 failed)
- [x] No emoji introduced
- [x] No unauthorized severity indicators

🤖 Generated with [Claude Code](https://claude.com/claude-code)