### PR TITLE
feat(onboarding): first-run tour — SessionStart hook + /tonone-onboard skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2160,6 +2160,19 @@
       "type": "skill",
       "category": "security",
       "tags": ["warden", "skill"]
+    },
+    {
+      "name": "tonone-onboard",
+      "description": "First-run onboarding tour — guided walkthrough of tonone's 23 agents, key skills, elephant memory, and worktree sessions. Two paths: expert (~90 sec) and newcomer (~8 min). Use when asked \"how do I use tonone\", \"what can tonone do\", \"show me around\", or \"first steps\".",
+      "version": "0.8.0",
+      "source": "./skills/tonone-onboard",
+      "author": {
+        "name": "tonone-ai",
+        "url": "https://tonone.ai"
+      },
+      "type": "skill",
+      "category": "onboarding",
+      "tags": ["tonone", "skill", "onboarding"]
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tonone",
   "description": "Engineering + Product team — 23 agents as Claude Code specialists. Infrastructure, DevOps, backend, security, ML/AI, mobile, UX, analytics, growth, strategy, and more.",
-  "version": "0.6.10",
+  "version": "0.8.0",
   "author": {
     "name": "tonone-ai",
     "url": "https://tonone.ai"
@@ -46,6 +46,11 @@
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/tonone-worktree-session.js\"",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/tonone-onboard.js\"",
+            "timeout": 5
           }
         ]
       }

--- a/hooks/tonone-onboard.js
+++ b/hooks/tonone-onboard.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+"use strict";
+
+// tonone-onboard — SessionStart hook
+// Fires exactly once after install. Writes a marker to ~/.config/tonone/onboarded.
+// On subsequent sessions exits silently. Never blocks the session on any error.
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || path.join(__dirname, "..");
+const PLUGIN_JSON = path.join(PLUGIN_ROOT, ".claude-plugin", "plugin.json");
+const MARKER_DIR = path.join(os.homedir(), ".config", "tonone");
+const MARKER_FILE = path.join(MARKER_DIR, "onboarded");
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function currentVersion() {
+  try {
+    return JSON.parse(fs.readFileSync(PLUGIN_JSON, "utf8")).version || "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+function isOnboarded() {
+  try {
+    return fs.existsSync(MARKER_FILE);
+  } catch {
+    return true; // fail-safe: don't re-show if we can't check
+  }
+}
+
+function writeMarker(version) {
+  try {
+    fs.mkdirSync(MARKER_DIR, { recursive: true });
+    fs.writeFileSync(
+      MARKER_FILE,
+      JSON.stringify({ version, ts: new Date().toISOString() })
+    );
+  } catch {
+    // If write fails, hook exits 0 and retries next session — correct behavior.
+  }
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+if (isOnboarded()) process.exit(0);
+
+const version = currentVersion();
+writeMarker(version);
+
+const pad = (s, w) => s + " ".repeat(Math.max(0, w - s.length));
+const W = 54;
+const inner = W - 2; // chars between ║ and ║
+
+function row(text) {
+  return "║ " + pad(text, inner - 1) + "║";
+}
+
+const banner = [
+  "╔" + "═".repeat(W) + "╗",
+  row(`tonone v${version} installed!`),
+  "╠" + "═".repeat(W) + "╣",
+  row("You have 23 agents and 100+ skills."),
+  row(""),
+  row("Run /tonone-onboard for a guided tour."),
+  row("Takes ~90 sec (expert) or ~8 min (newcomer)."),
+  "╚" + "═".repeat(W) + "╝",
+].join("\n");
+
+process.stdout.write("\n" + banner + "\n\n");

--- a/skills/tonone-onboard/.claude-plugin/plugin.json
+++ b/skills/tonone-onboard/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "tonone-onboard",
+  "version": "0.8.0",
+  "description": "First-run onboarding tour — guided walkthrough of tonone's 23 agents, key skills, elephant memory, and worktree sessions. Two paths: expert (~90 sec) and newcomer (~8 min). Use when asked \"how do I use tonone\", \"what can tonone do\", \"show me around\", or \"first steps\".",
+  "author": {
+    "name": "tonone-ai",
+    "url": "https://tonone.ai"
+  },
+  "repository": "https://github.com/tonone-ai/tonone",
+  "license": "MIT",
+  "type": "skill",
+  "keywords": ["tonone", "skill", "onboarding"]
+}

--- a/skills/tonone-onboard/SKILL.md
+++ b/skills/tonone-onboard/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: tonone-onboard
+description: First-run onboarding tour — guided walkthrough of tonone's 23 agents, key skills, elephant memory, and worktree sessions. Two paths: expert (~90 sec) and newcomer (~8 min). Use when asked "how do I use tonone", "what can tonone do", "show me around", or "first steps".
+allowed-tools: AskUserQuestion
+version: 0.8.0
+author: tonone-ai <hello@tonone.ai>
+license: MIT
+---
+
+# tonone Onboarding Tour
+
+Always runs. Never checks the marker file — the skill replays the tour regardless
+of prior runs. To re-show the SessionStart welcome banner, delete
+`~/.config/tonone/onboarded`.
+
+## Step 1: Tier Check
+
+Ask via AskUserQuestion:
+
+> Are you familiar with Claude Code agents?
+
+Options:
+- A) Yes — I know CC agents, just show me tonone's capabilities (~90 sec)
+- B) No — walk me through the whole thing (~8 min)
+
+---
+
+## Expert Path (A)
+
+### What tonone is
+
+23 specialists, 2 teams. Engineering (15 agents) + Product (8 agents). Each owns a
+domain. You dispatch them. They don't fight over work — Apex routes automatically.
+
+### Top 5 commands to bookmark
+
+Output this block verbatim:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  /apex-takeover     hand any task to the full team          │
+│  /elephant          review your session memory log          │
+│  /atlas-onboard     generate project docs for day-1 devs   │
+│  /forge-audit       infra cost check                        │
+│  /relay-ship        deploy your stack                       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Two mental models (memorize these)
+
+**Elephant memory:** Every session is logged automatically. Say "recall what we
+worked on last week" and any agent will surface relevant context. No manual notes.
+
+**Worktree sessions:** Every session gets its own git branch automatically.
+Parallel sessions never conflict. Clean sessions auto-remove their branch on close.
+
+### Done
+
+> Run `/apex-takeover` to start. Describe any task and Apex routes it.
+>
+> Replay this tour any time: `/tonone-onboard`
+
+---
+
+## Newcomer Path (B)
+
+### What Claude Code agents are
+
+Claude Code can act as specialized agents — each configured with a persona, domain
+knowledge, and a set of skills. Instead of one generalist AI, tonone gives you a
+team of 23 specialists. You talk to them like colleagues. They coordinate through
+Apex, the engineering lead.
+
+### Meet the team
+
+Output this block verbatim:
+
+```
+Engineering Team (15 agents)
+─────────────────────────────────────────────────────────────
+Apex    Engineering lead — routes tasks, coordinates the team
+Atlas   Knowledge engineer — docs, ADRs, onboarding
+Forge   Infrastructure — cloud, IaC, cost
+Relay   DevOps — CI/CD, deployments, GitOps
+Spine   Backend — APIs, system design, performance
+Flux    Data — databases, migrations, pipelines
+Warden  Security — IAM, secrets, threat modeling
+Vigil   Observability — monitoring, alerting, SRE
+Prism   Frontend/DX — UI, internal tools, portals
+Cortex  ML/AI — LLM integration, evals, RAG
+Touch   Mobile — iOS, Android, cross-platform
+Volt    Embedded/IoT — firmware, edge, protocols
+Lens    Analytics — dashboards, metrics, reporting
+Proof   QA — test strategy, E2E, flaky triage
+Pave    Platform — dev experience, golden paths
+
+Product Team (8 agents)
+─────────────────────────────────────────────────────────────
+Helm    Head of Product — briefs, handoff to engineering
+Echo    User research — interviews, personas, JTBD
+Lumen   Product analytics — OKRs, funnels, A/B tests
+Draft   UX design — flows, IA, wireframes
+Form    Visual design — brand, tokens, design system
+Crest   Strategy — roadmap, prioritization, competitive
+Pitch   Marketing — positioning, messaging, GTM
+Surge   Growth — acquisition, activation, retention
+```
+
+### How to invoke Apex
+
+Run `/apex-takeover` and describe your task. Example:
+
+> Run `/apex-takeover` and say "check our security posture."
+> Apex reads the request, dispatches Warden, brings you the result.
+> You never invoke Warden directly.
+
+The right agent always gets the job. You don't need to know who to call.
+
+### Elephant memory
+
+Every session is logged automatically by the elephant-recall and elephant-writer
+hooks. The log lives at `.elephant/memory.md` (project) and
+`~/.claude/elephant/memory.md` (global across all projects).
+
+At the start of each session, recent entries are surfaced in your context. Ask any
+agent: "recall what we built last Tuesday" and it will look back.
+
+Commands:
+- `/elephant show` — print current memory
+- `/elephant save <note>` — add an entry manually
+- `/elephant takeover` — seed memory from git history (great for new installs)
+
+### Worktree sessions
+
+Every session gets an isolated git branch at `.claude/worktrees/`. Sessions editing
+the same files don't conflict — they each work on their own branch. When a session
+ends with no changes, the branch cleans itself up automatically.
+
+You don't need to manage this. It happens automatically via the SessionStart and
+Stop hooks.
+
+### Skill routing
+
+Skill routing tells Claude to use a specialized workflow instead of answering
+directly when the request matches a known pattern. This is already configured in
+this project's `CLAUDE.md` — see the `## Skill routing` section.
+
+Examples already wired:
+- "there's a bug" → `/investigate`
+- "ship this" → `/ship`
+- "review my diff" → `/review`
+- "product idea" → `/office-hours`
+
+You can add your own routing rules to `CLAUDE.md` at any time.
+
+### Next steps — try these first
+
+Output this block verbatim:
+
+```
+1. /apex-takeover     describe any task, Apex routes it
+2. /elephant show     see your current memory (probably empty — that's fine)
+3. /atlas-onboard     generate onboarding docs for this project
+```
+
+### Done
+
+> You're set. 23 agents, 100+ skills, automatic memory, isolated sessions.
+>
+> Replay this tour any time: `/tonone-onboard`
+> Re-show the install banner: delete `~/.config/tonone/onboarded`


### PR DESCRIPTION
## Summary

New users install tonone and get 23 agents with zero orientation. This ships a two-part fix.

**`hooks/tonone-onboard.js`** — SessionStart hook that fires exactly once after install. Writes a marker to `~/.config/tonone/onboarded`, prints a welcome banner pointing to `/tonone-onboard`. All file I/O is wrapped in try/catch — never blocks a session on failure. Silent on every subsequent session.

**`skills/tonone-onboard/`** — Two-tier onboarding skill. Always reruns regardless of the marker (marker only controls the SessionStart banner).
- Expert path (~90 sec): what tonone is, top 5 commands, elephant memory + worktrees in two sentences, done
- Newcomer path (~8 min): full agent roster, how to invoke Apex via `/apex-takeover`, elephant memory with examples, worktree sessions, skill routing rules, 3 next steps

## Files

| File | Change |
|------|--------|
| `hooks/tonone-onboard.js` | New |
| `skills/tonone-onboard/SKILL.md` | New |
| `skills/tonone-onboard/.claude-plugin/plugin.json` | New |
| `.claude-plugin/plugin.json` | Hook in SessionStart + version `0.8.0` |
| `.claude-plugin/marketplace.json` | Skill listing |

## Version bump

`0.6.10 → 0.8.0` (minor — new user-visible feature, existing update-check will notify users)

## Test

Delete `~/.config/tonone/onboarded` if it exists, start a new session — banner appears. Run `/tonone-onboard` — tour runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)