### PR TITLE
fix(relay-ship): enrich PR footer with Tonone attribution table

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tonone",
   "description": "Engineering + Product team \u2014 23 agents as Claude Code specialists. Infrastructure, DevOps, backend, security, ML/AI, mobile, UX, analytics, growth, strategy, and more.",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "author": {
     "name": "tonone-ai",
     "url": "https://tonone.ai"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.7] — 2026-04-28
+
+### Improved
+
+- **relay-ship:** PR footer is now a rich attributed block — shows Tonone branding, agents used, session duration, and estimated cost. Previously collapsed to a bare link.
+
 ## [0.9.6] — 2026-04-28
 
 ### Changed

--- a/ELEPHANT.md
+++ b/ELEPHANT.md
@@ -98,3 +98,4 @@
 2026-04-28 13:48 : readme updated — version badge 0.9.1 → 0.9.5 — @fatih
 2026-04-28 13:49 : chore: elephant takeover + readme badge 0.9.1 → 0.9.5 — @fatih
 [!!] 2026-04-28 14:00 : release 0.9.6 — elephant memory seeded, readme badge fixed — @fatih
+2026-04-28 14:57 : fix(relay-ship): enrich PR footer with Tonone attribution table — @fatih

--- a/bundle/engineering-team/.claude-plugin/plugin.json
+++ b/bundle/engineering-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "engineering-team",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Engineering team \u2014 15 agents: Apex, Forge, Relay, Spine, Flux, Warden, Vigil, Prism, Cortex, Touch, Volt, Atlas, Lens, Proof, Pave",
   "author": {
     "name": "tonone-ai",
@@ -8,5 +8,9 @@
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["agents", "engineering-team", "bundle"]
+  "keywords": [
+    "agents",
+    "engineering-team",
+    "bundle"
+  ]
 }

--- a/bundle/full-team/.claude-plugin/plugin.json
+++ b/bundle/full-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "full-team",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Full tonone team \u2014 all 23 agents (Engineering + Product) with all 125 skills",
   "author": {
     "name": "tonone-ai",

--- a/bundle/product-team/.claude-plugin/plugin.json
+++ b/bundle/product-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-team",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Product team \u2014 8 agents: Helm, Echo, Lumen, Draft, Form, Crest, Pitch, Surge",
   "author": {
     "name": "tonone-ai",
@@ -8,5 +8,9 @@
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["agents", "product-team", "bundle"]
+  "keywords": [
+    "agents",
+    "product-team",
+    "bundle"
+  ]
 }

--- a/hooks/tonone-pr-attribution.js
+++ b/hooks/tonone-pr-attribution.js
@@ -41,15 +41,25 @@ function readAgents() {
 }
 
 function clearAgents() {
-  try { fs.writeFileSync(SESSION_FILE, ""); } catch {}
+  try {
+    fs.writeFileSync(SESSION_FILE, "");
+  } catch {}
 }
 
 function getPrUrl(toolOutput) {
-  const raw = (toolOutput && (typeof toolOutput === "string" ? toolOutput : toolOutput.output)) || "";
-  const urlMatch = String(raw).match(/https:\/\/github\.com\/[\w.\-]+\/[\w.\-]+\/pull\/\d+/);
+  const raw =
+    (toolOutput &&
+      (typeof toolOutput === "string" ? toolOutput : toolOutput.output)) ||
+    "";
+  const urlMatch = String(raw).match(
+    /https:\/\/github\.com\/[\w.\-]+\/[\w.\-]+\/pull\/\d+/,
+  );
   if (urlMatch) return urlMatch[0];
   try {
-    const url = execSync("gh pr view --json url -q .url", { encoding: "utf8", timeout: 5000 }).trim();
+    const url = execSync("gh pr view --json url -q .url", {
+      encoding: "utf8",
+      timeout: 5000,
+    }).trim();
     if (url.startsWith("http")) return url;
   } catch {}
   return null;
@@ -59,18 +69,26 @@ function appendAttribution(prUrl, attributionLine) {
   const tmpFile = path.join(os.tmpdir(), `tonone-pr-body-${process.pid}.md`);
   try {
     const viewResult = spawnSync(
-      "gh", ["pr", "view", prUrl, "--json", "body", "-q", ".body"],
-      { encoding: "utf8", timeout: 5000 }
+      "gh",
+      ["pr", "view", prUrl, "--json", "body", "-q", ".body"],
+      { encoding: "utf8", timeout: 5000 },
     );
     const currentBody = (viewResult.stdout || "").trim();
+    // Skip if relay-ship already wrote the rich Tonone footer
+    if (
+      currentBody.includes("tonone.ai") &&
+      currentBody.includes("Co-Authored-By: Tonone")
+    )
+      return;
     const newBody = `${currentBody}\n\n---\n${attributionLine}`;
     fs.writeFileSync(tmpFile, newBody);
-    spawnSync(
-      "gh", ["pr", "edit", prUrl, "--body-file", tmpFile],
-      { timeout: 10000 }
-    );
+    spawnSync("gh", ["pr", "edit", prUrl, "--body-file", tmpFile], {
+      timeout: 10000,
+    });
   } finally {
-    try { fs.unlinkSync(tmpFile); } catch {}
+    try {
+      fs.unlinkSync(tmpFile);
+    } catch {}
   }
 }
 
@@ -82,7 +100,7 @@ if (require.main !== module) {
 let input = "";
 const timeout = setTimeout(() => process.exit(0), 3000);
 process.stdin.setEncoding("utf8");
-process.stdin.on("data", chunk => (input += chunk));
+process.stdin.on("data", (chunk) => (input += chunk));
 process.stdin.on("end", () => {
   clearTimeout(timeout);
   try {

--- a/lib/uiux/pyproject.toml
+++ b/lib/uiux/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uiux"
-version = "0.9.6"
+version = "0.9.7"
 description = "Shared UI/UX design intelligence library — BM25 search engine + design system generator"
 license = "MIT"
 requires-python = ">=3.10"

--- a/skills/apex-plan/.claude-plugin/plugin.json
+++ b/skills/apex-plan/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-plan",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Plan and scope a project \u2014 discovery, challenge assumptions, present S/M/L options with token and cost estimates. Use when asked to \"plan this\", \"scope this\", \"how should we build X\", or when a new project/feature request comes in.",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["apex", "skill"]
+  "keywords": [
+    "apex",
+    "skill"
+  ]
 }

--- a/skills/apex-recon/.claude-plugin/plugin.json
+++ b/skills/apex-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-recon",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Engineering lead reconnaissance \u2014 inventory the project before planning. Use when asked to \"understand this project\", \"orient me on this codebase\", \"what's the state of the repo\", \"what's in progress\", or before starting work on an unfamiliar codebase.",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["apex", "skill"]
+  "keywords": [
+    "apex",
+    "skill"
+  ]
 }

--- a/skills/apex-review/.claude-plugin/plugin.json
+++ b/skills/apex-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-review",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Cross-cutting review of recent work \u2014 catches gaps between specialists. Use when asked to \"review what we built\", \"check the work\", \"pre-launch review\", or after completing a significant chunk of work.",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["apex", "skill"]
+  "keywords": [
+    "apex",
+    "skill"
+  ]
 }

--- a/skills/apex-status/.claude-plugin/plugin.json
+++ b/skills/apex-status/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-status",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "CTO-level project status from git and codebase state. Use when asked \"where are we\", \"project status\", \"what's done\", or at the start of a work session.",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["apex", "skill"]
+  "keywords": [
+    "apex",
+    "skill"
+  ]
 }

--- a/skills/apex-takeover/.claude-plugin/plugin.json
+++ b/skills/apex-takeover/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-takeover",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "System takeover \u2014 take ownership of an existing codebase or inherited system. Use when \"we acquired this\", \"previous team left\", \"take over this system\", \"inherited this codebase\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["apex", "skill"]
+  "keywords": [
+    "apex",
+    "skill"
+  ]
 }

--- a/skills/atlas-adr/.claude-plugin/plugin.json
+++ b/skills/atlas-adr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atlas-adr",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Write an Architecture Decision Record \u2014 document what was decided, why, what alternatives were considered, and what trade-offs were accepted. Use when asked to \"write an ADR\", \"document this decision\", or \"why did we choose X\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["atlas", "skill"]
+  "keywords": [
+    "atlas",
+    "skill"
+  ]
 }

--- a/skills/atlas-changelog/.claude-plugin/plugin.json
+++ b/skills/atlas-changelog/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atlas-changelog",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Maintain per-repo and cross-repo changelogs \u2014 append structured entries after agent work. Use when asked to \"log this change\", \"update changelog\", \"what changed\", \"change history\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["atlas", "skill"]
+  "keywords": [
+    "atlas",
+    "skill"
+  ]
 }

--- a/skills/atlas-map/.claude-plugin/plugin.json
+++ b/skills/atlas-map/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atlas-map",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Map the system architecture \u2014 read the codebase, identify services and connections, output a C4-level architecture map as Mermaid diagrams with component descriptions. Use when asked to \"map the architecture\", \"system diagram\", \"how does this work\", or \"architecture overview\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["atlas", "skill"]
+  "keywords": [
+    "atlas",
+    "skill"
+  ]
 }

--- a/skills/atlas-onboard/.claude-plugin/plugin.json
+++ b/skills/atlas-onboard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atlas-onboard",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Generate onboarding documentation \u2014 what this project does, how to set up locally, where things live, key decisions, how to deploy. Written for day-one engineers who know nothing. Use when asked for \"onboarding docs\", \"new engineer guide\", \"how to get started\", or \"developer setup\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["atlas", "skill"]
+  "keywords": [
+    "atlas",
+    "skill"
+  ]
 }

--- a/skills/atlas-present/.claude-plugin/plugin.json
+++ b/skills/atlas-present/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atlas-present",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Generate a polished HTML presentation page and Obsidian Canvas for big releases \u2014 new products, takeovers, major migrations. Non-technical audience. Use when asked to \"present this\", \"release announcement\", \"show what we built\", or \"stakeholder update\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["atlas", "skill"]
+  "keywords": [
+    "atlas",
+    "skill"
+  ]
 }

--- a/skills/atlas-recon/.claude-plugin/plugin.json
+++ b/skills/atlas-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atlas-recon",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Documentation reconnaissance for takeover \u2014 find all docs, assess accuracy, freshness, coverage, and discoverability, and identify critical knowledge gaps. Use when asked \"what docs exist\", \"documentation assessment\", or \"knowledge gaps\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["atlas", "skill"]
+  "keywords": [
+    "atlas",
+    "skill"
+  ]
 }

--- a/skills/atlas-report/.claude-plugin/plugin.json
+++ b/skills/atlas-report/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atlas-report",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Render agent findings as a styled HTML report in the browser. Use when asked for \"full report\", \"detailed report\", \"show in browser\", or when CLI output exceeds the 40-line budget.",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["atlas", "skill"]
+  "keywords": [
+    "atlas",
+    "skill"
+  ]
 }

--- a/skills/cortex-eval/.claude-plugin/plugin.json
+++ b/skills/cortex-eval/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex-eval",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Evaluate model performance \u2014 check for accuracy drops, data drift, and error patterns. Use when asked about \"model accuracy dropped\", \"evaluate the model\", \"check for drift\", or \"model performance\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["cortex", "skill"]
+  "keywords": [
+    "cortex",
+    "skill"
+  ]
 }

--- a/skills/cortex-integrate/.claude-plugin/plugin.json
+++ b/skills/cortex-integrate/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex-integrate",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Design and implement an AI feature integration \u2014 model selection, architecture pattern, system prompt, data flow, error handling, cost estimate. Use when asked to \"add AI to this\", \"LLM integration\", \"add Claude/GPT\", or \"AI-powered feature\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["cortex", "skill"]
+  "keywords": [
+    "cortex",
+    "skill"
+  ]
 }

--- a/skills/cortex-model/.claude-plugin/plugin.json
+++ b/skills/cortex-model/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex-model",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Build an ML pipeline \u2014 from data to trained model to serving endpoint. Use when asked to \"build ML model\", \"train a model\", \"prediction pipeline\", \"classification\", or \"regression\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["cortex", "skill"]
+  "keywords": [
+    "cortex",
+    "skill"
+  ]
 }

--- a/skills/cortex-prompt/.claude-plugin/plugin.json
+++ b/skills/cortex-prompt/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex-prompt",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Build a production-ready prompt package \u2014 system prompt, few-shot examples, output format, edge case handling, eval criteria. Use when asked to \"prompt engineering\", \"build a prompt\", \"write a system prompt\", or \"improve this prompt\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["cortex", "skill"]
+  "keywords": [
+    "cortex",
+    "skill"
+  ]
 }

--- a/skills/cortex-recon/.claude-plugin/plugin.json
+++ b/skills/cortex-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex-recon",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "ML reconnaissance \u2014 inventory all models, pipelines, data sources, and monitoring. Use when asked \"what ML do we have\", \"model inventory\", or \"ML assessment\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["cortex", "skill"]
+  "keywords": [
+    "cortex",
+    "skill"
+  ]
 }

--- a/skills/crest-compete/.claude-plugin/plugin.json
+++ b/skills/crest-compete/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "crest-compete",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Competitive analysis ending in a clear positioning call \u2014 where to play, how to win. Use when asked to \"analyze competitors\", \"competitive landscape\", \"how do we compare to X\", \"competitive positioning\", \"where should we play\", \"find our white space\", or \"who else does this\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["crest", "skill"]
+  "keywords": [
+    "crest",
+    "skill"
+  ]
 }

--- a/skills/crest-narrative/.claude-plugin/plugin.json
+++ b/skills/crest-narrative/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "crest-narrative",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Strategic narrative \u2014 write a standalone strategy memo that frames product direction, bets, and rationale for a planning horizon. Use when asked to \"write a strategy doc\", \"product vision\", \"strategic narrative\", \"company strategy memo\", \"planning memo\", or \"explain our product direction\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["crest", "skill"]
+  "keywords": [
+    "crest",
+    "skill"
+  ]
 }

--- a/skills/crest-okr/.claude-plugin/plugin.json
+++ b/skills/crest-okr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "crest-okr",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "OKR design \u2014 create objectives and key results with a North Star metric, input metrics tree, and cadence. Use when asked to \"set OKRs\", \"define our objectives\", \"what should we measure this quarter\", \"design our OKR framework\", \"build a metrics tree\", or \"what's our North Star\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["crest", "skill"]
+  "keywords": [
+    "crest",
+    "skill"
+  ]
 }

--- a/skills/crest-recon/.claude-plugin/plugin.json
+++ b/skills/crest-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "crest-recon",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Strategic context reconnaissance \u2014 read existing roadmaps, OKRs, competitive docs, and briefs to establish context before planning. Use when asked to \"understand our strategy\", \"what's the current roadmap\", \"what OKRs do we have\", \"strategic context\", or before starting any prioritization or roadmap work.",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["crest", "skill"]
+  "keywords": [
+    "crest",
+    "skill"
+  ]
 }

--- a/skills/crest-roadmap/.claude-plugin/plugin.json
+++ b/skills/crest-roadmap/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "crest-roadmap",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Build a product roadmap with sequenced bets and explicit tradeoffs. Use when asked to \"build a roadmap\", \"prioritize the backlog strategically\", \"what do we build next quarter\", \"sequence our bets\", \"what should we focus on\", or \"product strategy for the next N months\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["crest", "skill"]
+  "keywords": [
+    "crest",
+    "skill"
+  ]
 }

--- a/skills/draft-flow/.claude-plugin/plugin.json
+++ b/skills/draft-flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-flow",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["draft", "skill"]
+  "keywords": [
+    "draft",
+    "skill"
+  ]
 }

--- a/skills/draft-ia/.claude-plugin/plugin.json
+++ b/skills/draft-ia/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-ia",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Information architecture \u2014 design navigation structure, content hierarchy, sitemap, and taxonomy for a product or feature set. Use when asked to \"organize the navigation\", \"information architecture\", \"how should content be structured\", \"sitemap\", \"nav redesign\", \"where should X live\", or \"content hierarchy\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["draft", "skill"]
+  "keywords": [
+    "draft",
+    "skill"
+  ]
 }

--- a/skills/draft-landing/.claude-plugin/plugin.json
+++ b/skills/draft-landing/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-landing",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["draft", "skill"]
+  "keywords": [
+    "draft",
+    "skill"
+  ]
 }

--- a/skills/draft-patterns/.claude-plugin/plugin.json
+++ b/skills/draft-patterns/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-patterns",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["draft", "skill"]
+  "keywords": [
+    "draft",
+    "skill"
+  ]
 }

--- a/skills/draft-recon/.claude-plugin/plugin.json
+++ b/skills/draft-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-recon",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "UI and UX reconnaissance \u2014 scan existing frontend routes, components, navigation, and flows to understand the current UX state before designing. Use when asked to \"understand the current UI\", \"what UX patterns exist\", \"map the navigation\", \"what screens exist\", or before starting any flow or wireframe work.",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["draft", "skill"]
+  "keywords": [
+    "draft",
+    "skill"
+  ]
 }

--- a/skills/draft-review/.claude-plugin/plugin.json
+++ b/skills/draft-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-review",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Usability review \u2014 evaluate an existing flow or UI against usability heuristics, flag friction points, and recommend fixes. Use when asked to \"review the UX\", \"usability audit\", \"what's wrong with this flow\", \"UX feedback\", \"critique this design\", or \"why are users dropping off here\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["draft", "skill"]
+  "keywords": [
+    "draft",
+    "skill"
+  ]
 }

--- a/skills/draft-wireframe/.claude-plugin/plugin.json
+++ b/skills/draft-wireframe/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-wireframe",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Text and Mermaid wireframes \u2014 produce screen-level layouts with content hierarchy, component placement, and interaction annotations. Use when asked to \"wireframe this\", \"sketch the UI\", \"layout for this screen\", \"lo-fi mockup\", \"screen design\", or \"what should this page look like\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["draft", "skill"]
+  "keywords": [
+    "draft",
+    "skill"
+  ]
 }

--- a/skills/echo-feedback/.claude-plugin/plugin.json
+++ b/skills/echo-feedback/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "echo-feedback",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Feedback synthesis \u2014 cluster support tickets, NPS verbatims, app store reviews, and churn surveys by theme, separate signal from noise, and produce an actionable insight report. Use when asked to \"synthesize this feedback\", \"analyze support tickets\", \"what are users complaining about\", \"NPS analysis\", \"churn feedback synthesis\", or \"what's the feedback telling us\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["echo", "skill"]
+  "keywords": [
+    "echo",
+    "skill"
+  ]
 }

--- a/skills/echo-interview/.claude-plugin/plugin.json
+++ b/skills/echo-interview/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "echo-interview",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Run a user interview \u2014 produce an interview guide and synthesize the output into an actionable insight report. Use when asked to \"run a user interview\", \"synthesize these interview notes\", \"what do users actually want\", \"build a persona from this feedback\", \"find the JTBD in these transcripts\", or \"analyze this interview data\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["echo", "skill"]
+  "keywords": [
+    "echo",
+    "skill"
+  ]
 }

--- a/skills/echo-jobs/.claude-plugin/plugin.json
+++ b/skills/echo-jobs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "echo-jobs",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Jobs-to-Be-Done analysis \u2014 given a product, user descriptions, transcripts, or tickets, produce a JTBD job map with switching forces analysis and opportunity ranking. Use when asked to \"find the JTBD\", \"what jobs are users hiring us for\", \"job mapping\", \"what are users really trying to do\", \"JTBD framework\", or \"why are users switching\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["echo", "skill"]
+  "keywords": [
+    "echo",
+    "skill"
+  ]
 }

--- a/skills/echo-recon/.claude-plugin/plugin.json
+++ b/skills/echo-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "echo-recon",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "User research reconnaissance \u2014 survey existing personas, research docs, interview notes, and feedback artifacts to establish what is already known about users. Use when asked to \"what research exists\", \"review existing personas\", \"what do we know about our users\", or before starting new research or synthesis work.",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["echo", "skill"]
+  "keywords": [
+    "echo",
+    "skill"
+  ]
 }

--- a/skills/echo-segment/.claude-plugin/plugin.json
+++ b/skills/echo-segment/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "echo-segment",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "User segmentation and persona creation from mixed data sources \u2014 analytics, CRM, support tickets, reviews, or any combination. Use when asked to \"build personas\", \"who are our users\", \"segment our users\", \"create user profiles\", \"define user archetypes\", or \"who is the target user\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["echo", "skill"]
+  "keywords": [
+    "echo",
+    "skill"
+  ]
 }

--- a/skills/flux-health/.claude-plugin/plugin.json
+++ b/skills/flux-health/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flux-health",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Data quality and pipeline health check \u2014 freshness, schema drift, null rates, orphaned records, pipeline status. Use when asked about \"data quality check\", \"pipeline health\", \"is our data fresh\", or \"schema drift\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["flux", "skill"]
+  "keywords": [
+    "flux",
+    "skill"
+  ]
 }

--- a/skills/flux-migrate/.claude-plugin/plugin.json
+++ b/skills/flux-migrate/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flux-migrate",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Build zero-downtime database migrations \u2014 forward SQL, rollback SQL, deployment sequence. Use when asked to \"write migration\", \"schema change\", \"add column\", \"rename table\", \"drop column\", or \"migrate safely\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["flux", "skill"]
+  "keywords": [
+    "flux",
+    "skill"
+  ]
 }

--- a/skills/flux-pipeline/.claude-plugin/plugin.json
+++ b/skills/flux-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flux-pipeline",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Build a data pipeline \u2014 ETL/ELT with extraction, transformation, loading, error handling, and scheduling. Use when asked to \"build ETL\", \"data pipeline\", \"move data from X to Y\", or \"sync data\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["flux", "skill"]
+  "keywords": [
+    "flux",
+    "skill"
+  ]
 }

--- a/skills/flux-query/.claude-plugin/plugin.json
+++ b/skills/flux-query/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flux-query",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Optimize slow database queries \u2014 analyze execution plans, add indexes, rewrite queries. Use when asked about \"slow query\", \"optimize SQL\", \"query performance\", or \"explain this query\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["flux", "skill"]
+  "keywords": [
+    "flux",
+    "skill"
+  ]
 }

--- a/skills/flux-recon/.claude-plugin/plugin.json
+++ b/skills/flux-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flux-recon",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Database reconnaissance \u2014 full inventory of schema, migrations, data volume, backups, connection pooling, and query patterns. Use when asked to \"assess this database\", \"understand the schema\", or \"database health check\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["flux", "skill"]
+  "keywords": [
+    "flux",
+    "skill"
+  ]
 }

--- a/skills/flux-schema/.claude-plugin/plugin.json
+++ b/skills/flux-schema/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flux-schema",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Design and build database schema \u2014 tables, columns, types, indexes, constraints, relationships. Given a domain description, output the schema and write the files. Use when asked to \"design schema\", \"database design\", \"create tables\", or \"data model\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["flux", "skill"]
+  "keywords": [
+    "flux",
+    "skill"
+  ]
 }

--- a/skills/forge-audit/.claude-plugin/plugin.json
+++ b/skills/forge-audit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-audit",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Audit existing infrastructure for security issues, waste, and misconfigurations. Use when asked to \"audit my infra\", \"check cloud setup\", \"infra review\", \"are we wasting money\", \"security check on infra\", or \"review my terraform\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["forge", "skill"]
+  "keywords": [
+    "forge",
+    "skill"
+  ]
 }

--- a/skills/forge-cost/.claude-plugin/plugin.json
+++ b/skills/forge-cost/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-cost",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Audit cloud infrastructure costs and produce a concrete optimization plan with specific changes and estimated savings. Use when asked to \"how much is this costing\", \"reduce cloud spend\", \"cost optimization\", \"are we overpaying\", \"cloud bill\", or \"budget for this infra\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["forge", "skill"]
+  "keywords": [
+    "forge",
+    "skill"
+  ]
 }

--- a/skills/forge-diagnose/.claude-plugin/plugin.json
+++ b/skills/forge-diagnose/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-diagnose",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Diagnose runtime infrastructure issues \u2014 cold starts, timeouts, scaling problems, network failures. Use when asked about \"infra is slow\", \"cold starts\", \"network issues\", \"why is this timing out\", \"scaling problem\", \"latency spikes\", or \"service is down\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["forge", "skill"]
+  "keywords": [
+    "forge",
+    "skill"
+  ]
 }

--- a/skills/forge-infra/.claude-plugin/plugin.json
+++ b/skills/forge-infra/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-infra",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Build production-grade infrastructure as code for a service or project. Use when asked to \"set up infra\", \"provision infrastructure\", \"create cloud resources\", \"IaC for this project\", \"terraform for this\", or \"deploy this service\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["forge", "skill"]
+  "keywords": [
+    "forge",
+    "skill"
+  ]
 }

--- a/skills/forge-network/.claude-plugin/plugin.json
+++ b/skills/forge-network/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-network",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Design and build networking infrastructure \u2014 VPCs, subnets, DNS, load balancers, firewall rules. Use when asked to \"set up networking\", \"VPC design\", \"configure DNS\", \"load balancer setup\", \"network architecture\", or \"firewall rules\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["forge", "skill"]
+  "keywords": [
+    "forge",
+    "skill"
+  ]
 }

--- a/skills/forge-recon/.claude-plugin/plugin.json
+++ b/skills/forge-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-recon",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Infrastructure reconnaissance \u2014 inventory all cloud resources, map connections, flag risks. Use when asked to \"inventory our infra\", \"what infrastructure do we have\", \"map our cloud resources\", \"infra discovery\", or \"what's running in our cloud\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["forge", "skill"]
+  "keywords": [
+    "forge",
+    "skill"
+  ]
 }

--- a/skills/form-audit/.claude-plugin/plugin.json
+++ b/skills/form-audit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-audit",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["form", "skill"]
+  "keywords": [
+    "form",
+    "skill"
+  ]
 }

--- a/skills/form-brand/.claude-plugin/plugin.json
+++ b/skills/form-brand/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-brand",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["form", "skill"]
+  "keywords": [
+    "form",
+    "skill"
+  ]
 }

--- a/skills/form-component/.claude-plugin/plugin.json
+++ b/skills/form-component/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-component",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["form", "skill"]
+  "keywords": [
+    "form",
+    "skill"
+  ]
 }

--- a/skills/form-deck/.claude-plugin/plugin.json
+++ b/skills/form-deck/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-deck",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["form", "skill"]
+  "keywords": [
+    "form",
+    "skill"
+  ]
 }

--- a/skills/form-email/.claude-plugin/plugin.json
+++ b/skills/form-email/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-email",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["form", "skill"]
+  "keywords": [
+    "form",
+    "skill"
+  ]
 }

--- a/skills/form-exam/.claude-plugin/plugin.json
+++ b/skills/form-exam/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-exam",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["form", "skill"]
+  "keywords": [
+    "form",
+    "skill"
+  ]
 }

--- a/skills/form-logo/.claude-plugin/plugin.json
+++ b/skills/form-logo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-logo",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["form", "skill"]
+  "keywords": [
+    "form",
+    "skill"
+  ]
 }

--- a/skills/form-mobile/.claude-plugin/plugin.json
+++ b/skills/form-mobile/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-mobile",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["form", "skill"]
+  "keywords": [
+    "form",
+    "skill"
+  ]
 }

--- a/skills/form-palette/.claude-plugin/plugin.json
+++ b/skills/form-palette/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-palette",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["form", "skill"]
+  "keywords": [
+    "form",
+    "skill"
+  ]
 }

--- a/skills/form-social/.claude-plugin/plugin.json
+++ b/skills/form-social/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-social",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["form", "skill"]
+  "keywords": [
+    "form",
+    "skill"
+  ]
 }

--- a/skills/form-style/.claude-plugin/plugin.json
+++ b/skills/form-style/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-style",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["form", "skill"]
+  "keywords": [
+    "form",
+    "skill"
+  ]
 }

--- a/skills/form-tokens/.claude-plugin/plugin.json
+++ b/skills/form-tokens/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-tokens",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["form", "skill"]
+  "keywords": [
+    "form",
+    "skill"
+  ]
 }

--- a/skills/form-web/.claude-plugin/plugin.json
+++ b/skills/form-web/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-web",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["form", "skill"]
+  "keywords": [
+    "form",
+    "skill"
+  ]
 }

--- a/skills/helm-arbiter/.claude-plugin/plugin.json
+++ b/skills/helm-arbiter/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-arbiter",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Scope arbitration \u2014 resolve disagreements between product and engineering on what is in or out of scope, with a decision log and escalation path. Use when asked to \"resolve this scope disagreement\", \"arbitrate between product and eng\", \"scope is creeping\", \"we can't agree on what's in scope\", or \"help us decide what to cut\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["helm", "skill"]
+  "keywords": [
+    "helm",
+    "skill"
+  ]
 }

--- a/skills/helm-brief/.claude-plugin/plugin.json
+++ b/skills/helm-brief/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-brief",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["helm", "skill"]
+  "keywords": [
+    "helm",
+    "skill"
+  ]
 }

--- a/skills/helm-handoff/.claude-plugin/plugin.json
+++ b/skills/helm-handoff/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-handoff",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["helm", "skill"]
+  "keywords": [
+    "helm",
+    "skill"
+  ]
 }

--- a/skills/helm-plan/.claude-plugin/plugin.json
+++ b/skills/helm-plan/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-plan",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["helm", "skill"]
+  "keywords": [
+    "helm",
+    "skill"
+  ]
 }

--- a/skills/helm-recon/.claude-plugin/plugin.json
+++ b/skills/helm-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-recon",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Product landscape reconnaissance \u2014 survey existing briefs, research, strategy, and team output before writing new briefs or dispatching specialists. Use when asked to \"understand the product state\", \"what briefs exist\", \"what has the team produced\", \"orient me on this product\", or before starting a new product initiative.",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["helm", "skill"]
+  "keywords": [
+    "helm",
+    "skill"
+  ]
 }

--- a/skills/lens-audit/.claude-plugin/plugin.json
+++ b/skills/lens-audit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lens-audit",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Review existing analytics \u2014 find all dashboards and reports, check who uses them, whether metrics are defined, and whether they drive decisions. Recommend what to keep, kill, or add. Use when asked \"are our dashboards useful\", \"analytics review\", or \"metrics audit\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["lens", "skill"]
+  "keywords": [
+    "lens",
+    "skill"
+  ]
 }

--- a/skills/lens-chart/.claude-plugin/plugin.json
+++ b/skills/lens-chart/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lens-chart",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["lens", "skill"]
+  "keywords": [
+    "lens",
+    "skill"
+  ]
 }

--- a/skills/lens-dashboard/.claude-plugin/plugin.json
+++ b/skills/lens-dashboard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lens-dashboard",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Design and spec an analytical dashboard \u2014 define the question each chart answers, write the SQL queries, spec the layout and refresh cadence. Produces a complete dashboard spec ready to implement. Use when asked to \"build a dashboard\", \"analytics dashboard\", \"BI dashboard\", \"weekly product health\", or \"visualize this data\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["lens", "skill"]
+  "keywords": [
+    "lens",
+    "skill"
+  ]
 }

--- a/skills/lens-metrics/.claude-plugin/plugin.json
+++ b/skills/lens-metrics/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lens-metrics",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Produce a complete metrics definition doc \u2014 metric name, formula, data source, segmentation, SQL or event tracking spec, and what good/bad looks like. Given a product area, outputs the full metrics spec. Use when asked to \"define KPIs\", \"metrics framework\", \"what should we measure\", \"north star metric\", or \"instrument this feature\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["lens", "skill"]
+  "keywords": [
+    "lens",
+    "skill"
+  ]
 }

--- a/skills/lens-recon/.claude-plugin/plugin.json
+++ b/skills/lens-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lens-recon",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Analytics reconnaissance for takeover \u2014 find all analytics tools, inventory what's tracked and dashboarded, assess data freshness and metric definitions, and present a coverage map. Use when asked \"what analytics exist\", \"BI assessment\", or \"what do we track\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["lens", "skill"]
+  "keywords": [
+    "lens",
+    "skill"
+  ]
 }

--- a/skills/lens-report/.claude-plugin/plugin.json
+++ b/skills/lens-report/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lens-report",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Build a reporting pipeline \u2014 scheduled reports with SQL queries, delivery via Slack or email, threshold alerts, and historical comparison. Use when asked for \"automated reports\", \"scheduled report\", \"email digest\", or \"Slack alerts for metrics\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["lens", "skill"]
+  "keywords": [
+    "lens",
+    "skill"
+  ]
 }

--- a/skills/lumen-abtest/.claude-plugin/plugin.json
+++ b/skills/lumen-abtest/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lumen-abtest",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "A/B test design \u2014 produce an experiment spec with hypothesis, primary metric, MDE, sample size, run time, and decision rule. Also determines when NOT to A/B test and what to do instead. Use when asked to \"design an A/B test\", \"should we test this\", \"experiment design\", \"how do we know if this works\", \"what's the sample size\", or \"set up an experiment\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["lumen", "skill"]
+  "keywords": [
+    "lumen",
+    "skill"
+  ]
 }

--- a/skills/lumen-funnel/.claude-plugin/plugin.json
+++ b/skills/lumen-funnel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lumen-funnel",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["lumen", "skill"]
+  "keywords": [
+    "lumen",
+    "skill"
+  ]
 }

--- a/skills/lumen-instrument/.claude-plugin/plugin.json
+++ b/skills/lumen-instrument/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lumen-instrument",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Instrumentation plan \u2014 design event taxonomy, property schema, and tracking plan for analytics tools. Use when asked to \"what should we track\", \"instrumentation plan\", \"set up analytics events\", \"analytics event schema\", \"tracking plan\", or \"instrument this feature\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["lumen", "skill"]
+  "keywords": [
+    "lumen",
+    "skill"
+  ]
 }

--- a/skills/lumen-metrics/.claude-plugin/plugin.json
+++ b/skills/lumen-metrics/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lumen-metrics",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Metrics architecture \u2014 produce a complete metrics plan given a product description. North Star, input metrics tree, instrumentation spec, action triggers, and counter-metrics. Use when asked to \"design a metrics framework\", \"what should we measure\", \"build a metrics system\", \"define our KPIs\", \"what are our success metrics\", \"metrics strategy\", or \"what do we track\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["lumen", "skill"]
+  "keywords": [
+    "lumen",
+    "skill"
+  ]
 }

--- a/skills/lumen-recon/.claude-plugin/plugin.json
+++ b/skills/lumen-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lumen-recon",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Analytics reconnaissance \u2014 scan existing event tracking, metric definitions, dashboards, and analytics configuration to understand what is currently being measured. Use when asked to \"what are we tracking\", \"audit our analytics\", \"what metrics exist\", \"analytics inventory\", or before designing new metrics or instrumentation.",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["lumen", "skill"]
+  "keywords": [
+    "lumen",
+    "skill"
+  ]
 }

--- a/skills/pave-audit/.claude-plugin/plugin.json
+++ b/skills/pave-audit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pave-audit",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Audit developer experience \u2014 measure onboarding time, build speed, deployment friction, and developer satisfaction. Use when asked to \"DX audit\", \"developer experience review\", \"why is development slow\", \"onboarding assessment\", or \"DORA metrics\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["pave", "skill"]
+  "keywords": [
+    "pave",
+    "skill"
+  ]
 }

--- a/skills/pave-catalog/.claude-plugin/plugin.json
+++ b/skills/pave-catalog/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pave-catalog",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Build a service catalog \u2014 schema, starter entries, and governance model. Produces what information to capture per service, how it's maintained, and where it lives. Use when asked to \"service catalog\", \"what services do we have\", \"catalog our services\", \"service inventory\", or \"who owns what\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["pave", "skill"]
+  "keywords": [
+    "pave",
+    "skill"
+  ]
 }

--- a/skills/pave-env/.claude-plugin/plugin.json
+++ b/skills/pave-env/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pave-env",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Set up local development environments \u2014 devcontainers, Docker Compose, one-command setup, dev/prod parity. Use when asked to \"set up dev environment\", \"devcontainer\", \"docker compose for dev\", \"local development setup\", or \"one command to run\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["pave", "skill"]
+  "keywords": [
+    "pave",
+    "skill"
+  ]
 }

--- a/skills/pave-golden/.claude-plugin/plugin.json
+++ b/skills/pave-golden/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pave-golden",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Define a golden path \u2014 the opinionated, supported way to do a common developer task (create a new service, set up an environment, deploy a feature). Produces concrete steps, templates, and tooling. Use when asked to \"golden path\", \"create project template\", \"scaffold a new service\", \"how should we create services\", or \"standardize our setup\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["pave", "skill"]
+  "keywords": [
+    "pave",
+    "skill"
+  ]
 }

--- a/skills/pave-recon/.claude-plugin/plugin.json
+++ b/skills/pave-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pave-recon",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Platform reconnaissance \u2014 inventory all developer tooling, environments, build systems, and developer workflows for project takeover. Use when asked to \"understand the dev setup\", \"developer tooling assessment\", \"platform assessment\", or \"how do developers work here\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["pave", "skill"]
+  "keywords": [
+    "pave",
+    "skill"
+  ]
 }

--- a/skills/pitch-copy/.claude-plugin/plugin.json
+++ b/skills/pitch-copy/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pitch-copy",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Landing page and marketing copy \u2014 write hero section, problem/solution blocks, proof points, and CTAs. Use when asked to \"write landing page copy\", \"write the homepage\", \"marketing copy for this feature\", \"product page copy\", \"write the hero section\", or \"write copy for [surface]\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["pitch", "skill"]
+  "keywords": [
+    "pitch",
+    "skill"
+  ]
 }

--- a/skills/pitch-landing/.claude-plugin/plugin.json
+++ b/skills/pitch-landing/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pitch-landing",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["pitch", "skill"]
+  "keywords": [
+    "pitch",
+    "skill"
+  ]
 }

--- a/skills/pitch-launch/.claude-plugin/plugin.json
+++ b/skills/pitch-launch/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pitch-launch",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Produce an actual launch plan with announcement copy, channel sequence, and day-1 checklist. Use when asked to \"plan a launch\", \"GTM strategy\", \"how do we announce this\", \"launch plan for [feature]\", \"go-to-market\", \"write our Product Hunt post\", or \"how do we get people to notice this\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["pitch", "skill"]
+  "keywords": [
+    "pitch",
+    "skill"
+  ]
 }

--- a/skills/pitch-message/.claude-plugin/plugin.json
+++ b/skills/pitch-message/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pitch-message",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Messaging framework \u2014 produce a full headline, subheadline, proof points, and CTA hierarchy for use across all surfaces. Use when asked to \"write our messaging\", \"messaging framework\", \"what should our headline say\", \"copy hierarchy\", \"tagline and messaging\", or \"how do we talk about the product\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["pitch", "skill"]
+  "keywords": [
+    "pitch",
+    "skill"
+  ]
 }

--- a/skills/pitch-position/.claude-plugin/plugin.json
+++ b/skills/pitch-position/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pitch-position",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Produce a complete positioning document using the Dunford framework \u2014 competitive alternatives, unique attributes, value, best-fit customer, market category, positioning statement, and tagline. Use when asked to \"write our positioning\", \"define our value prop\", \"positioning statement\", \"what market are we in\", \"how do we position against X\", \"what's our tagline\", or \"write our messaging foundation\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["pitch", "skill"]
+  "keywords": [
+    "pitch",
+    "skill"
+  ]
 }

--- a/skills/pitch-recon/.claude-plugin/plugin.json
+++ b/skills/pitch-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pitch-recon",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Marketing and messaging reconnaissance \u2014 read existing landing pages, copy, positioning docs, and marketing materials to understand the current messaging state. Use when asked to \"review our current messaging\", \"what copy exists\", \"audit our positioning\", \"what marketing materials do we have\", or before writing new positioning or copy.",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["pitch", "skill"]
+  "keywords": [
+    "pitch",
+    "skill"
+  ]
 }

--- a/skills/prism-audit/.claude-plugin/plugin.json
+++ b/skills/prism-audit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-audit",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Frontend audit \u2014 bundle size, dependencies, accessibility, performance, component quality. Use when asked for \"frontend review\", \"performance audit\", \"accessibility check\", or \"bundle size\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["prism", "skill"]
+  "keywords": [
+    "prism",
+    "skill"
+  ]
 }

--- a/skills/prism-chart/.claude-plugin/plugin.json
+++ b/skills/prism-chart/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-chart",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["prism", "skill"]
+  "keywords": [
+    "prism",
+    "skill"
+  ]
 }

--- a/skills/prism-component/.claude-plugin/plugin.json
+++ b/skills/prism-component/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-component",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Implement a reusable, accessible, typed component from a design spec. Use when asked to \"create a component\", \"build a widget\", \"implement this design\", or \"reusable UI element\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["prism", "skill"]
+  "keywords": [
+    "prism",
+    "skill"
+  ]
 }

--- a/skills/prism-dashboard/.claude-plugin/plugin.json
+++ b/skills/prism-dashboard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-dashboard",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Build an internal dashboard with data tables, filters, detail views, and CRUD. Use when asked to build an \"admin panel\", \"internal dashboard\", \"back office\", or \"data dashboard UI\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["prism", "skill"]
+  "keywords": [
+    "prism",
+    "skill"
+  ]
 }

--- a/skills/prism-recon/.claude-plugin/plugin.json
+++ b/skills/prism-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-recon",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Frontend reconnaissance \u2014 map the component tree, routing, state management, build config, and assess quality. Use when asked to \"understand this frontend\", \"frontend assessment\", or \"what's the UI built with\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["prism", "skill"]
+  "keywords": [
+    "prism",
+    "skill"
+  ]
 }

--- a/skills/prism-stack/.claude-plugin/plugin.json
+++ b/skills/prism-stack/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-stack",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["prism", "skill"]
+  "keywords": [
+    "prism",
+    "skill"
+  ]
 }

--- a/skills/prism-ui/.claude-plugin/plugin.json
+++ b/skills/prism-ui/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-ui",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Implement a complete UI screen or feature from a Form visual spec. Use when asked to \"build a page\", \"implement this screen\", \"build the frontend for this feature\", or \"create this UI\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["prism", "skill"]
+  "keywords": [
+    "prism",
+    "skill"
+  ]
 }

--- a/skills/proof-api/.claude-plugin/plugin.json
+++ b/skills/proof-api/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "proof-api",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Build API test suites \u2014 endpoint testing, contract testing, load testing for REST/GraphQL/gRPC APIs. Use when asked to \"test this API\", \"API tests\", \"endpoint testing\", \"contract tests\", or \"load test\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["proof", "skill"]
+  "keywords": [
+    "proof",
+    "skill"
+  ]
 }

--- a/skills/proof-audit/.claude-plugin/plugin.json
+++ b/skills/proof-audit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "proof-audit",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Audit test suite health \u2014 find flaky tests, slow tests, coverage gaps, and testing anti-patterns. Use when asked to \"audit tests\", \"fix flaky tests\", \"why are tests slow\", \"test health\", or \"improve test suite\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["proof", "skill"]
+  "keywords": [
+    "proof",
+    "skill"
+  ]
 }

--- a/skills/proof-design/.claude-plugin/plugin.json
+++ b/skills/proof-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "proof-design",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["proof", "skill"]
+  "keywords": [
+    "proof",
+    "skill"
+  ]
 }

--- a/skills/proof-e2e/.claude-plugin/plugin.json
+++ b/skills/proof-e2e/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "proof-e2e",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Build E2E test specs for critical user journeys \u2014 Playwright or Cypress, page objects, setup/teardown, CI config. Use when asked to \"write E2E tests\", \"end-to-end testing\", \"browser tests\", \"UI tests\", or \"Playwright tests\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["proof", "skill"]
+  "keywords": [
+    "proof",
+    "skill"
+  ]
 }

--- a/skills/proof-recon/.claude-plugin/plugin.json
+++ b/skills/proof-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "proof-recon",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Testing reconnaissance \u2014 inventory all tests, frameworks, coverage, CI integration, and assess testing maturity for project takeover. Use when asked to \"understand the tests\", \"testing assessment\", \"what's tested\", or \"test inventory\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["proof", "skill"]
+  "keywords": [
+    "proof",
+    "skill"
+  ]
 }

--- a/skills/proof-strategy/.claude-plugin/plugin.json
+++ b/skills/proof-strategy/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "proof-strategy",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Produce a test strategy for a project or feature \u2014 risk map, test type decisions, coverage targets, CI config. Use when asked to \"create test strategy\", \"what should we test\", \"testing plan\", or \"improve test coverage\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["proof", "skill"]
+  "keywords": [
+    "proof",
+    "skill"
+  ]
 }

--- a/skills/relay-audit/.claude-plugin/plugin.json
+++ b/skills/relay-audit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "relay-audit",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Audit an existing CI/CD pipeline for slowness, security issues, and reliability gaps. Use when asked to \"audit pipeline\", \"why is CI slow\", \"pipeline review\", or \"deployment review\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["relay", "skill"]
+  "keywords": [
+    "relay",
+    "skill"
+  ]
 }

--- a/skills/relay-deploy/.claude-plugin/plugin.json
+++ b/skills/relay-deploy/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "relay-deploy",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Set up a complete deployment configuration \u2014 Dockerfile, deployment manifest, environment config, and rollback procedure. Use when asked about \"deployment setup\", \"how do I deploy this\", \"deployment strategy\", or \"rollback plan\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["relay", "skill"]
+  "keywords": [
+    "relay",
+    "skill"
+  ]
 }

--- a/skills/relay-docker/.claude-plugin/plugin.json
+++ b/skills/relay-docker/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "relay-docker",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Build production-ready Dockerfiles with multi-stage builds, security hardening, and docker-compose for local dev. Use when asked to \"create Dockerfile\", \"optimize container\", or \"dockerize this\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["relay", "skill"]
+  "keywords": [
+    "relay",
+    "skill"
+  ]
 }

--- a/skills/relay-pipeline/.claude-plugin/plugin.json
+++ b/skills/relay-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "relay-pipeline",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Build a full CI/CD pipeline from scratch. Use when asked to \"set up CI/CD\", \"create pipeline\", or \"automate deploys\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["relay", "skill"]
+  "keywords": [
+    "relay",
+    "skill"
+  ]
 }

--- a/skills/relay-recon/.claude-plugin/plugin.json
+++ b/skills/relay-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "relay-recon",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Map the full CI/CD pipeline \u2014 triggers, build, test, deploy flow \u2014 with risk assessment. Use when asked \"how does this deploy\", \"map the pipeline\", or \"understand CI/CD\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["relay", "skill"]
+  "keywords": [
+    "relay",
+    "skill"
+  ]
 }

--- a/skills/relay-ship/.claude-plugin/plugin.json
+++ b/skills/relay-ship/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "relay-ship",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "End-to-end ship workflow \u2014 merge base, run tests, review diff, bump version, commit, push, create PR. Use when asked to \"ship\", \"push to main\", \"create a PR\", \"get this merged\", or \"deploy this branch\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["relay", "skill"]
+  "keywords": [
+    "relay",
+    "skill"
+  ]
 }

--- a/skills/relay-ship/SKILL.md
+++ b/skills/relay-ship/SKILL.md
@@ -186,7 +186,7 @@ If tests fail: STOP. Fix the issue, return to Step 2.
 git push -u origin <branch-name>
 ```
 
-Create the PR:
+Create the PR. **You MUST include the full Tonone footer block exactly as shown — do not collapse it to a link or omit it.**
 
 ```bash
 gh pr create --base <base> \
@@ -207,16 +207,25 @@ gh pr create --base <base> \
 
 ---
 
-<small>🤖 This PR was prepared by **[Tonone](https://tonone.ai)**'s AI engineering team.<br>Agents: <comma-separated list of agents that contributed this session, e.g. Relay, Proof, Atlas> · Session: ~<N> min · Token cost: ~$<cost if known, otherwise omit></small>
+---
+
+🤖 **This PR was prepared by [Tonone](https://tonone.ai) AI agents** — an autonomous engineering team of 23 specialized agents that plan, build, review, and ship software end-to-end.
+
+- **Agents:** Relay<!-- add others e.g. · Proof · Atlas · Apex · Spine -->
+- **Session:** ~N min
+- **Est. cost:** ~$0.00<!-- omit if unknown -->
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+Co-Authored-By: Tonone AI <noreply@tonone.ai>
 EOF
 )"
 ```
 
-> **Footer instructions:** Replace the `<…>` placeholders before creating the PR.
->
-> - **Agents:** list every agent invoked during this session (Relay is always listed; add others like Proof, Atlas, Apex as applicable).
-> - **Session:** estimate elapsed time from first tool call to now (round to nearest 5 min).
-> - **Token cost:** include if visible in session stats (e.g. `~$0.42`); omit the field entirely if unknown.
+**Footer fill-in rules (do this before running the command):**
+
+- **Agents:** Relay is always listed. Add every other agent invoked this session (e.g. `Relay, Proof, Atlas`).
+- **Session:** Estimate elapsed time from first tool call to now, rounded to nearest 5 min.
+- **Est. cost:** Include if visible in session stats (e.g. `~$0.42`). Remove the entire row if unknown.
 
 Output the PR URL.
 

--- a/skills/spine-api/.claude-plugin/plugin.json
+++ b/skills/spine-api/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-api",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Design and spec an API \u2014 endpoints, request/response shapes, error codes, auth pattern, pagination. Applies Stripe's consistency principles. Use when asked to \"design an API\", \"build API endpoints\", \"create REST API\", or \"API for this feature\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["spine", "skill"]
+  "keywords": [
+    "spine",
+    "skill"
+  ]
 }

--- a/skills/spine-design/.claude-plugin/plugin.json
+++ b/skills/spine-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-design",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Produce a system design doc \u2014 components, data flow, decisions made, tradeoffs, failure modes. Not a list of options. An actual design with calls made. Use when asked for \"system design for\", \"architect this\", \"how should we build\", or \"design the backend\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["spine", "skill"]
+  "keywords": [
+    "spine",
+    "skill"
+  ]
 }

--- a/skills/spine-perf/.claude-plugin/plugin.json
+++ b/skills/spine-perf/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-perf",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Find and fix performance bottlenecks \u2014 N+1 queries, missing indexes, sync bottlenecks, caching gaps. Use when asked \"why is this slow\", \"performance issue\", \"optimize this endpoint\", or \"N+1 queries\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["spine", "skill"]
+  "keywords": [
+    "spine",
+    "skill"
+  ]
 }

--- a/skills/spine-recon/.claude-plugin/plugin.json
+++ b/skills/spine-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-recon",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Backend reconnaissance \u2014 map all routes, middleware, models, dependencies, auth, and assess code quality for project takeover. Use when asked to \"understand this backend\", \"map the API\", or \"assess code quality\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["spine", "skill"]
+  "keywords": [
+    "spine",
+    "skill"
+  ]
 }

--- a/skills/spine-review/.claude-plugin/plugin.json
+++ b/skills/spine-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-review",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "API and backend code review \u2014 REST conventions, auth, validation, error handling, pagination, rate limiting, test coverage. Use when asked to \"review this API\", \"code review\", \"review backend\", or \"pre-launch backend check\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["spine", "skill"]
+  "keywords": [
+    "spine",
+    "skill"
+  ]
 }

--- a/skills/spine-service/.claude-plugin/plugin.json
+++ b/skills/spine-service/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-service",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Build a new production-ready service from scratch \u2014 config management, health checks, graceful shutdown, structured logging. Use when asked to \"new service\", \"scaffold a backend\", \"bootstrap service\", or \"create microservice\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["spine", "skill"]
+  "keywords": [
+    "spine",
+    "skill"
+  ]
 }

--- a/skills/surge-activation/.claude-plugin/plugin.json
+++ b/skills/surge-activation/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surge-activation",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["surge", "skill"]
+  "keywords": [
+    "surge",
+    "skill"
+  ]
 }

--- a/skills/surge-experiment/.claude-plugin/plugin.json
+++ b/skills/surge-experiment/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surge-experiment",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Growth experiment design \u2014 structure a growth hypothesis, define metric, baseline, expected lift, and kill condition for a single experiment. Use when asked to \"design a growth experiment\", \"test this growth idea\", \"experiment framework\", \"how do we test if this works\", or \"growth hypothesis\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["surge", "skill"]
+  "keywords": [
+    "surge",
+    "skill"
+  ]
 }

--- a/skills/surge-landing/.claude-plugin/plugin.json
+++ b/skills/surge-landing/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surge-landing",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["surge", "skill"]
+  "keywords": [
+    "surge",
+    "skill"
+  ]
 }

--- a/skills/surge-plg/.claude-plugin/plugin.json
+++ b/skills/surge-plg/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surge-plg",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "PLG motion design \u2014 free tier definition, activation sequence, expansion trigger points, viral mechanic assessment. Given a product, output the PLG architecture and make the calls. Use when asked to \"PLG strategy\", \"freemium model\", \"product-led growth plan\", \"self-serve motion\", \"how do we add a free tier\", \"upgrade triggers\", or \"viral loop design\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["surge", "skill"]
+  "keywords": [
+    "surge",
+    "skill"
+  ]
 }

--- a/skills/surge-recon/.claude-plugin/plugin.json
+++ b/skills/surge-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surge-recon",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Growth state reconnaissance \u2014 scan existing onboarding flows, acquisition channels, conversion funnels, and growth experiment logs to understand current growth state. Use when asked to \"what's our growth state\", \"audit the funnel\", \"what growth experiments have we run\", \"acquisition channel inventory\", or before designing new growth experiments.",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["surge", "skill"]
+  "keywords": [
+    "surge",
+    "skill"
+  ]
 }

--- a/skills/surge-retention/.claude-plugin/plugin.json
+++ b/skills/surge-retention/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surge-retention",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Retention diagnosis + intervention plan \u2014 analyze the retention curve, identify the primary drop-off point, and produce a specific intervention plan with expected impact. Use when asked to \"improve retention\", \"why are users churning\", \"build a retention playbook\", \"reduce churn\", \"win-back campaign\", or \"users aren't coming back\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["surge", "skill"]
+  "keywords": [
+    "surge",
+    "skill"
+  ]
 }

--- a/skills/tonone-onboard/.claude-plugin/plugin.json
+++ b/skills/tonone-onboard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tonone-onboard",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "First-run onboarding tour \u2014 guided walkthrough of tonone's 23 agents, key skills, and worktree sessions. Two paths: expert (~90 sec) and newcomer (~8 min). Use when asked \"how do I use tonone\", \"what can tonone do\", \"show me around\", or \"first steps\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,9 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["tonone", "skill", "onboarding"]
+  "keywords": [
+    "tonone",
+    "skill",
+    "onboarding"
+  ]
 }

--- a/skills/touch-app/.claude-plugin/plugin.json
+++ b/skills/touch-app/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "touch-app",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Produce a complete mobile app architecture design \u2014 platform choice, navigation structure, state management, data layer, key screens. Use when asked to \"build a mobile app\", \"new app\", \"create iOS/Android app\", \"app architecture\", or \"cross-platform app\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["touch", "skill"]
+  "keywords": [
+    "touch",
+    "skill"
+  ]
 }

--- a/skills/touch-audit/.claude-plugin/plugin.json
+++ b/skills/touch-audit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "touch-audit",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Mobile audit \u2014 app size, startup time, crash reporting, store compliance, accessibility, offline behavior. Use when asked for \"mobile review\", \"app store readiness\", \"mobile performance\", or \"crash analysis\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["touch", "skill"]
+  "keywords": [
+    "touch",
+    "skill"
+  ]
 }

--- a/skills/touch-feature/.claude-plugin/plugin.json
+++ b/skills/touch-feature/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "touch-feature",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Produce a mobile feature spec \u2014 user story, technical approach, component breakdown, platform-specific considerations, edge cases. Use when asked to \"add a screen\", \"spec this feature\", \"mobile feature\", \"new tab\", \"push notifications\", or \"deep link\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["touch", "skill"]
+  "keywords": [
+    "touch",
+    "skill"
+  ]
 }

--- a/skills/touch-recon/.claude-plugin/plugin.json
+++ b/skills/touch-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "touch-recon",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Mobile reconnaissance \u2014 understand the app's tech stack, architecture, dependencies, and health for takeover. Use when asked to \"understand this app\", \"mobile assessment\", or \"app health\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["touch", "skill"]
+  "keywords": [
+    "touch",
+    "skill"
+  ]
 }

--- a/skills/touch-release/.claude-plugin/plugin.json
+++ b/skills/touch-release/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "touch-release",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Set up mobile release pipeline \u2014 Fastlane, code signing, CI, beta distribution, versioning. Use when asked about \"app store setup\", \"release pipeline\", \"fastlane\", \"beta distribution\", or \"signing\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["touch", "skill"]
+  "keywords": [
+    "touch",
+    "skill"
+  ]
 }

--- a/skills/touch-ui/.claude-plugin/plugin.json
+++ b/skills/touch-ui/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "touch-ui",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "|",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["touch", "skill"]
+  "keywords": [
+    "touch",
+    "skill"
+  ]
 }

--- a/skills/vigil-alert/.claude-plugin/plugin.json
+++ b/skills/vigil-alert/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vigil-alert",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Write SLO-based alert rules with burn rate thresholds and paired runbooks. Outputs actual alert configs, not a strategy doc. Use when asked to \"set up alerts\", \"create runbooks\", \"define SLOs\", or \"alerting strategy\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["vigil", "skill"]
+  "keywords": [
+    "vigil",
+    "skill"
+  ]
 }

--- a/skills/vigil-check/.claude-plugin/plugin.json
+++ b/skills/vigil-check/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vigil-check",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Verify observability posture \u2014 audit monitoring coverage, find blind spots, prioritize gaps. Use when asked \"is monitoring sufficient\", \"observability review\", \"are we covered\", or \"pre-launch monitoring check\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["vigil", "skill"]
+  "keywords": [
+    "vigil",
+    "skill"
+  ]
 }

--- a/skills/vigil-incident/.claude-plugin/plugin.json
+++ b/skills/vigil-incident/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vigil-incident",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Incident response \u2014 diagnose production issues, find root cause, propose fix with rollback. Use when asked about \"something is broken\", \"production issue\", \"why is this down\", \"incident\", or \"debug production\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["vigil", "skill"]
+  "keywords": [
+    "vigil",
+    "skill"
+  ]
 }

--- a/skills/vigil-instrument/.claude-plugin/plugin.json
+++ b/skills/vigil-instrument/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vigil-instrument",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Instrument a service with OpenTelemetry \u2014 RED metrics, structured logs, distributed tracing, and health checks. Outputs actual code and config, not a plan. Use when asked to \"add monitoring\", \"instrument this\", \"add logging\", \"set up tracing\", or \"observability\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["vigil", "skill"]
+  "keywords": [
+    "vigil",
+    "skill"
+  ]
 }

--- a/skills/vigil-recon/.claude-plugin/plugin.json
+++ b/skills/vigil-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vigil-recon",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Observability reconnaissance \u2014 inventory what monitoring exists, map coverage, highlight blind spots. Use when asked \"what monitoring exists\", \"observability assessment\", or \"what can we see\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["vigil", "skill"]
+  "keywords": [
+    "vigil",
+    "skill"
+  ]
 }

--- a/skills/volt-driver/.claude-plugin/plugin.json
+++ b/skills/volt-driver/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "volt-driver",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Build a device driver or protocol handler \u2014 I2C sensors, BLE services, MQTT clients, SPI peripherals with interrupt-driven I/O and clean HAL abstraction. Use when asked to \"write a driver\", \"I2C device\", \"BLE service\", \"MQTT client\", or \"sensor integration\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["volt", "skill"]
+  "keywords": [
+    "volt",
+    "skill"
+  ]
 }

--- a/skills/volt-firmware/.claude-plugin/plugin.json
+++ b/skills/volt-firmware/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "volt-firmware",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Produce a complete firmware architecture spec for a described device \u2014 layer diagram, module responsibilities, HAL interface definitions, key state machines, RTOS decision. Use when asked to \"design firmware architecture\", \"plan embedded firmware\", \"architect an IoT device\", \"how should I structure this firmware\", or given a device description and asked what the firmware should look like.",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["volt", "skill"]
+  "keywords": [
+    "volt",
+    "skill"
+  ]
 }

--- a/skills/volt-ota/.claude-plugin/plugin.json
+++ b/skills/volt-ota/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "volt-ota",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Produce a complete OTA update system design \u2014 partition layout, update flow, rollback conditions, validation checks, fleet management approach, failure modes and recovery. Use when asked about \"OTA updates\", \"firmware updates over the air\", \"how do I update devices in the field\", \"OTA strategy\", or \"remote firmware update design\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["volt", "skill"]
+  "keywords": [
+    "volt",
+    "skill"
+  ]
 }

--- a/skills/volt-power/.claude-plugin/plugin.json
+++ b/skills/volt-power/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "volt-power",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Power management audit \u2014 analyze sleep modes, wake sources, power state machines, radio duty cycles, and battery life estimates. Use when asked to \"audit power usage\", \"optimize battery life\", \"review power management\", \"why is my battery draining\", \"power budget analysis\", or \"sleep mode review\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["volt", "skill"]
+  "keywords": [
+    "volt",
+    "skill"
+  ]
 }

--- a/skills/volt-recon/.claude-plugin/plugin.json
+++ b/skills/volt-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "volt-recon",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Firmware reconnaissance for takeover \u2014 inventory the MCU, peripherals, RTOS, protocols, OTA, power management, and assess code quality with risk flags. Use when asked to \"understand this firmware\", \"device inventory\", or \"embedded assessment\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["volt", "skill"]
+  "keywords": [
+    "volt",
+    "skill"
+  ]
 }

--- a/skills/warden-audit/.claude-plugin/plugin.json
+++ b/skills/warden-audit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warden-audit",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Full security audit \u2014 secrets, dependencies, IAM, auth, injection, XSS, HTTPS, rate limiting, public storage. Use when asked for \"security audit\", \"check for vulnerabilities\", \"security review\", or \"are we secure\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["warden", "skill"]
+  "keywords": [
+    "warden",
+    "skill"
+  ]
 }

--- a/skills/warden-harden/.claude-plugin/plugin.json
+++ b/skills/warden-harden/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warden-harden",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Produce a hardening spec and implement it \u2014 auth patterns, security headers, rate limiting, input validation, secrets management, dependency hygiene. Use when asked to \"harden this\", \"add security to this service\", \"what security do I need\", or \"secure this before launch\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["warden", "skill"]
+  "keywords": [
+    "warden",
+    "skill"
+  ]
 }

--- a/skills/warden-iam/.claude-plugin/plugin.json
+++ b/skills/warden-iam/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warden-iam",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Build IAM from scratch \u2014 roles, policies, service accounts with least privilege. Use when asked to \"set up IAM\", \"create roles\", \"service accounts\", or \"access control\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["warden", "skill"]
+  "keywords": [
+    "warden",
+    "skill"
+  ]
 }

--- a/skills/warden-recon/.claude-plugin/plugin.json
+++ b/skills/warden-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warden-recon",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Security reconnaissance \u2014 full inventory of secrets management, IAM, dependencies, auth, encryption, audit logging, and compliance gaps. Use when asked about \"security posture\", \"how secure is this\", or \"security assessment\".",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["warden", "skill"]
+  "keywords": [
+    "warden",
+    "skill"
+  ]
 }

--- a/skills/warden-threat/.claude-plugin/plugin.json
+++ b/skills/warden-threat/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warden-threat",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Produce a threat model \u2014 assets, ranked threats, mitigations, accepted risks. Use when asked to \"threat model this\", \"what could go wrong security-wise\", \"map our attack surface\", or before designing any security-sensitive feature.",
   "author": {
     "name": "tonone-ai",
@@ -9,5 +9,8 @@
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
   "type": "skill",
-  "keywords": ["warden", "skill"]
+  "keywords": [
+    "warden",
+    "skill"
+  ]
 }

--- a/team/apex/.claude-plugin/plugin.json
+++ b/team/apex/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apex",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Engineering lead \u2014 orchestrates the team, scopes work, controls depth and budget",
   "author": {
     "name": "tonone-ai",
@@ -8,5 +8,10 @@
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["lead", "orchestrator", "tech-lead", "engineering-management"]
+  "keywords": [
+    "lead",
+    "orchestrator",
+    "tech-lead",
+    "engineering-management"
+  ]
 }

--- a/team/apex/scripts/pyproject.toml
+++ b/team/apex/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apex"
-version = "0.9.6"
+version = "0.9.7"
 description = "Engineering lead — orchestrates the team, scopes work, controls depth and budget"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/atlas/.claude-plugin/plugin.json
+++ b/team/atlas/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atlas",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Knowledge engineer \u2014 architecture docs, ADRs, API specs, system diagrams, onboarding, output formatting, browser reports, changelogs, release presentations",
   "author": {
     "name": "tonone-ai",

--- a/team/atlas/scripts/pyproject.toml
+++ b/team/atlas/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "atlas"
-version = "0.9.6"
+version = "0.9.7"
 description = "Knowledge engineer — architecture docs, ADRs, API specs, system diagrams, onboarding"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/cortex/.claude-plugin/plugin.json
+++ b/team/cortex/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "ML/AI engineer \u2014 model training, MLOps, feature engineering, LLM integration",
   "author": {
     "name": "tonone-ai",
@@ -8,5 +8,12 @@
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["ml", "ai", "mlops", "models", "llm", "feature-engineering"]
+  "keywords": [
+    "ml",
+    "ai",
+    "mlops",
+    "models",
+    "llm",
+    "feature-engineering"
+  ]
 }

--- a/team/cortex/scripts/pyproject.toml
+++ b/team/cortex/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cortex"
-version = "0.9.6"
+version = "0.9.7"
 description = "ML/AI engineer — model training, MLOps, feature engineering, LLM integration"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/crest/.claude-plugin/plugin.json
+++ b/team/crest/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "crest",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Product strategist \u2014 roadmap planning, prioritization frameworks, competitive analysis, and market positioning",
   "author": {
     "name": "tonone-ai",

--- a/team/crest/scripts/pyproject.toml
+++ b/team/crest/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "crest"
-version = "0.9.6"
+version = "0.9.7"
 description = "Product strategist — roadmap planning, prioritization frameworks, competitive analysis, and market positioning"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/draft/.claude-plugin/plugin.json
+++ b/team/draft/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "draft",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "UX designer \u2014 user flows, information architecture, wireframes, and interaction design",
   "author": {
     "name": "tonone-ai",
@@ -8,5 +8,11 @@
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["ux", "design", "user-flows", "wireframes", "product-team"]
+  "keywords": [
+    "ux",
+    "design",
+    "user-flows",
+    "wireframes",
+    "product-team"
+  ]
 }

--- a/team/draft/scripts/pyproject.toml
+++ b/team/draft/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "draft"
-version = "0.9.6"
+version = "0.9.7"
 description = "UX designer — user flows, information architecture, wireframes, and interaction design"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/echo/.claude-plugin/plugin.json
+++ b/team/echo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "echo",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "User researcher \u2014 interviews, personas, Jobs-to-Be-Done, and customer feedback synthesis",
   "author": {
     "name": "tonone-ai",

--- a/team/echo/scripts/pyproject.toml
+++ b/team/echo/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "echo"
-version = "0.9.6"
+version = "0.9.7"
 description = "User researcher — interviews, personas, Jobs-to-Be-Done, and customer feedback synthesis"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/flux/.claude-plugin/plugin.json
+++ b/team/flux/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Data engineer \u2014 databases, migrations, pipelines, data modeling",
   "author": {
     "name": "tonone-ai",
@@ -8,5 +8,11 @@
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["data", "databases", "migrations", "pipelines", "modeling"]
+  "keywords": [
+    "data",
+    "databases",
+    "migrations",
+    "pipelines",
+    "modeling"
+  ]
 }

--- a/team/flux/scripts/pyproject.toml
+++ b/team/flux/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flux"
-version = "0.9.6"
+version = "0.9.7"
 description = "Data engineer — databases, migrations, pipelines, data modeling"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/forge/.claude-plugin/plugin.json
+++ b/team/forge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forge",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Infrastructure engineer \u2014 cloud services, networking, IaC, cost optimization",
   "author": {
     "name": "tonone-ai",
@@ -8,5 +8,11 @@
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["infrastructure", "cloud", "iac", "networking", "cost"]
+  "keywords": [
+    "infrastructure",
+    "cloud",
+    "iac",
+    "networking",
+    "cost"
+  ]
 }

--- a/team/forge/scripts/pyproject.toml
+++ b/team/forge/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "forge"
-version = "0.9.6"
+version = "0.9.7"
 description = "Infrastructure engineer — cloud services, networking, IaC, cost optimization"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/form/.claude-plugin/plugin.json
+++ b/team/form/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Visual designer \u2014 brand identity, color systems, typography, UI design, and design systems",
   "author": {
     "name": "tonone-ai",

--- a/team/form/scripts/pyproject.toml
+++ b/team/form/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "form"
-version = "0.9.6"
+version = "0.9.7"
 description = "Visual designer — brand identity, color systems, typography, UI design, and design systems"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/helm/.claude-plugin/plugin.json
+++ b/team/helm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "helm",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Head of Product \u2014 product strategy, requirements, and engineering handoff via the Helm\u2194Apex interface",
   "author": {
     "name": "tonone-ai",
@@ -8,5 +8,11 @@
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["product", "strategy", "requirements", "cpo", "product-team"]
+  "keywords": [
+    "product",
+    "strategy",
+    "requirements",
+    "cpo",
+    "product-team"
+  ]
 }

--- a/team/helm/scripts/pyproject.toml
+++ b/team/helm/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "helm"
-version = "0.9.6"
+version = "0.9.7"
 description = "Head of Product — product strategy, requirements, and engineering handoff"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/lens/.claude-plugin/plugin.json
+++ b/team/lens/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lens",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Data analytics & BI engineer \u2014 dashboards, metrics design, reporting, data storytelling",
   "author": {
     "name": "tonone-ai",

--- a/team/lens/scripts/pyproject.toml
+++ b/team/lens/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lens"
-version = "0.9.6"
+version = "0.9.7"
 description = "Data analytics & BI engineer — dashboards, metrics design, reporting, data storytelling"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/lumen/.claude-plugin/plugin.json
+++ b/team/lumen/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lumen",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Product analyst \u2014 metrics frameworks, funnel analysis, OKRs, A/B test design, and retention analysis",
   "author": {
     "name": "tonone-ai",

--- a/team/lumen/scripts/pyproject.toml
+++ b/team/lumen/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lumen"
-version = "0.9.6"
+version = "0.9.7"
 description = "Product analyst — metrics frameworks, funnel analysis, OKRs, A/B test design, and retention analysis"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/pave/.claude-plugin/plugin.json
+++ b/team/pave/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pave",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Platform engineer \u2014 developer experience, service catalogs, internal CLIs, golden paths, environment management",
   "author": {
     "name": "tonone-ai",

--- a/team/pave/scripts/pyproject.toml
+++ b/team/pave/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pave"
-version = "0.9.6"
+version = "0.9.7"
 description = "Platform engineer — developer experience, service catalogs, golden paths, environment management"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/pitch/.claude-plugin/plugin.json
+++ b/team/pitch/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pitch",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Product marketer \u2014 positioning, messaging, value proposition, GTM strategy, and launch copy",
   "author": {
     "name": "tonone-ai",

--- a/team/pitch/scripts/pyproject.toml
+++ b/team/pitch/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pitch"
-version = "0.9.6"
+version = "0.9.7"
 description = "Product marketer — positioning, messaging, value proposition, GTM strategy, and launch copy"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/prism/.claude-plugin/plugin.json
+++ b/team/prism/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Frontend & DX engineer \u2014 UI, internal tools, developer portals",
   "author": {
     "name": "tonone-ai",
@@ -8,5 +8,11 @@
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["frontend", "dx", "ui", "developer-tools", "portals"]
+  "keywords": [
+    "frontend",
+    "dx",
+    "ui",
+    "developer-tools",
+    "portals"
+  ]
 }

--- a/team/prism/scripts/pyproject.toml
+++ b/team/prism/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prism"
-version = "0.9.6"
+version = "0.9.7"
 description = "Frontend & DX engineer — UI, internal tools, developer portals"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/proof/.claude-plugin/plugin.json
+++ b/team/proof/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "proof",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "QA & testing engineer \u2014 test strategy, E2E suites, integration testing, test infrastructure, flaky test triage",
   "author": {
     "name": "tonone-ai",
@@ -8,7 +8,13 @@
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["testing", "qa", "e2e", "integration", "playwright"],
+  "keywords": [
+    "testing",
+    "qa",
+    "e2e",
+    "integration",
+    "playwright"
+  ],
   "skills": [
     {
       "name": "proof-strategy",

--- a/team/proof/scripts/pyproject.toml
+++ b/team/proof/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "proof"
-version = "0.9.6"
+version = "0.9.7"
 description = "QA & testing engineer — test strategy, E2E suites, integration testing, test infrastructure"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/relay/.claude-plugin/plugin.json
+++ b/team/relay/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "relay",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "DevOps engineer \u2014 CI/CD, deployments, GitOps, developer experience",
   "author": {
     "name": "tonone-ai",
@@ -8,5 +8,13 @@
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["devops", "cicd", "deployments", "gitops", "dx", "ship", "pr"]
+  "keywords": [
+    "devops",
+    "cicd",
+    "deployments",
+    "gitops",
+    "dx",
+    "ship",
+    "pr"
+  ]
 }

--- a/team/relay/scripts/pyproject.toml
+++ b/team/relay/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "relay"
-version = "0.9.6"
+version = "0.9.7"
 description = "DevOps engineer — CI/CD, deployments, GitOps, developer experience"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/relay/skills/relay-ship/skill.md
+++ b/team/relay/skills/relay-ship/skill.md
@@ -186,7 +186,7 @@ If tests fail: STOP. Fix the issue, return to Step 2.
 git push -u origin <branch-name>
 ```
 
-Create the PR:
+Create the PR. **You MUST include the full Tonone footer block exactly as shown — do not collapse it to a link or omit it.**
 
 ```bash
 gh pr create --base <base> \
@@ -207,16 +207,25 @@ gh pr create --base <base> \
 
 ---
 
-<small>🤖 This PR was prepared by **[Tonone](https://tonone.ai)**'s AI engineering team.<br>Agents: <comma-separated list of agents that contributed this session, e.g. Relay, Proof, Atlas> · Session: ~<N> min · Token cost: ~$<cost if known, otherwise omit></small>
+---
+
+🤖 **This PR was prepared by [Tonone](https://tonone.ai) AI agents** — an autonomous engineering team of 23 specialized agents that plan, build, review, and ship software end-to-end.
+
+- **Agents:** Relay<!-- add others e.g. · Proof · Atlas · Apex · Spine -->
+- **Session:** ~N min
+- **Est. cost:** ~$0.00<!-- omit if unknown -->
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+Co-Authored-By: Tonone AI <noreply@tonone.ai>
 EOF
 )"
 ```
 
-> **Footer instructions:** Replace the `<…>` placeholders before creating the PR.
->
-> - **Agents:** list every agent invoked during this session (Relay is always listed; add others like Proof, Atlas, Apex as applicable).
-> - **Session:** estimate elapsed time from first tool call to now (round to nearest 5 min).
-> - **Token cost:** include if visible in session stats (e.g. `~$0.42`); omit the field entirely if unknown.
+**Footer fill-in rules (do this before running the command):**
+
+- **Agents:** Relay is always listed. Add every other agent invoked this session (e.g. `Relay, Proof, Atlas`).
+- **Session:** Estimate elapsed time from first tool call to now, rounded to nearest 5 min.
+- **Est. cost:** Include if visible in session stats (e.g. `~$0.42`). Remove the entire row if unknown.
 
 Output the PR URL.
 

--- a/team/spine/.claude-plugin/plugin.json
+++ b/team/spine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spine",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Backend engineer \u2014 APIs, system design, performance, distributed systems",
   "author": {
     "name": "tonone-ai",

--- a/team/spine/scripts/pyproject.toml
+++ b/team/spine/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spine"
-version = "0.9.6"
+version = "0.9.7"
 description = "Backend engineer — APIs, system design, performance, distributed systems"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/surge/.claude-plugin/plugin.json
+++ b/team/surge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surge",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Growth engineer \u2014 acquisition channels, activation funnels, retention playbooks, and PLG strategy",
   "author": {
     "name": "tonone-ai",

--- a/team/surge/scripts/pyproject.toml
+++ b/team/surge/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surge"
-version = "0.9.6"
+version = "0.9.7"
 description = "Growth engineer — acquisition channels, activation funnels, retention playbooks, and PLG strategy"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/touch/.claude-plugin/plugin.json
+++ b/team/touch/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "touch",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Mobile engineer \u2014 native iOS/Android, cross-platform, app stores, mobile performance",
   "author": {
     "name": "tonone-ai",

--- a/team/touch/scripts/pyproject.toml
+++ b/team/touch/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "touch"
-version = "0.9.6"
+version = "0.9.7"
 description = "Mobile engineer — native iOS/Android, cross-platform, app stores, mobile performance"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/vigil/.claude-plugin/plugin.json
+++ b/team/vigil/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vigil",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Observability & reliability engineer \u2014 monitoring, alerting, SRE, incident response, SLOs",
   "author": {
     "name": "tonone-ai",

--- a/team/vigil/scripts/pyproject.toml
+++ b/team/vigil/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vigil"
-version = "0.9.6"
+version = "0.9.7"
 description = "Observability & reliability engineer — monitoring, alerting, SRE, incident response, SLOs"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/volt/.claude-plugin/plugin.json
+++ b/team/volt/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "volt",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Embedded & IoT engineer \u2014 firmware, microcontrollers, edge computing, device protocols",
   "author": {
     "name": "tonone-ai",

--- a/team/volt/scripts/pyproject.toml
+++ b/team/volt/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "volt"
-version = "0.9.6"
+version = "0.9.7"
 description = "Embedded & IoT engineer — firmware, microcontrollers, edge computing, device protocols"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/warden/.claude-plugin/plugin.json
+++ b/team/warden/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warden",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Security engineer \u2014 IAM, secrets, compliance, threat modeling",
   "author": {
     "name": "tonone-ai",
@@ -8,5 +8,11 @@
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["security", "iam", "secrets", "compliance", "threat-modeling"]
+  "keywords": [
+    "security",
+    "iam",
+    "secrets",
+    "compliance",
+    "threat-modeling"
+  ]
 }

--- a/team/warden/scripts/pyproject.toml
+++ b/team/warden/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "warden"
-version = "0.9.6"
+version = "0.9.7"
 description = "Security engineer — IAM, secrets, compliance, threat modeling"
 license = "MIT"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- **relay-ship footer redesigned** — rich bullet-point block replaces the bare `— tonone` link
- Shows: Tonone branding + one-liner description, agents used, session duration, estimated cost
- "prepared by" wording
- `Co-Authored-By` trailers for Claude Code and Tonone AI
- `tonone-pr-attribution.js` hook skips append when body already has Tonone footer (no duplicate)
- Explicit guard instruction so Claude doesn't collapse or omit the block

## Test Coverage

Skill markdown + hook guard string check — no new logic paths. All 54 tests pass.

## Review Findings

No issues found.

## Test Plan

- [x] All 54 tests pass
- [ ] Manual: run `/relay-ship` on a test branch — verify bullet footer appears, no duplicate `— tonone`

---

🤖 **This PR was prepared by [Tonone](https://tonone.ai) AI agents** — an autonomous engineering team of 23 specialized agents that plan, build, review, and ship software end-to-end.

- **Agents:** Relay
- **Session:** ~25 min
- **Est. cost:** ~$0.26

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Co-Authored-By: Tonone AI <noreply@tonone.ai>