### PR TITLE
feat: /contribute skill — automated session learning to upstream PR

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2173,6 +2173,19 @@
       "type": "skill",
       "category": "onboarding",
       "tags": ["tonone", "skill", "onboarding"]
+    },
+    {
+      "name": "contribute",
+      "description": "Contribute a discovery back to the upstream tonone repo — new skill, improved agent prompt, better routing rule. Use when you hit a gap, found a better pattern, or built something reusable that others would benefit from.",
+      "version": "0.1.0",
+      "source": "./skills/contribute",
+      "author": {
+        "name": "tonone-ai",
+        "url": "https://tonone.ai"
+      },
+      "type": "skill",
+      "category": "community",
+      "tags": ["tonone", "skill", "community"]
     }
   ]
 }

--- a/hooks/tonone-worktree-close.js
+++ b/hooks/tonone-worktree-close.js
@@ -4,9 +4,12 @@
 // If the current session is in a worktree with changes, prints a /ship prompt.
 // Clean worktrees are left in place — pruning happens at SessionStart, not here,
 // because Stop fires after every assistant turn (not just at true session exit).
+// For main-branch sessions, suggests /contribute once per session if agents ran.
 // Silent-fails on any error — never block the user's workflow.
 
 const { execSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
 const path = require("path");
 
 /** Detect default branch: remote HEAD → fallback to main → master. */
@@ -46,7 +49,25 @@ process.stdin.on("end", () => {
     } catch {
       process.exit(0);
     }
-    if (gitDir === commonDir) process.exit(0); // Not in a worktree
+    if (gitDir === commonDir) {
+      // Main branch session — suggest /contribute once per session if agents ran
+      const sessionAgentsFile = path.join(".claude", "session-agents");
+      let agentsUsed = false;
+      try {
+        agentsUsed = fs.readFileSync(sessionAgentsFile, "utf8").trim().length > 0;
+      } catch {}
+      if (agentsUsed) {
+        const sessionId = ((JSON.parse(input) || {}).session_id || "").replace(/[^a-z0-9]/gi, "");
+        if (sessionId) {
+          const flagFile = path.join(os.tmpdir(), `tonone-contribute-${sessionId}`);
+          if (!fs.existsSync(flagFile)) {
+            fs.writeFileSync(flagFile, "1");
+            console.log("\nSession had agent activity. Run /contribute to share any learnings upstream.");
+          }
+        }
+      }
+      process.exit(0);
+    }
 
     // 2. Gather context
     const branch = execSync("git rev-parse --abbrev-ref HEAD", {
@@ -83,6 +104,7 @@ process.stdin.on("end", () => {
       console.log(
         `\nWorktree: ${branch}\n` +
           `Changes detected. Run /ship to open a PR.\n` +
+          `Discovered something reusable? Run /contribute to PR it upstream.\n` +
           `To discard: git -C "${mainRepoPath}" worktree remove --force "${worktreePath}" ` +
           `&& git -C "${mainRepoPath}" branch -D ${branch}\n`,
       );

--- a/skills/contribute/SKILL.md
+++ b/skills/contribute/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: contribute
+description: Contribute a session learning back to the upstream tonone repo. Scans the conversation, extracts the single most reusable insight, asks one question, creates the PR. Use when you hit a gap, found a better pattern, or want to share a discovery.
+allowed-tools: Read, Write, Edit, Bash, AskUserQuestion
+version: 0.2.0
+author: tonone-ai <hello@tonone.ai>
+license: MIT
+---
+
+# Contribute to tonone
+
+You are Pave. Scan the session. Find the learning. One question. PR. Done.
+
+---
+
+## Step 1 — Extract the learning (no user input needed)
+
+Read the current conversation and find the single most reusable insight. Look for:
+
+- A **routing gap**: user's request didn't match any skill, they worked around it
+- **Agent corrections**: user corrected the same agent 2+ times for the same pattern
+- A **missing skill**: user built something that should exist as a `/skill-name`
+- A **prompt improvement**: agent's default behavior needed explicit correction
+
+Score candidates by reusability (would this help ANY tonone user, not just this project?).
+Pick the highest-scoring one. If nothing qualifies, print:
+
+```
+╭─ PAVE ── contribute ─────────────────────────────╮
+  No reusable learnings found in this session.
+╰──────────────────────────────────────────────────╯
+```
+...and exit.
+
+---
+
+## Step 2 — Map to a file change
+
+Determine exactly what to change in the tonone repo:
+
+| Learning type | File to change |
+|---------------|---------------|
+| routing gap | `CLAUDE.md` — add routing rule |
+| agent correction | `agents/<name>.md` — patch system prompt |
+| missing skill | `skills/<name>/SKILL.md` — new skill stub |
+| prompt improvement | `agents/<name>.md` or `skills/<name>/SKILL.md` |
+
+Draft the exact diff in memory. Keep it minimal — one logical change.
+
+---
+
+## Step 3 — Sanitize (automatic, no asking)
+
+Strip all user-specific context from the proposed change:
+- Project/company/domain names → `<project>` / `<company>`
+- Personal file paths → `<path>`
+- Any credentials or tokens → `<redacted>`
+
+---
+
+## Step 4 — One question
+
+Use AskUserQuestion with exactly this format:
+
+> **Learning found:** `<one-line description of the improvement>`
+> **Change:** `<file>` — `<what changes, in 10 words or less>`
+>
+> Contribute this to tonone?
+
+Options: **Yes** / **No**
+
+If No: exit silently.
+
+---
+
+## Step 5 — Create the PR (no further questions)
+
+```bash
+TONONE_TMP=$(mktemp -d)
+git clone https://github.com/tonone-ai/tonone "$TONONE_TMP/tonone" --depth=1 --quiet
+cd "$TONONE_TMP/tonone"
+
+gh repo fork --remote-name=fork --clone=false 2>/dev/null || true
+GH_USER=$(gh api user --jq .login)
+git remote add fork "https://github.com/${GH_USER}/tonone.git" 2>/dev/null || \
+  git remote set-url fork "https://github.com/${GH_USER}/tonone.git"
+
+BRANCH="contribute/$(echo '<slug>' | tr ' ' '-')-$(date +%Y%m%d)"
+git checkout -b "$BRANCH"
+```
+
+Apply the diff to the appropriate file. Then:
+
+```bash
+git add -A
+git commit -m "contribute: <one-line description>"
+git push fork "$BRANCH" --quiet
+
+PR_URL=$(gh pr create \
+  --repo tonone-ai/tonone \
+  --head "${GH_USER}:${BRANCH}" \
+  --title "<title>" \
+  --body "## Learning
+
+<description>
+
+## Type
+
+\`<routing | agent-patch | skill-new | skill-improve>\`
+
+---
+*Via \`/contribute\` — auto-extracted from a tonone session*" \
+  --json url --jq .url)
+
+rm -rf "$TONONE_TMP"
+```
+
+---
+
+## Step 6 — Receipt
+
+```
+╭─ PAVE ── contribute ─────────────────────────────╮
+
+  PR open: <PR_URL>
+
+╰──────────────────────────────────────────────────╯
+```
+
+---
+
+## Error handling
+
+- `gh` not authenticated → print "Run `gh auth login` first." Exit.
+- Nothing reusable found → print "No reusable learnings found." Exit.
+- Push fails → print error, `rm -rf "$TONONE_TMP"`, exit.


### PR DESCRIPTION
## Summary

- Adds `/contribute` skill: scans session context, extracts the single most reusable learning, asks one question, creates PR to upstream tonone automatically
- Extends `tonone-worktree-close.js` Stop hook with two new nudges: worktree sessions get a `/contribute` suggestion alongside `/ship`; main-branch sessions get a once-per-session nudge when agents ran
- Registers skill in `marketplace.json` under `category: community`

## How it works

1. User runs `/contribute` (or sees nudge at session end)
2. Skill scans conversation — no questions asked
3. Extracts one learning, maps to a file change, sanitizes automatically
4. Single `AskUserQuestion`: "Learning: X. Contribute?" — yes/no
5. Clones repo, forks, applies diff, pushes, opens PR
6. Prints PR URL

## Test plan

- [x] `marketplace.json` valid JSON
- [x] Hook syntax check passes
- [x] Stop hook fires suggestion on main-branch session with agents
- [x] Stop hook dedupes — same session_id only triggers once
- [x] Stop hook silent when no agents ran
- [x] Malformed hook input handled gracefully
- [ ] End-to-end skill invocation (requires live session + `gh auth`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
*— [tonone](https://second.tonone.ai)*