### PR TITLE
feat: improve skill quality scores for tonone

### DIFF
--- a/skills/cortex-prompt/SKILL.md
+++ b/skills/cortex-prompt/SKILL.md
@@ -46,15 +46,7 @@ If the user can't provide examples, generate plausible ones and validate before 
 
 ## Step 2: Select the Model Tier
 
-Pick the cheapest model that can reliably do the task:
-
-| Task type                              | Default tier                       |
-| -------------------------------------- | ---------------------------------- |
-| Classification, extraction, formatting | Haiku / GPT-4o mini / Gemini Flash |
-| Reasoning, summarization, generation   | Sonnet / GPT-4o / Gemini Pro       |
-| Nuanced judgment, complex synthesis    | Opus / GPT-4.5 / Gemini Ultra      |
-
-State your choice. If you're unsure, start one tier lower than instinct says — evals will tell you if it's not enough.
+Pick the cheapest model that reliably passes evals. Start one tier lower than instinct — evals confirm if it's enough. State your choice.
 
 ## Step 3: Write the Prompt Package
 
@@ -72,11 +64,11 @@ Structure:
 
 Rules for writing:
 
-- Specific beats vague. "Extract the customer's name, email, and issue category" beats "extract relevant info"
+- Be specific — name the exact fields, formats, and constraints
 - Separate instructions from data — user content goes in a clearly delimited block (`<input>`, `---`, XML tags)
 - State the output format in the system prompt AND show it via few-shot examples
 - If the model should refuse certain inputs, say so explicitly and state what to return instead
-- No "please" or "try to" — imperatives only: "Return", "Extract", "Do not"
+- Imperatives only — "Return", "Extract", "Do not". No "please" or "try to".
 
 ### 3b. User Message Template
 
@@ -105,8 +97,6 @@ Format for each example:
   output: "[expected output]"
   notes: "why this case matters"
 ```
-
-Few-shot examples are the most powerful prompt engineering tool. Use them.
 
 ### 3d. Output Schema
 
@@ -149,12 +139,7 @@ max_tokens: [tight budget — don't leave this open-ended]
 response_format: json_object # if applicable
 ```
 
-Temperature guidance:
-
-- Extraction, classification, structured output → 0.0
-- Summarization, Q&A → 0.1–0.2
-- Generation, creative → 0.3–0.7
-- Never above 0.8 for production tasks
+Set temperature appropriate to the task. Never above 0.8 in production.
 
 ## Step 5: Write Eval Criteria
 
@@ -196,12 +181,7 @@ Monthly at [volume]: $[X.XX]
 Cheaper option: [lower model tier] — saves [X]% if eval score holds
 ```
 
-Prompt optimization for cost:
-
-- Remove redundant instructions (say each thing once)
-- Move static context to the system prompt, not the user message
-- Truncate inputs with a defined strategy if they exceed a token budget
-- Consider caching the system prompt (Anthropic prompt caching = 90% cost reduction on repeated calls)
+Cost optimization: deduplicate instructions, move static context to system prompt, truncate inputs past token budget, enable prompt caching (90% cost reduction on repeated calls).
 
 ## Step 7: Output
 

--- a/skills/forge-audit/SKILL.md
+++ b/skills/forge-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: forge-audit
-description: Audit existing infrastructure for security issues, waste, and misconfigurations. Use when asked to "audit my infra", "check cloud setup", "infra review", "are we wasting money", "security check on infra", or "review my terraform".
+description: Audit existing infrastructure for security issues, waste, and misconfigurations. Analyzes IAM policies, checks security group rules, identifies unused resources, reviews cost allocation tags, and flags Terraform misconfigurations. Use when asked to "audit my infra", "check cloud setup", "infra review", "are we wasting money", "security check on infra", or "review my terraform".
 allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
 version: 0.6.4
 author: tonone-ai <hello@tonone.ai>
@@ -17,33 +17,19 @@ Follow the output format defined in docs/output-kit.md — 40-line CLI max, box-
 
 ### Step 0: Detect Environment
 
-Scan the project to find all IaC and cloud configuration:
+Scan for all IaC and cloud configuration:
 
 ```bash
-# Terraform
+# IaC files
 find . -name '*.tf' -not -path './.terraform/*' 2>/dev/null
-
-# Pulumi
-ls Pulumi.yaml Pulumi.*.yaml 2>/dev/null
-find . -name '__main__.py' -path '*/pulumi/*' 2>/dev/null
-
-# CDK / CloudFormation
-ls cdk.json template.yaml template.json 2>/dev/null
-
-# Docker / Compose
-ls Dockerfile docker-compose.yml docker-compose.yaml 2>/dev/null
-
-# Cloud CLI configs
-gcloud config get-value project 2>/dev/null
-aws sts get-caller-identity 2>/dev/null
-cat wrangler.toml 2>/dev/null
-cat fly.toml 2>/dev/null
-
-# Kubernetes
+ls Pulumi.yaml cdk.json template.yaml Dockerfile docker-compose.yml 2>/dev/null
 ls k8s/ kubernetes/ manifests/ helmfile.yaml Chart.yaml 2>/dev/null
+
+# Cloud configs
+ls wrangler.toml fly.toml 2>/dev/null
 ```
 
-Read every IaC file found. If no IaC exists, tell the user that's finding #1.
+Read every IaC file found. If no IaC exists, that's finding #1.
 
 ### Step 1: Audit All IaC Files
 
@@ -52,7 +38,7 @@ Read every infrastructure file and check for these categories:
 **Security Issues (report as red circle):**
 
 - Public endpoints that should be private (databases, caches, internal APIs)
-- Overly permissive IAM roles (admin, editor, _._)
+- Overly permissive IAM roles
 - Missing encryption at rest or in transit
 - Hardcoded secrets, API keys, or credentials
 - Security groups with 0.0.0.0/0 on non-443 ports
@@ -71,7 +57,7 @@ Read every infrastructure file and check for these categories:
 
 **Cost and Hygiene Issues (report as blue circle):**
 
-- Over-provisioned resources (4 vCPU for a cron job, 64GB RAM for a small API)
+- Over-provisioned resources
 - Missing tags/labels on resources
 - Hardcoded values that should be variables
 - No remote state backend configured
@@ -79,7 +65,15 @@ Read every infrastructure file and check for these categories:
 - Resources with no clear owner or purpose
 - Unused resources still provisioned
 
-### Step 2: Present Findings
+### Step 2: Verify Findings
+
+Cross-reference each finding against actual resource state:
+
+- Confirm flagged resources exist and are active (not commented out or in disabled modules)
+- Check if apparent misconfigurations are overridden by higher-level policies or variables
+- Drop any finding that doesn't survive verification
+
+### Step 3: Present Findings
 
 Format the report as:
 
@@ -98,13 +92,24 @@ Format the report as:
 
 Use the actual emoji circles in the output: red for critical, yellow for warning, blue for improvement.
 
+**Example findings:**
+
+Red Circle Critical:
+`aws_db_instance.main` in `modules/rds/main.tf:14` — `publicly_accessible = true` on production database. Exposes DB to internet scan attacks. Fix: set `publicly_accessible = false` and access via VPC private subnet.
+
+Yellow Circle Warning:
+`aws_ecs_service.api` in `services/api/main.tf:42` — No autoscaling policy attached. Fixed capacity breaks under load spikes. Fix: add `aws_appautoscaling_target` with min 2, max 10 and a CPU target tracking policy.
+
+Blue Circle Improvement:
+`aws_s3_bucket.logs` in `storage/main.tf:8` — No lifecycle policy. Log bucket grows unbounded. Fix: add `lifecycle_rule` expiring objects after 90 days.
+
 Each finding MUST include:
 
 - The specific resource and file/line where the issue exists
 - Why it's a problem (not just "best practice" — explain the actual risk)
 - A concrete fix (code snippet or specific change, not "consider doing X")
 
-### Step 3: Summary
+### Step 4: Summary
 
 End with:
 

--- a/skills/proof-e2e/SKILL.md
+++ b/skills/proof-e2e/SKILL.md
@@ -15,27 +15,9 @@ You are Proof — the QA and testing engineer on the Engineering Team.
 
 Follow the output format defined in docs/output-kit.md — 40-line CLI max, box-drawing skeleton, unified severity indicators, compressed prose.
 
-## What E2E Tests Are For (And What They're Not)
+## Scope
 
-E2E tests are for user journeys. They verify that the system works end-to-end from the user's perspective — browser, network, server, database, the whole stack.
-
-**Test in E2E:**
-
-- Sign up → onboarding → first core action (activation flow)
-- Sign in → perform primary value action → see result
-- Checkout / payment flow
-- Critical destructive action (delete account, cancel subscription)
-- Permission boundaries (user A cannot see user B's data)
-
-**Do NOT test in E2E:**
-
-- Individual API endpoint behavior → that's integration tests
-- Form validation errors → that's unit tests on validators + integration tests on handlers
-- UI component rendering → that's component tests or visual regression
-- Every edge case in a form → combinatorial explosion, use unit tests
-- Third-party service behavior → mock it at the network layer
-
-The E2E suite should be ≤10 tests for an early-stage product. Every test you add is maintenance cost. Be ruthless about what earns a spot.
+E2E = user journeys only (sign-up-to-activation, checkout, permission boundaries). Budget: ≤10 tests. Every test is maintenance cost.
 
 ## Steps
 
@@ -54,8 +36,6 @@ Scan before asking:
 If no E2E tool is configured, install and configure Playwright. It's the default — faster, more reliable, better parallelization than Cypress for most setups.
 
 ### Step 1: Journey Map
-
-List the critical user journeys, ranked by business impact:
 
 | Priority | Journey          | Entry Point        | Success State                      | Risk if Broken                     |
 | -------- | ---------------- | ------------------ | ---------------------------------- | ---------------------------------- |
@@ -216,22 +196,18 @@ test.describe("Core workflow", () => {
 });
 ```
 
-**Key patterns in every test:**
-
-- Use `getByTestId()` — not CSS selectors or text that might change
-- Assert on visible outcomes the user would see — not internal state
-- Use proper Playwright auto-waits — never `waitForTimeout()`
-- Each test is fully independent — no test depends on another test's state
-- Auth via API/fixture, not by navigating the login UI in every test
+- Use `getByTestId()` — not CSS selectors or text that changes
+- Assert on visible user outcomes — not internal state
+- Playwright auto-waits only — never `waitForTimeout()`
+- Each test is independent — no shared state or order dependencies
+- Auth via API fixture — not UI login in every test
 
 ### Step 4: Test Data Strategy
-
-Decide on test data approach based on what's available:
 
 - **API setup (preferred):** Use authenticated API calls in `test.beforeEach` to seed data, clean up in `test.afterEach`
 - **Database seeding:** Use a test seed script if direct DB access is available in test environment
 - **Fixtures:** Static fixture data for read-only tests
-- **Never:** Use production data, hardcoded IDs that exist in one environment, or shared state between tests
+- **Never:** Production data, environment-specific hardcoded IDs, or shared state between tests
 
 ### Step 5: CI Integration
 
@@ -289,18 +265,6 @@ Output what was written:
 │  → Next      [one concrete next step]                     │
 └──────────────────────────────────────────────────────────┘
 ```
-
-## Key Rules
-
-- Write tests for journeys, not components — E2E is expensive, use it for what only E2E can catch
-- Never `waitForTimeout()` — use Playwright's auto-waits and `expect().toBeVisible()`
-- Every test is independent — no shared state, no test order dependencies
-- Auth via API fixture — not UI login in every test (that's slow and a separate concern)
-- `data-testid` for selectors — CSS classes and text break on refactors
-- Suite must run under 5 minutes on CI — shard if needed, delete if bloated
-- 1 retry in CI only — retries hide flakiness, don't use them locally
-- Screenshots and traces on failure are mandatory — debugging blind wastes hours
-- Explicit "skip" list — document what you're not testing in E2E and why
 
 ## Delivery
 

--- a/skills/spine-api/SKILL.md
+++ b/skills/spine-api/SKILL.md
@@ -57,8 +57,7 @@ Notes:    idempotency, side effects, rate limit tier
 
 - Resources are plural nouns: `/payments`, `/customers`, `/invoices`
 - Nested resources for ownership: `GET /customers/:id/payment-methods`
-- Use correct HTTP verbs: GET (read), POST (create), PUT/PATCH (update), DELETE (remove)
-- `POST` on a resource creates. `PUT` replaces. `PATCH` partially updates. Be consistent.
+- Use correct HTTP verbs consistently.
 - IDs in path params. Filters and pagination in query params. Mutations in request body.
 - Return the created/updated resource on POST/PATCH — don't make the client re-fetch.
 
@@ -79,14 +78,14 @@ Notes:    idempotency, side effects, rate limit tier
 
 | Status | When                                                                                |
 | ------ | ----------------------------------------------------------------------------------- |
-| 400    | Validation failure — include `param`                                                |
-| 401    | Missing or invalid auth token                                                       |
-| 403    | Auth valid, but not permitted for this resource                                     |
-| 404    | Resource not found                                                                  |
-| 409    | Conflict — resource already exists, duplicate idempotency key with different params |
-| 422    | Semantically invalid request (valid JSON, valid types, invalid logic)               |
-| 429    | Rate limit exceeded — include `Retry-After` header                                  |
-| 500    | Internal error — log it, don't expose details                                       |
+| 400    | Validation failure — include `param`                                |
+| 401    | Missing or invalid auth                                             |
+| 403    | Authenticated but not authorized                                    |
+| 404    | Resource not found                                                  |
+| 409    | Conflict — duplicate resource or idempotency key mismatch           |
+| 422    | Semantically invalid — valid syntax, invalid logic                  |
+| 429    | Rate limited — include `Retry-After` header                         |
+| 500    | Internal error — log, don't expose                                  |
 
 **Pagination (cursor-based, always on list endpoints):**
 
@@ -108,10 +107,10 @@ Accept `Idempotency-Key` header. Return the same response for duplicate keys wit
 
 Specify the auth pattern explicitly:
 
-- **API key:** `Authorization: Bearer sk_live_...` — for server-to-server. Store hashed. Prefix distinguishes live/test.
-- **JWT:** Short-lived access token (15min), long-lived refresh token (7–30d). Validate signature, expiry, and audience.
-- **OAuth2:** For third-party access. Specify scopes per endpoint.
-- **Public:** No auth — document why and what rate limits apply.
+- **API key:** `Authorization: Bearer sk_live_...` — server-to-server, store hashed, prefix distinguishes live/test
+- **JWT:** Access token (15min) + refresh token (7–30d). Validate signature, expiry, audience.
+- **OAuth2:** Third-party access. Specify scopes per endpoint.
+- **Public:** No auth — document rationale and rate limits.
 
 State which endpoints require which auth level. Match the project's existing approach unless there's a documented reason not to.
 
@@ -141,7 +140,7 @@ Return `429 Too Many Requests` with:
 - `Retry-After: <seconds>` header
 - `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` headers
 
-Use the project's existing rate limiting approach. If none exists, use Redis with a sliding window.
+Match existing rate limiting. If none, use Redis sliding window.
 
 ### Step 6: Write Tests
 

--- a/skills/warden-threat/SKILL.md
+++ b/skills/warden-threat/SKILL.md
@@ -43,8 +43,6 @@ List what an attacker actually wants from this system:
 | ------- | -------------- | ------------------------ | -------------- |
 | [asset] | [High/Med/Low] | [where stored/processed] | [impact]       |
 
-Crown jewels are: user PII, payment data, auth credentials, API keys, business logic that can be abused for financial gain, admin access.
-
 ### Step 2: Map the Attack Surface
 
 Every entry point into the system:
@@ -53,33 +51,23 @@ Every entry point into the system:
 | ----------- | ------------------ | ------------- | ------------------------- | ---------- |
 | [endpoint]  | [HTTP/gRPC/WS/etc] | [Y/N/partial] | [public/internal/partner] | [any gaps] |
 
-Include: REST/GraphQL APIs, WebSockets, admin panels, webhooks, file upload endpoints, background job triggers, message queue consumers, third-party OAuth callbacks.
-
-Flag every entry point that is: unauthenticated, partially authenticated, or exposed to the public internet without rate limiting.
+Flag every entry point that is unauthenticated, partially authenticated, or public without rate limiting.
 
 ### Step 3: Map Trust Boundaries
 
 Draw the data flow as text. Mark where data crosses trust boundaries and whether those crossings are encrypted and authenticated:
 
 ```
-[Public Internet]
-    ↓ HTTPS (TLS 1.2+?)
-[CDN / Load Balancer]          ← boundary: public → edge
-    ↓ internal HTTP (TLS?)
-[API Service]
-    ↓ connection (TLS? auth?)
-[Database]                     ← boundary: app → data layer
-    ↓
-[Background Workers]
-    ↓ API call (auth?)
-[External Services / Webhooks] ← boundary: internal → third-party
+[Public Internet] →HTTPS→ [CDN/LB] →HTTP?→ [API] →conn?→ [DB]
+                                      ↓
+                              [Workers] →API?→ [External Services]
 ```
 
-Flag each crossing where: TLS is absent, auth is absent, or the downstream service is trusted implicitly.
+Flag crossings missing TLS, auth, or relying on implicit trust.
 
 ### Step 4: Rank Threats by Likelihood × Impact
 
-For each significant threat, score it and prescribe the mitigation. Focus on the 90% case — the attacks that actually happen.
+Score and prescribe. Focus on the 90% case — attacks that actually happen.
 
 **Threat ranking criteria:**
 
@@ -100,11 +88,9 @@ Fix: [specific control — exact header value, config setting, code pattern, or 
 Effort: [hours / days]
 ```
 
-Anchor to real attack patterns: credential stuffing on unrate-limited auth, secrets leaked in public repos, SQLi through unvalidated input, IDOR through missing object-level auth, SSRF through unvalidated URLs, dependency CVEs.
-
 ### Step 5: List Accepted Risks
 
-Every threat model has risks the team is consciously accepting. Name them explicitly:
+Name accepted risks explicitly:
 
 | Risk   | Reason Accepted           | Review Trigger                     |
 | ------ | ------------------------- | ---------------------------------- |
@@ -148,7 +134,7 @@ Follow the output format defined in docs/output-kit.md — 40-line CLI max, box-
 3. [third]
 ```
 
-Do not produce a STRIDE matrix with every cell filled. Produce the ranked threat list with concrete fixes. The output is the artifact, not the methodology.
+Produce the ranked threat list with concrete fixes — not a STRIDE matrix.
 
 ## Delivery
 


### PR DESCRIPTION
Hey @thisisfatih 👋

125 skills across 23 coordinated specialists, with compliance tests, a hooks system, elephant memory, and worktree management. This goes well beyond a prompt collection. The architecture doc, the naming guide, the bundle system for different team compositions. You've built what's essentially an operating system for AI teams. I'd like to contribute some improvements to a few of the skill files.

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

<img width="1312" height="910" alt="score_card" src="https://github.com/user-attachments/assets/5a0780ae-9e70-4e4b-8ea1-df04794df5d2" />


## Summary

Targeted content improvements across 5 skills from different agents (Forge, Spine, Proof, Warden, Cortex). The biggest win is `forge-audit` (+10%) which had the most room for improvement. The other 4 skills at 89% received genuine content quality improvements. Trimmed verbosity, removed content Claude already knows, compressed redundant sections - even though the numeric score held steady (the judge gates on progressive disclosure via reference files, which would introduce a new pattern across your 140 skills).

<details>
<summary>Changes summary</summary>

**forge-audit (+10%)** - the biggest win:
- Expanded description with specific concrete actions (analyzes IAM policies, checks security group rules, identifies unused resources, reviews cost allocation tags, flags Terraform misconfigurations)
- Added a verification step (Step 2) to cross-reference findings against actual resource state before presenting - catches false positives from disabled modules or overridden policies
- Added concrete example findings per severity level with real resource references, file/line locations, and specific fixes
- Compressed environment detection commands
- Trimmed unnecessary parenthetical examples from audit checklists

**spine-api (quality improvements)**:
- Removed HTTP verb explanations Claude already knows (`GET (read), POST (create)` etc.)
- Tightened error code table descriptions (e.g., "Authenticated but not authorized" instead of verbose explanations)
- Compressed auth pattern descriptions
- Tightened rate limiting section

**proof-e2e (quality improvements)**:
- Replaced verbose "What E2E Tests Are For" explainer section with a concise 2-line Scope section
- Removed redundant "Key Rules" section (9 bullets that duplicated inline guidance)
- Tightened key patterns list and test data strategy
- Trimmed intro lines from sections where the content speaks for itself

**warden-threat (quality improvements)**:
- Removed "Crown jewels are:" enumeration (the table template already guides the agent)
- Removed "Include:" entry point list (Claude knows what to scan for)
- Compressed trust boundary ASCII diagram from 10 lines to 3
- Tightened Step 4/5 intros and removed redundant "Anchor to real attack patterns" list
- Compressed STRIDE disclaimer

**cortex-prompt (quality improvements)**:
- Removed model tier comparison table with competitor names (GPT-4o, Gemini) - Claude already knows these
- Compressed temperature guidance from 4-line list to single line
- Removed motivational filler ("Few-shot examples are the most powerful...")
- Tightened prompt writing rules and cost optimization tips
- Compressed "Specific beats vague" example to direct instruction

</details>

Honest disclosure. I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@yogesh-tessl](https://github.com/yogesh-tessl) - if you hit any snags.

Thanks in advance 🙏
