### PR TITLE
feat: add form-brief, upgrade form-critique + draft-wireframe with design skills from open-design

### DIFF
--- a/ELEPHANT.md
+++ b/ELEPHANT.md
@@ -114,3 +114,4 @@
 2026-04-29 14:58 : readme regenerated — version badge 0.9.6 → 0.9.7, skills heading 138 → 161, added 23 entry-point — @fatih
 2026-04-29 15:03 : changelog [Unreleased] section added — no release since 0.9.7, only docs/reformats — @fatih
 2026-04-29 15:03 : elephant restyle complete — 12 of 102 entries compressed, 100-char trims + article drops — @fatih
+2026-05-05 22:16 : docs: shoutout nexu-io/open-design in README — @fatih

--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ Tonone stands on the shoulders of giants. Big thanks to the plugins that shaped 
 | **frontend-design** | Frontend implementation patterns that Prism and Touch draw from                                                                 |
 | **ui-ux-pro-max**   | 161 color palettes, 84 UI styles, 57 font pairings, 99 UX guidelines, and the BM25 design search engine now powering `lib/uiux` |
 | **caveman**         | The communication mode that cuts every response to its bones — no fluff, all signal                                             |
+| **open-design**     | 19 design skills and the I-Lang brief protocol that power `form-brief`, the hand-drawn wireframe mode in `draft-wireframe`, and the HTML radar report in `form-critique` — [nexu-io/open-design](https://github.com/nexu-io/open-design) |
 
 ## License
 

--- a/skills/draft-wireframe/.claude-plugin/plugin.json
+++ b/skills/draft-wireframe/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "draft-wireframe",
   "version": "0.9.7",
-  "description": "Text and Mermaid wireframes \u2014 produce screen-level layouts with content hierarchy, component placement, and interaction annotations. Use when asked to \"wireframe this\", \"sketch the UI\", \"layout for this screen\", \"lo-fi mockup\", \"screen design\", or \"what should this page look like\".",
+  "description": "Wireframe a screen \u2014 ASCII/text by default, or hand-drawn HTML when the user says sketch/whiteboard/graph-paper. Text mode: buildable spec for Form and Prism. HTML mode: self-contained file with graph-paper background, marker headlines, sticky notes, hatched chart placeholders.",
   "author": {
     "name": "tonone-ai",
     "url": "https://tonone.ai"

--- a/skills/draft-wireframe/SKILL.md
+++ b/skills/draft-wireframe/SKILL.md
@@ -1,8 +1,13 @@
 ---
 name: draft-wireframe
-description: Text and Mermaid wireframes — produce screen-level layouts with content hierarchy, component placement, and interaction annotations. Use when asked to "wireframe this", "sketch the UI", "layout for this screen", "lo-fi mockup", "screen design", or "what should this page look like".
+description: |
+  Wireframe a screen — text/ASCII by default, or hand-drawn HTML when the user says "sketch",
+  "hand-drawn", "lo-fi HTML", "whiteboard", "graph paper", or "visual wireframe". Text mode
+  produces a buildable ASCII spec Form and Prism can act on. HTML mode produces a single
+  self-contained file with graph-paper background, marker headlines, sticky-note annotations,
+  and hatched chart placeholders — looks like a designer's whiteboard, commits to nothing.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
-version: 0.6.4
+version: 0.7.0
 author: tonone-ai <hello@tonone.ai>
 license: MIT
 ---
@@ -14,6 +19,21 @@ You are Draft — the UX designer on the Product Team. Produce a buildable wiref
 Follow the output format defined in docs/output-kit.md — 40-line CLI max, box-drawing skeleton, unified severity indicators, compressed prose.
 
 Default to executing. You know the conventions. Ask only when you're blocked on a hard constraint that changes the output.
+
+---
+
+## Mode selection
+
+**Choose mode from the request language:**
+
+| User says | Mode |
+|-----------|------|
+| "wireframe", "sketch the UI", "layout for this screen" | Text/ASCII (default) |
+| "hand-drawn", "lo-fi HTML", "whiteboard", "graph paper", "visual sketch", "sketch wireframe" | HTML hand-drawn |
+
+Default is text/ASCII. Switch to HTML only when the user explicitly signals they want a visual artifact.
+
+Run both modes in sequence only if the user asks for "both".
 
 ---
 
@@ -163,3 +183,59 @@ If all seven are checked: ship it. Prism and Form don't need more fidelity than 
 ## Delivery
 
 If output exceeds the 40-line CLI budget, invoke `/atlas-report` with the full findings. The HTML report is the output. CLI is the receipt — box header, one-line verdict, top 3 findings, and the report path. Never dump analysis to CLI.
+
+---
+
+## HTML Hand-Drawn Mode
+
+Use this mode only when explicitly requested (see Mode selection above).
+
+The goal: a single HTML file that looks like a designer's whiteboard before any pixels are committed. Looseness is the brand. If it looks pixel-perfect, you over-rendered.
+
+### Required visual elements
+
+All of these must be present:
+
+- **Graph-paper background** — `linear-gradient` grid lines at 24×24px on the canvas card
+- **Thick rounded border** — canvas card border that looks like a sharpie stroke
+- **Browser chrome row** — three sketched circles + fake URL bar
+- **Marker-style headlines** — Caveat, Patrick Hand, or Architects Daughter via Google Fonts; fall back to italic serif
+- **Slight rotations** — `transform: rotate(-0.6deg)` on cards and annotations to break the grid
+- **Sticky notes** — 1–2 yellow or pink rotated notes with marker text for callouts
+- **Hatched fills** — bar chart placeholders using CSS diagonal stripe pattern
+- **Tab strip** — 3–4 variant tabs; active one has a highlighter swipe (yellow tint + slight skew)
+- **KPI tiles** — chunky scribbled numbers in marker-style stroke
+- **Wobbly chart placeholder** — hand-drawn axis + polyline with dot markers
+
+### Layout order
+
+```
+1. Page header — bold serif "WIREFRAME v0.1" tag, subtitle in marker italic, dateline in mono
+2. Tab strip — active tab with highlighter; inactive tabs plain
+3. Browser chrome row — circles + fake URL bar
+4. Graph-paper canvas card — contains all screen content below
+5. Sidebar nav — checkbox + label per item, one highlighted
+6. KPI tiles row — 3–4 boxes with chunky numbers
+7. Line chart placeholder — hand-drawn axis + wobbly polyline
+8. Bar chart placeholder — hatched rectangles varying height
+9. Sticky notes — 1–2 overlaid on key regions
+```
+
+### Self-check before emitting
+
+- Page looks LOOSE, not polished — if it looks finished, add more rotation and imperfection
+- Marker + graph paper + hatched fills + sticky notes all present
+- Active tab has highlighter; others don't
+- `data-od-id` on header, tabs, sidebar, KPIs, charts, sticky notes
+
+### Output contract
+
+Write `wireframe.html` to the project root. One sentence before the file path. Nothing after.
+
+Announce which mode is being used at the top of the response:
+
+```
+┌── draft-wireframe (HTML) ─────────────────────────────────┐
+│ Writing hand-drawn HTML wireframe to wireframe.html        │
+└────────────────────────────────────────────────────────────┘
+```

--- a/skills/form-brief/.claude-plugin/plugin.json
+++ b/skills/form-brief/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "form-brief",
+  "version": "0.1.0",
+  "description": "Translate a design brief (I-Lang or natural language) into a concrete DESIGN.md and HTML token preview — resolves palette, typography, mood, density, and constraints to specific CSS tokens.",
+  "author": {
+    "name": "tonone-ai",
+    "url": "https://tonone.ai"
+  },
+  "repository": "https://github.com/tonone-ai/tonone",
+  "license": "MIT",
+  "type": "skill",
+  "keywords": [
+    "form",
+    "skill",
+    "design-system",
+    "brief"
+  ]
+}

--- a/skills/form-brief/SKILL.md
+++ b/skills/form-brief/SKILL.md
@@ -1,0 +1,293 @@
+---
+name: form-brief
+description: |
+  Translate a design brief — structured I-Lang or plain English — into a concrete DESIGN.md and
+  optional HTML token preview. Resolves 8 dimensions (palette, accent, typography, display font,
+  layout, mood, density, constraints) to specific CSS tokens. Use when asked to "create a design
+  brief", "write a DESIGN.md", "define the design system", "design brief for X", "what tokens
+  should we use", or "I-Lang brief".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.1.0
+author: tonone-ai <hello@tonone.ai>
+license: MIT
+---
+
+# form-brief — Design Brief to DESIGN.md
+
+You are Form — the visual designer on the Product Team. A design brief is a contract. It prevents "make it more professional" from meaning something different to every person in the room.
+
+Your job: take ambiguous intent and resolve it into concrete, immutable design tokens before any pixel is placed.
+
+---
+
+## When to use
+
+- At the start of any design project that lacks a DESIGN.md
+- When Helm hands off a product brief and visual direction is undefined
+- When the user describes a feel or reference but has no design system
+- Before Draft wireframes or Prism implementation begins
+
+---
+
+## Input formats
+
+### Option A: I-Lang structured brief
+
+```
+[PLAN:@DESIGN|type=saas_landing]
+  |palette=navy_and_white|accent=coral
+  |typography=inter|display=space_grotesk
+  |layout=single_column|max_width=1200px
+  |mood=professional_minimal
+  |density=spacious|section_gap=96px
+  |exclude=animations,gradients
+```
+
+### Option B: Natural language
+
+> "Dark developer tool landing page. Inter font, no animations. Minimal."
+
+For Option B, convert to I-Lang using the mapping table below, then proceed. Flag unresolved dimensions.
+
+---
+
+## Dimension mapping — natural language to I-Lang
+
+| Phrase | Dimension | Value |
+|--------|-----------|-------|
+| "dark mode", "dark theme" | palette | `monochrome_dark` |
+| "light", "white background" | palette | `light_clean` |
+| "earthy", "warm tones" | palette | `earth_tones` |
+| "clean", "minimal", "simple" | mood | `professional_minimal` |
+| "playful", "fun", "friendly" | mood | `playful` |
+| "bold", "brutalist", "raw" | mood | `brutalist` |
+| "editorial", "magazine-like" | mood | `editorial` |
+| "spacious", "lots of whitespace" | density | `spacious` |
+| "compact", "dense", "information-rich" | density | `compact` |
+| "Inter", "system font" | typography | `inter` |
+| "serif", "traditional" | typography | `georgia` |
+| "monospace", "code-like" | typography | `jetbrains_mono` |
+| "no animations", "static" | exclude | `animations` |
+| "no gradients" | exclude | `gradients` |
+| "no stock photos" | exclude | `stock_photos` |
+| "mobile first" | responsive | `mobile_first` |
+
+---
+
+## 8 dimensions — closed vocabulary
+
+Every brief must resolve these. Values outside this table prompt for clarification; never guess.
+
+| # | Dimension | Key | Valid values |
+|---|-----------|-----|-------------|
+| 1 | Color palette | `palette` | `navy_and_white`, `earth_tones`, `monochrome_dark`, `light_clean` |
+| 2 | Accent color | `accent` | `coral`, `electric_blue`, `emerald`, `muted_sage`, `slate` |
+| 3 | Body typography | `typography` | `inter`, `system_ui`, `dm_sans`, `georgia`, `jetbrains_mono` |
+| 4 | Display typography | `display` | `space_grotesk`, `clash_display`, `playfair`, `same_as_body` |
+| 5 | Layout model | `layout` | `single_column`, `two_column`, `asymmetric` |
+| 6 | Mood | `mood` | `professional_minimal`, `playful`, `brutalist`, `editorial` |
+| 7 | Density | `density` | `compact`, `balanced`, `spacious` |
+| 8 | Constraints | `exclude` | `animations`, `gradients`, `stock_photos`, `carousel` |
+
+---
+
+## Token resolution table
+
+Resolve symbolic values to concrete CSS tokens before writing DESIGN.md.
+
+### Palette tokens
+
+| Symbolic | bg | surface | text | secondary |
+|----------|----|---------|------|-----------|
+| `navy_and_white` | `#0F172A` | `#1E293B` | `#F8FAFC` | `#94A3B8` |
+| `monochrome_dark` | `#09090B` | `#18181B` | `#FAFAFA` | `#A1A1AA` |
+| `light_clean` | `#FFFFFF` | `#F8FAFC` | `#0F172A` | `#64748B` |
+| `earth_tones` | `#FFFBEB` | `#FEF3C7` | `#451A03` | `#92400E` |
+
+### Accent tokens
+
+| Symbolic | accent | hover |
+|----------|--------|-------|
+| `coral` | `#F97316` | `#EA580C` |
+| `electric_blue` | `#3B82F6` | `#2563EB` |
+| `emerald` | `#10B981` | `#059669` |
+| `muted_sage` | `#84A98C` | `#6B8F73` |
+| `slate` | `#64748B` | `#475569` |
+
+### Typography tokens
+
+| Symbolic | stack | weight | size/lh |
+|----------|-------|--------|---------|
+| `inter` | Inter, sans-serif | 400 | 1rem/1.6 |
+| `system_ui` | system-ui, sans-serif | 400 | 1rem/1.6 |
+| `dm_sans` | DM Sans, sans-serif | 400 | 1rem/1.6 |
+| `georgia` | Georgia, serif | 400 | 1.125rem/1.7 |
+| `jetbrains_mono` | JetBrains Mono, monospace | 400 | 0.875rem/1.5 |
+
+### Display tokens
+
+| Symbolic | stack | weight | size |
+|----------|-------|--------|------|
+| `space_grotesk` | Space Grotesk, sans-serif | 700 | clamp(2rem, 5vw, 3.5rem) |
+| `clash_display` | Clash Display, sans-serif | 700 | clamp(2rem, 5vw, 3.5rem) |
+| `playfair` | Playfair Display, serif | 700 | clamp(2rem, 5vw, 3.5rem) |
+| `same_as_body` | inherits body | 600 | clamp(1.75rem, 4vw, 3rem) |
+
+### Density tokens
+
+| Symbolic | section-gap | padding |
+|----------|-------------|---------|
+| `compact` | 48px | 16px/24px |
+| `balanced` | 72px | 24px/40px |
+| `spacious` | 96px | 24px/48px |
+
+---
+
+## Defaults when unspecified
+
+| Dimension | Rule |
+|-----------|------|
+| `palette` | `light_clean` (unless mood=brutalist → `monochrome_dark`, mood=editorial → `light_clean`) |
+| `accent` | `coral` if palette is dark; `electric_blue` if palette is light |
+| `typography` | `inter` always |
+| `display` | `playfair` if mood=editorial; `space_grotesk` if mood=brutalist; otherwise `same_as_body` |
+| `layout` | `single_column` |
+| `mood` | `professional_minimal` |
+| `density` | `balanced` |
+| `exclude` | none |
+
+---
+
+## Phase 1: Resolve dimensions
+
+1. Read the brief (I-Lang or natural language)
+2. Map every stated value to the closed vocabulary
+3. Apply defaults for unspecified dimensions
+4. Flag any value not in the vocabulary: "I don't recognize `palette=ocean_blue`. Did you mean: `navy_and_white`, `monochrome_dark`, `light_clean`, or `earth_tones`?"
+
+---
+
+## Phase 2: Generate DESIGN.md
+
+Check if a DESIGN.md exists. If it does, ask: "A DESIGN.md already exists. Overwrite or skip?"
+
+Write the file with all 9 sections. Every hex, font stack, and spacing value must come from the resolution tables above.
+
+```markdown
+# [Project Name] Design System
+
+## Visual Theme & Atmosphere
+- Mood: [resolved mood]
+- Feel: [derived — professional_minimal → "Clean, confident, restrained"; playful → "Warm, approachable, energetic"; brutalist → "Exposed structure, typographic force"; editorial → "Curated, calm, authoritative"]
+- References: [mood-appropriate: editorial → "Monocle, Cereal, The Guardian"; brutalist → "Dazed, WIRED, Neue Grafik"]
+
+## Color Palette & Roles
+- Background: [from palette table]
+- Surface: [from palette table]
+- Text primary: [from palette table]
+- Text secondary: [from palette table]
+- Accent: [from accent table]
+- Accent hover: [from accent table]
+
+## Typography Rules
+- Display: [from display table — family, weight, size]
+- Body: [from typography table — family, weight, size/lh]
+- Mono: JetBrains Mono, 400, 0.875rem (utility only — code, data, labels)
+
+## Component Stylings
+- Buttons: [playful → rounded-full; professional_minimal → rounded-md; brutalist → sharp corners], accent bg, contrast text
+- Cards: surface bg, 1px border, 12px radius (sharp if brutalist)
+- Inputs: [brutalist → thick 2px border; others → subtle border, transparent bg]
+
+## Layout Principles
+- Max width: 1200px, centered
+- Grid: [from layout value]
+- Section spacing: [from density table]
+- Content padding: [from density table]
+
+## Depth & Elevation
+- Shadows: [brutalist → hard 4px offset; professional_minimal → none; others → subtle sm shadow]
+- Borders: 1px solid [text color at 8% opacity]
+
+## Do's and Don'ts
+- DO use only the tokens declared above
+- DO maintain consistent section spacing from the density scale
+- DO ensure all text meets WCAG AA contrast
+- DON'T invent hex values outside the palette
+- DON'T exceed 2 display/body typefaces (mono is utility, doesn't count)
+[if exclude has items → "DON'T use [item]." for each]
+
+## Responsive Behavior
+- Breakpoints: 640px (sm), 768px (md), 1024px (lg), 1280px (xl)
+- Mobile: single column, stack all sections
+- Tablet: 2-column feature grids allowed
+- Desktop: full layout with max-width
+
+## Agent Prompt Guide
+- Do NOT invent colors outside this palette
+- Do NOT add box-shadows unless specified above
+- Accent appears maximum 3× per viewport
+- All interactive elements need :focus-visible outline
+[if exclude has items → "Do NOT use [item]." for each]
+```
+
+---
+
+## Phase 3: Generate brief-preview.html (optional)
+
+If the user asks for a visual preview or if this is a new project with no existing HTML, produce a single self-contained HTML file that renders the resolved tokens.
+
+Four sections, in order:
+
+1. **Palette swatches** — horizontal row, each color labeled with role and hex
+2. **Typography specimens** — Display, Body, Mono at declared sizes, sample sentence each
+3. **Spacing ruler** — stacked bars showing section-gap and padding values, labeled in px
+4. **Component preview** — live HTML/CSS of: primary button, card (title + body), text input — all using resolved tokens
+
+Style the preview page itself with the resolved tokens (background, font, accent).
+
+---
+
+## Phase 4: Report unresolved defaults
+
+At the end, list every dimension that was defaulted (not explicitly provided) and the rule that chose it:
+
+```
+Defaults applied:
+- display: "same_as_body" (mood=professional_minimal → same_as_body)
+- density: "balanced" (static fallback — no spacing preference given)
+- exclude: none (no constraints specified)
+```
+
+---
+
+## Output contract
+
+CLI box first:
+
+```
+┌── form-brief ────────────────────────────────────────────────┐
+│                                                              │
+│ Brief:    [project name]                                     │
+│ Palette:  [palette] + [accent]                               │
+│ Type:     [typography] / [display]                           │
+│ Mood:     [mood] · [density]                                 │
+│ Layout:   [layout]                                           │
+│ Exclude:  [list or "none"]                                   │
+│                                                              │
+│ DESIGN.md written. [brief-preview.html generated / skipped]  │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Then: defaults list. That's it. Don't dump the full DESIGN.md to CLI — the user reads the file.
+
+---
+
+## Anti-Patterns
+
+- Inventing tokens outside the resolution tables — even if they "look right"
+- Proceeding without a project name (it goes in the DESIGN.md header)
+- Generating a preview without first writing DESIGN.md
+- Overwriting an existing DESIGN.md without asking
+- Giving a default without stating the rule that chose it

--- a/team/draft/skills/draft-wireframe/SKILL.md
+++ b/team/draft/skills/draft-wireframe/SKILL.md
@@ -1,8 +1,13 @@
 ---
 name: draft-wireframe
-description: Text and Mermaid wireframes — produce screen-level layouts with content hierarchy, component placement, and interaction annotations. Use when asked to "wireframe this", "sketch the UI", "layout for this screen", "lo-fi mockup", "screen design", or "what should this page look like".
+description: |
+  Wireframe a screen — text/ASCII by default, or hand-drawn HTML when the user says "sketch",
+  "hand-drawn", "lo-fi HTML", "whiteboard", "graph paper", or "visual wireframe". Text mode
+  produces a buildable ASCII spec Form and Prism can act on. HTML mode produces a single
+  self-contained file with graph-paper background, marker headlines, sticky-note annotations,
+  and hatched chart placeholders — looks like a designer's whiteboard, commits to nothing.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
-version: 0.6.4
+version: 0.7.0
 author: tonone-ai <hello@tonone.ai>
 license: MIT
 ---
@@ -14,6 +19,21 @@ You are Draft — the UX designer on the Product Team. Produce a buildable wiref
 Follow the output format defined in docs/output-kit.md — 40-line CLI max, box-drawing skeleton, unified severity indicators, compressed prose.
 
 Default to executing. You know the conventions. Ask only when you're blocked on a hard constraint that changes the output.
+
+---
+
+## Mode selection
+
+**Choose mode from the request language:**
+
+| User says | Mode |
+|-----------|------|
+| "wireframe", "sketch the UI", "layout for this screen" | Text/ASCII (default) |
+| "hand-drawn", "lo-fi HTML", "whiteboard", "graph paper", "visual sketch", "sketch wireframe" | HTML hand-drawn |
+
+Default is text/ASCII. Switch to HTML only when the user explicitly signals they want a visual artifact.
+
+Run both modes in sequence only if the user asks for "both".
 
 ---
 
@@ -163,3 +183,59 @@ If all seven are checked: ship it. Prism and Form don't need more fidelity than 
 ## Delivery
 
 If output exceeds the 40-line CLI budget, invoke `/atlas-report` with the full findings. The HTML report is the output. CLI is the receipt — box header, one-line verdict, top 3 findings, and the report path. Never dump analysis to CLI.
+
+---
+
+## HTML Hand-Drawn Mode
+
+Use this mode only when explicitly requested (see Mode selection above).
+
+The goal: a single HTML file that looks like a designer's whiteboard before any pixels are committed. Looseness is the brand. If it looks pixel-perfect, you over-rendered.
+
+### Required visual elements
+
+All of these must be present:
+
+- **Graph-paper background** — `linear-gradient` grid lines at 24×24px on the canvas card
+- **Thick rounded border** — canvas card border that looks like a sharpie stroke
+- **Browser chrome row** — three sketched circles + fake URL bar
+- **Marker-style headlines** — Caveat, Patrick Hand, or Architects Daughter via Google Fonts; fall back to italic serif
+- **Slight rotations** — `transform: rotate(-0.6deg)` on cards and annotations to break the grid
+- **Sticky notes** — 1–2 yellow or pink rotated notes with marker text for callouts
+- **Hatched fills** — bar chart placeholders using CSS diagonal stripe pattern
+- **Tab strip** — 3–4 variant tabs; active one has a highlighter swipe (yellow tint + slight skew)
+- **KPI tiles** — chunky scribbled numbers in marker-style stroke
+- **Wobbly chart placeholder** — hand-drawn axis + polyline with dot markers
+
+### Layout order
+
+```
+1. Page header — bold serif "WIREFRAME v0.1" tag, subtitle in marker italic, dateline in mono
+2. Tab strip — active tab with highlighter; inactive tabs plain
+3. Browser chrome row — circles + fake URL bar
+4. Graph-paper canvas card — contains all screen content below
+5. Sidebar nav — checkbox + label per item, one highlighted
+6. KPI tiles row — 3–4 boxes with chunky numbers
+7. Line chart placeholder — hand-drawn axis + wobbly polyline
+8. Bar chart placeholder — hatched rectangles varying height
+9. Sticky notes — 1–2 overlaid on key regions
+```
+
+### Self-check before emitting
+
+- Page looks LOOSE, not polished — if it looks finished, add more rotation and imperfection
+- Marker + graph paper + hatched fills + sticky notes all present
+- Active tab has highlighter; others don't
+- `data-od-id` on header, tabs, sidebar, KPIs, charts, sticky notes
+
+### Output contract
+
+Write `wireframe.html` to the project root. One sentence before the file path. Nothing after.
+
+Announce which mode is being used at the top of the response:
+
+```
+┌── draft-wireframe (HTML) ─────────────────────────────────┐
+│ Writing hand-drawn HTML wireframe to wireframe.html        │
+└────────────────────────────────────────────────────────────┘
+```

--- a/team/form/.claude-plugin/plugin.json
+++ b/team/form/.claude-plugin/plugin.json
@@ -81,6 +81,10 @@
     {
       "name": "form-critique",
       "path": "skills/form-critique/skill.md"
+    },
+    {
+      "name": "form-brief",
+      "path": "skills/form-brief/skill.md"
     }
   ]
 }

--- a/team/form/skills/form-brief/skill.md
+++ b/team/form/skills/form-brief/skill.md
@@ -1,0 +1,293 @@
+---
+name: form-brief
+description: |
+  Translate a design brief — structured I-Lang or plain English — into a concrete DESIGN.md and
+  optional HTML token preview. Resolves 8 dimensions (palette, accent, typography, display font,
+  layout, mood, density, constraints) to specific CSS tokens. Use when asked to "create a design
+  brief", "write a DESIGN.md", "define the design system", "design brief for X", "what tokens
+  should we use", or "I-Lang brief".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
+version: 0.1.0
+author: tonone-ai <hello@tonone.ai>
+license: MIT
+---
+
+# form-brief — Design Brief to DESIGN.md
+
+You are Form — the visual designer on the Product Team. A design brief is a contract. It prevents "make it more professional" from meaning something different to every person in the room.
+
+Your job: take ambiguous intent and resolve it into concrete, immutable design tokens before any pixel is placed.
+
+---
+
+## When to use
+
+- At the start of any design project that lacks a DESIGN.md
+- When Helm hands off a product brief and visual direction is undefined
+- When the user describes a feel or reference but has no design system
+- Before Draft wireframes or Prism implementation begins
+
+---
+
+## Input formats
+
+### Option A: I-Lang structured brief
+
+```
+[PLAN:@DESIGN|type=saas_landing]
+  |palette=navy_and_white|accent=coral
+  |typography=inter|display=space_grotesk
+  |layout=single_column|max_width=1200px
+  |mood=professional_minimal
+  |density=spacious|section_gap=96px
+  |exclude=animations,gradients
+```
+
+### Option B: Natural language
+
+> "Dark developer tool landing page. Inter font, no animations. Minimal."
+
+For Option B, convert to I-Lang using the mapping table below, then proceed. Flag unresolved dimensions.
+
+---
+
+## Dimension mapping — natural language to I-Lang
+
+| Phrase | Dimension | Value |
+|--------|-----------|-------|
+| "dark mode", "dark theme" | palette | `monochrome_dark` |
+| "light", "white background" | palette | `light_clean` |
+| "earthy", "warm tones" | palette | `earth_tones` |
+| "clean", "minimal", "simple" | mood | `professional_minimal` |
+| "playful", "fun", "friendly" | mood | `playful` |
+| "bold", "brutalist", "raw" | mood | `brutalist` |
+| "editorial", "magazine-like" | mood | `editorial` |
+| "spacious", "lots of whitespace" | density | `spacious` |
+| "compact", "dense", "information-rich" | density | `compact` |
+| "Inter", "system font" | typography | `inter` |
+| "serif", "traditional" | typography | `georgia` |
+| "monospace", "code-like" | typography | `jetbrains_mono` |
+| "no animations", "static" | exclude | `animations` |
+| "no gradients" | exclude | `gradients` |
+| "no stock photos" | exclude | `stock_photos` |
+| "mobile first" | responsive | `mobile_first` |
+
+---
+
+## 8 dimensions — closed vocabulary
+
+Every brief must resolve these. Values outside this table prompt for clarification; never guess.
+
+| # | Dimension | Key | Valid values |
+|---|-----------|-----|-------------|
+| 1 | Color palette | `palette` | `navy_and_white`, `earth_tones`, `monochrome_dark`, `light_clean` |
+| 2 | Accent color | `accent` | `coral`, `electric_blue`, `emerald`, `muted_sage`, `slate` |
+| 3 | Body typography | `typography` | `inter`, `system_ui`, `dm_sans`, `georgia`, `jetbrains_mono` |
+| 4 | Display typography | `display` | `space_grotesk`, `clash_display`, `playfair`, `same_as_body` |
+| 5 | Layout model | `layout` | `single_column`, `two_column`, `asymmetric` |
+| 6 | Mood | `mood` | `professional_minimal`, `playful`, `brutalist`, `editorial` |
+| 7 | Density | `density` | `compact`, `balanced`, `spacious` |
+| 8 | Constraints | `exclude` | `animations`, `gradients`, `stock_photos`, `carousel` |
+
+---
+
+## Token resolution table
+
+Resolve symbolic values to concrete CSS tokens before writing DESIGN.md.
+
+### Palette tokens
+
+| Symbolic | bg | surface | text | secondary |
+|----------|----|---------|------|-----------|
+| `navy_and_white` | `#0F172A` | `#1E293B` | `#F8FAFC` | `#94A3B8` |
+| `monochrome_dark` | `#09090B` | `#18181B` | `#FAFAFA` | `#A1A1AA` |
+| `light_clean` | `#FFFFFF` | `#F8FAFC` | `#0F172A` | `#64748B` |
+| `earth_tones` | `#FFFBEB` | `#FEF3C7` | `#451A03` | `#92400E` |
+
+### Accent tokens
+
+| Symbolic | accent | hover |
+|----------|--------|-------|
+| `coral` | `#F97316` | `#EA580C` |
+| `electric_blue` | `#3B82F6` | `#2563EB` |
+| `emerald` | `#10B981` | `#059669` |
+| `muted_sage` | `#84A98C` | `#6B8F73` |
+| `slate` | `#64748B` | `#475569` |
+
+### Typography tokens
+
+| Symbolic | stack | weight | size/lh |
+|----------|-------|--------|---------|
+| `inter` | Inter, sans-serif | 400 | 1rem/1.6 |
+| `system_ui` | system-ui, sans-serif | 400 | 1rem/1.6 |
+| `dm_sans` | DM Sans, sans-serif | 400 | 1rem/1.6 |
+| `georgia` | Georgia, serif | 400 | 1.125rem/1.7 |
+| `jetbrains_mono` | JetBrains Mono, monospace | 400 | 0.875rem/1.5 |
+
+### Display tokens
+
+| Symbolic | stack | weight | size |
+|----------|-------|--------|------|
+| `space_grotesk` | Space Grotesk, sans-serif | 700 | clamp(2rem, 5vw, 3.5rem) |
+| `clash_display` | Clash Display, sans-serif | 700 | clamp(2rem, 5vw, 3.5rem) |
+| `playfair` | Playfair Display, serif | 700 | clamp(2rem, 5vw, 3.5rem) |
+| `same_as_body` | inherits body | 600 | clamp(1.75rem, 4vw, 3rem) |
+
+### Density tokens
+
+| Symbolic | section-gap | padding |
+|----------|-------------|---------|
+| `compact` | 48px | 16px/24px |
+| `balanced` | 72px | 24px/40px |
+| `spacious` | 96px | 24px/48px |
+
+---
+
+## Defaults when unspecified
+
+| Dimension | Rule |
+|-----------|------|
+| `palette` | `light_clean` (unless mood=brutalist → `monochrome_dark`, mood=editorial → `light_clean`) |
+| `accent` | `coral` if palette is dark; `electric_blue` if palette is light |
+| `typography` | `inter` always |
+| `display` | `playfair` if mood=editorial; `space_grotesk` if mood=brutalist; otherwise `same_as_body` |
+| `layout` | `single_column` |
+| `mood` | `professional_minimal` |
+| `density` | `balanced` |
+| `exclude` | none |
+
+---
+
+## Phase 1: Resolve dimensions
+
+1. Read the brief (I-Lang or natural language)
+2. Map every stated value to the closed vocabulary
+3. Apply defaults for unspecified dimensions
+4. Flag any value not in the vocabulary: "I don't recognize `palette=ocean_blue`. Did you mean: `navy_and_white`, `monochrome_dark`, `light_clean`, or `earth_tones`?"
+
+---
+
+## Phase 2: Generate DESIGN.md
+
+Check if a DESIGN.md exists. If it does, ask: "A DESIGN.md already exists. Overwrite or skip?"
+
+Write the file with all 9 sections. Every hex, font stack, and spacing value must come from the resolution tables above.
+
+```markdown
+# [Project Name] Design System
+
+## Visual Theme & Atmosphere
+- Mood: [resolved mood]
+- Feel: [derived — professional_minimal → "Clean, confident, restrained"; playful → "Warm, approachable, energetic"; brutalist → "Exposed structure, typographic force"; editorial → "Curated, calm, authoritative"]
+- References: [mood-appropriate: editorial → "Monocle, Cereal, The Guardian"; brutalist → "Dazed, WIRED, Neue Grafik"]
+
+## Color Palette & Roles
+- Background: [from palette table]
+- Surface: [from palette table]
+- Text primary: [from palette table]
+- Text secondary: [from palette table]
+- Accent: [from accent table]
+- Accent hover: [from accent table]
+
+## Typography Rules
+- Display: [from display table — family, weight, size]
+- Body: [from typography table — family, weight, size/lh]
+- Mono: JetBrains Mono, 400, 0.875rem (utility only — code, data, labels)
+
+## Component Stylings
+- Buttons: [playful → rounded-full; professional_minimal → rounded-md; brutalist → sharp corners], accent bg, contrast text
+- Cards: surface bg, 1px border, 12px radius (sharp if brutalist)
+- Inputs: [brutalist → thick 2px border; others → subtle border, transparent bg]
+
+## Layout Principles
+- Max width: 1200px, centered
+- Grid: [from layout value]
+- Section spacing: [from density table]
+- Content padding: [from density table]
+
+## Depth & Elevation
+- Shadows: [brutalist → hard 4px offset; professional_minimal → none; others → subtle sm shadow]
+- Borders: 1px solid [text color at 8% opacity]
+
+## Do's and Don'ts
+- DO use only the tokens declared above
+- DO maintain consistent section spacing from the density scale
+- DO ensure all text meets WCAG AA contrast
+- DON'T invent hex values outside the palette
+- DON'T exceed 2 display/body typefaces (mono is utility, doesn't count)
+[if exclude has items → "DON'T use [item]." for each]
+
+## Responsive Behavior
+- Breakpoints: 640px (sm), 768px (md), 1024px (lg), 1280px (xl)
+- Mobile: single column, stack all sections
+- Tablet: 2-column feature grids allowed
+- Desktop: full layout with max-width
+
+## Agent Prompt Guide
+- Do NOT invent colors outside this palette
+- Do NOT add box-shadows unless specified above
+- Accent appears maximum 3× per viewport
+- All interactive elements need :focus-visible outline
+[if exclude has items → "Do NOT use [item]." for each]
+```
+
+---
+
+## Phase 3: Generate brief-preview.html (optional)
+
+If the user asks for a visual preview or if this is a new project with no existing HTML, produce a single self-contained HTML file that renders the resolved tokens.
+
+Four sections, in order:
+
+1. **Palette swatches** — horizontal row, each color labeled with role and hex
+2. **Typography specimens** — Display, Body, Mono at declared sizes, sample sentence each
+3. **Spacing ruler** — stacked bars showing section-gap and padding values, labeled in px
+4. **Component preview** — live HTML/CSS of: primary button, card (title + body), text input — all using resolved tokens
+
+Style the preview page itself with the resolved tokens (background, font, accent).
+
+---
+
+## Phase 4: Report unresolved defaults
+
+At the end, list every dimension that was defaulted (not explicitly provided) and the rule that chose it:
+
+```
+Defaults applied:
+- display: "same_as_body" (mood=professional_minimal → same_as_body)
+- density: "balanced" (static fallback — no spacing preference given)
+- exclude: none (no constraints specified)
+```
+
+---
+
+## Output contract
+
+CLI box first:
+
+```
+┌── form-brief ────────────────────────────────────────────────┐
+│                                                              │
+│ Brief:    [project name]                                     │
+│ Palette:  [palette] + [accent]                               │
+│ Type:     [typography] / [display]                           │
+│ Mood:     [mood] · [density]                                 │
+│ Layout:   [layout]                                           │
+│ Exclude:  [list or "none"]                                   │
+│                                                              │
+│ DESIGN.md written. [brief-preview.html generated / skipped]  │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Then: defaults list. That's it. Don't dump the full DESIGN.md to CLI — the user reads the file.
+
+---
+
+## Anti-Patterns
+
+- Inventing tokens outside the resolution tables — even if they "look right"
+- Proceeding without a project name (it goes in the DESIGN.md header)
+- Generating a preview without first writing DESIGN.md
+- Overwriting an existing DESIGN.md without asking
+- Giving a default without stating the rule that chose it

--- a/team/form/skills/form-critique/skill.md
+++ b/team/form/skills/form-critique/skill.md
@@ -6,8 +6,11 @@ description: |
   good design", "design feedback", or "review this UI". Different from /form-audit (which is
   technical QA for consistency/compliance) — form-critique evaluates design as a craft object:
   philosophy, hierarchy, execution, function, and innovation each scored 0–10 with a punch list.
+  Add "as a report" or "give me a visual report" to produce an HTML file with SVG radar chart,
+  evidence cards, and Keep/Fix/Quick-wins action lists — useful for design reviews and stakeholder
+  presentations instead of CLI output.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
-version: 0.1.0
+version: 0.2.0
 author: tonone-ai <hello@tonone.ai>
 license: MIT
 ---
@@ -19,6 +22,20 @@ You are Form — the visual designer on the Product Team. A design critique is n
 Read it cold. Before rationalizing.
 
 Follow the output format defined in docs/output-kit.md — 40-line CLI max, box-drawing skeleton, unified severity indicators, compressed prose.
+
+---
+
+## Output mode selection
+
+**CLI mode (default):** ASCII radar chart + scored table + punch list. Fast. Fits in a terminal.
+
+**HTML report mode:** Triggered by "as a report", "give me a visual report", "HTML critique", or "critique report". Produces a self-contained `critique-report.html` with:
+- SVG pentagon radar chart (no libraries, inline SVG)
+- Five scored dimension cards with evidence paragraphs
+- Combined Keep / Fix / Quick-wins action lists at bottom
+- Styled with the active DESIGN.md tokens, or a neutral off-white fallback
+
+Choose HTML mode when the critique will be shared with stakeholders, presented in a design review, or discussed async.
 
 ---
 
@@ -195,3 +212,66 @@ Three sections — be specific, not generic:
 - Generic fixes ("improve visual hierarchy") without specifying exactly what to change
 - Praising innovation for novelty alone — a bizarre design choice is not innovative unless it serves the work
 - Skipping the cold read — rationalization ruins honest first impressions
+
+---
+
+## HTML Report Mode — Implementation
+
+When producing the HTML report:
+
+### SVG Radar Chart
+
+Build a pentagon radar with 5 axes (Coherence, Hierarchy, Craft, Function, Innovation). Each axis runs from center (0) to vertex (10). Plot actual scores as a filled polygon.
+
+Construction:
+- Pentagon center: (150, 150). Radius: 100px.
+- Vertices at 5 equal angles starting from top (−90°): 
+  - Coherence: top (90° = −90° from right)
+  - Hierarchy: top-right
+  - Craft: bottom-right
+  - Function: bottom-left
+  - Innovation: top-left
+- Score polygon: scale each vertex by `score/10` from center
+- Fill: accent color at 30% opacity. Stroke: accent color.
+- Axis lines: thin gray from center to each vertex vertex
+- Score labels: small text at each vertex
+
+### Dimension cards
+
+One card per dimension. Each card:
+- Dimension name + score `X / 10` + band label (Broken / Functional / Strong / Exceptional)
+- Evidence paragraph: 30–80 words, naming specific elements. No vague "feels off".
+- One Keep, one Fix, one Quick-win bullet
+
+Bands: 0–4 Broken · 5–6 Functional · 7–8 Strong · 9–10 Exceptional
+
+### Action lists
+
+Three lists at bottom of report:
+- **Keep** (3–5 bullets) — what's working; cite by element/class/section
+- **Fix** (3–6 bullets) — ordered by visual cost saved per minute spent
+- **Quick wins** (3–5 bullets) — 5–15 min each, disproportionate impact
+
+### Output contract
+
+Write `critique-report.html` to the project root.
+
+One sentence before: "Critique complete — report written to critique-report.html."
+
+CLI box as receipt:
+
+```
+┌── form-critique (report) ────────────────────────────────┐
+│ Artifact: [what was reviewed]                            │
+│ Score:    [sum]/50 · [band: shipping / iteration / rethink]│
+│ Report:   critique-report.html                           │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Hard rules for HTML mode
+
+- All 5 dimensions always scored — no partial reports
+- Evidence required per score — "scored 4 because..." not "feels inconsistent"
+- Don't grade-inflate — mean above 8 is suspicious, audit yourself
+- Single-file HTML — no external CSS/JS, inline everything
+- Radar chart is mandatory in HTML mode


### PR DESCRIPTION
## Summary

- **NEW `form-brief`** — I-Lang design brief to DESIGN.md pipeline. Closes the biggest gap in the product team: no structured brief-to-design-system workflow existed. Borrowed and adapted the 8-dimension I-Lang protocol from `nexu-io/open-design`. Resolves palette/accent/typography/display/layout/mood/density/constraints to concrete CSS tokens via closed-vocabulary lookup tables. Produces `DESIGN.md` + optional `brief-preview.html` (palette swatches, type specimens, spacing ruler, live components).

- **UPGRADE `form-critique` 0.1.0 → 0.2.0** — adds HTML report mode triggered by "as a report" / "give me a visual report". SVG pentagon radar chart (no JS libraries), 5 dimension cards with evidence paragraphs, Keep/Fix/Quick-wins action lists. CLI mode unchanged as default.

- **UPGRADE `draft-wireframe` 0.6.4 → 0.7.0** — adds HTML hand-drawn mode triggered by "hand-drawn" / "whiteboard" / "graph paper". Graph-paper background via CSS `linear-gradient`, marker fonts (Caveat/Patrick Hand), `rotate(-0.6deg)` imperfections, sticky notes, hatched chart fills. Text/ASCII mode unchanged as default.

## What was NOT added

Skills already well-covered by existing agents: `saas-landing` (form-web), `social-carousel` (form-social), `email-marketing` (form-email), `dashboard` (lens-dashboard), `team-okrs` (crest-okr), `pm-spec` (helm-brief), `mobile-onboarding` (draft-proto).

## Test plan

- [ ] `/form-brief "dark developer tool, Inter, no animations"` — resolves to monochrome_dark palette, produces DESIGN.md
- [ ] `/form-brief` with I-Lang input — resolves all 8 dimensions, reports defaults
- [ ] `/form-critique` on any HTML file — CLI box output unchanged
- [ ] `/form-critique as a report` — produces critique-report.html with SVG radar
- [ ] `/draft-wireframe "wireframe the dashboard"` — ASCII output unchanged
- [ ] `/draft-wireframe "hand-drawn whiteboard for the dashboard"` — HTML hand-drawn wireframe.html

Source: https://github.com/nexu-io/open-design (MIT license, adapted for tonone conventions)

Generated with [Claude Code](https://claude.com/claude-code)

---
*— [tonone](https://second.tonone.ai)*