### PR TITLE
v0.9.8 feat(forge): real tool integration — infracost IaC analysis + AWS Cost Explorer

### DIFF
--- a/team/forge/scripts/forge_agent/cloud_cost_fetcher.py
+++ b/team/forge/scripts/forge_agent/cloud_cost_fetcher.py
@@ -1,0 +1,195 @@
+"""Cloud cost fetcher — queries actual spend from AWS Cost Explorer or GCP billing."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import date, timedelta
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from team.shared.report_schema import Finding
+
+_SPEND_SEVERITY = [
+    (5000.0,  "CRITICAL"),
+    (1000.0,  "HIGH"),
+    (200.0,   "MEDIUM"),
+    (0.01,    "LOW"),
+]
+
+
+def _severity_for_spend(monthly_usd: float) -> str:
+    for threshold, sev in _SPEND_SEVERITY:
+        if monthly_usd >= threshold:
+            return sev
+    return "INFO"
+
+
+def _aws_available() -> bool:
+    try:
+        result = subprocess.run(
+            ["aws", "--version"],
+            capture_output=True, text=True, timeout=10,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def _gcloud_available() -> bool:
+    try:
+        result = subprocess.run(
+            ["gcloud", "--version"],
+            capture_output=True, text=True, timeout=10,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def run_cloud_cost_fetch(target_path: str) -> list[Finding]:
+    """
+    Query actual cloud spend. Tries AWS Cost Explorer first, then GCP.
+    Returns [] if no cloud CLI is available or authenticated.
+    """
+    findings: list[Finding] = []
+
+    if _aws_available():
+        findings.extend(_fetch_aws_costs())
+
+    if _gcloud_available():
+        findings.extend(_fetch_gcp_costs())
+
+    if not findings and not _aws_available() and not _gcloud_available():
+        print(
+            "No cloud CLI found (aws/gcloud). Install to fetch actual spend.",
+            file=sys.stderr,
+        )
+
+    return findings
+
+
+def _fetch_aws_costs() -> list[Finding]:
+    today = date.today()
+    start = (today.replace(day=1) - timedelta(days=1)).replace(day=1).isoformat()
+    end = today.replace(day=1).isoformat()
+
+    cmd = [
+        "aws", "ce", "get-cost-and-usage",
+        "--time-period", f"Start={start},End={end}",
+        "--granularity", "MONTHLY",
+        "--metrics", "UnblendedCost",
+        "--group-by", "Type=DIMENSION,Key=SERVICE",
+        "--output", "json",
+    ]
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except subprocess.TimeoutExpired:
+        print("AWS Cost Explorer timed out.", file=sys.stderr)
+        return []
+
+    if result.returncode != 0:
+        stderr = result.stderr.lower()
+        if "unable to locate credentials" in stderr or "authfailure" in stderr or "accessdenied" in stderr:
+            print("AWS credentials not configured or missing ce:GetCostAndUsage permission.", file=sys.stderr)
+        else:
+            print(f"aws ce error: {result.stderr[:300]}", file=sys.stderr)
+        return []
+
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return []
+
+    return _parse_aws_costs(data, start, end)
+
+
+def _parse_aws_costs(data: dict, start: str, end: str) -> list[Finding]:
+    findings: list[Finding] = []
+    period_label = f"{start} to {end}"
+
+    for period in data.get("ResultsByTime", []):
+        for group in period.get("Groups", []):
+            service = group.get("Keys", ["unknown"])[0]
+            amount = float(group.get("Metrics", {}).get("UnblendedCost", {}).get("Amount", 0))
+
+            if amount < 1.0:
+                continue
+
+            severity = _severity_for_spend(amount)
+            recommendation = _aws_service_recommendation(service, amount)
+
+            findings.append(Finding(
+                id=f"AWS-{service.upper().replace(' ', '-')[:30]}",
+                severity=severity,
+                title=f"AWS spend: {service}",
+                detail=f"${amount:.2f} in {period_label}.",
+                location=f"aws://cost-explorer/{service}",
+                recommendation=recommendation,
+                effort="S",
+            ))
+
+    return sorted(findings, key=lambda f: -float(f.detail.split("$")[1].split(" ")[0]))
+
+
+def _aws_service_recommendation(service: str, amount: float) -> str:
+    recs: dict[str, str] = {
+        "Amazon EC2":                  "Check for idle/oversized instances. Consider Savings Plans (up to 66% off on-demand).",
+        "Amazon RDS":                  "Use Reserved Instances for steady-state workloads (up to 69% savings).",
+        "Amazon S3":                   "Enable Intelligent-Tiering for infrequently accessed data. Audit lifecycle rules.",
+        "AWS Lambda":                  "Review function memory sizing — Lambda bills on GB-seconds.",
+        "Amazon CloudFront":           "Review cache hit rate. Low hit rate = high origin transfer cost.",
+        "Amazon DynamoDB":             "Use on-demand only for spiky workloads; provisioned + auto-scaling is cheaper at steady state.",
+        "AWS Data Transfer":           "Minimize cross-AZ and cross-region traffic. Use VPC endpoints for S3/DynamoDB.",
+        "Amazon Elastic Container":    "Use Fargate Spot for fault-tolerant workloads (up to 70% savings).",
+        "Amazon Elastic Kubernetes":   "Right-size node groups and consider Karpenter for bin packing.",
+        "Amazon Relational Database":  "Use Reserved Instances for steady-state workloads (up to 69% savings).",
+    }
+    for key, rec in recs.items():
+        if key.lower() in service.lower():
+            return rec
+    if amount >= 1000:
+        return f"Review {service} — top spend driver. Explore Reserved/Committed pricing."
+    return f"Review {service} usage. Check for unused resources and tagging."
+
+
+def _fetch_gcp_costs() -> list[Finding]:
+    # List billing accounts and their projects for context
+    cmd = ["gcloud", "billing", "accounts", "list", "--format=json"]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=20)
+    except subprocess.TimeoutExpired:
+        return []
+
+    if result.returncode != 0:
+        stderr = result.stderr.lower()
+        if "not authenticated" in stderr or "credentials" in stderr or "permission" in stderr:
+            print("GCP credentials not configured or missing billing.accounts.list permission.", file=sys.stderr)
+        return []
+
+    try:
+        accounts = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return []
+
+    if not accounts:
+        return []
+
+    findings: list[Finding] = []
+    for account in accounts[:3]:
+        account_id = account.get("name", "").split("/")[-1]
+        display_name = account.get("displayName", account_id)
+        # Billing export via BigQuery is the full path; surface account as INFO for now
+        findings.append(Finding(
+            id=f"GCP-BILLING-{account_id[:20]}",
+            severity="INFO",
+            title=f"GCP billing account: {display_name}",
+            detail=f"Billing account {account_id} found. Detailed spend requires BigQuery billing export.",
+            location=f"gcp://billing/{account_id}",
+            recommendation="Enable BigQuery billing export for per-service cost breakdown. Run `gcloud alpha billing budgets list` to see active budgets.",
+            effort="S",
+        ))
+
+    return findings

--- a/team/forge/scripts/forge_agent/cost_scan.py
+++ b/team/forge/scripts/forge_agent/cost_scan.py
@@ -1,0 +1,93 @@
+"""Main entry point for /forge-cost — orchestrates IaC cost analysis + cloud spend."""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from team.shared.report_schema import AgentReport, ReportMetadata
+from team.forge.scripts.forge_agent.infracost_analyzer import run_infracost, check_infracost
+from team.forge.scripts.forge_agent.cloud_cost_fetcher import run_cloud_cost_fetch
+
+
+def main():
+    parser = argparse.ArgumentParser(description="forge-cost: IaC cost analysis + cloud spend audit")
+    parser.add_argument("target", nargs="?", default=".", help="Path to scan (default: .)")
+    parser.add_argument("--skip-infracost", action="store_true", help="Skip infracost IaC analysis")
+    parser.add_argument("--skip-cloud", action="store_true", help="Skip cloud CLI cost fetch")
+    parser.add_argument("--out", help="Write JSON report to this path")
+    args = parser.parse_args()
+
+    target = os.path.abspath(args.target)
+    if not os.path.exists(target):
+        print(f"Error: target path does not exist: {target}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"💰 Scanning {target}...")
+    start = time.time()
+    findings = []
+
+    if not args.skip_infracost:
+        print("  [1/2] Running infracost IaC analysis...")
+        iac_findings = run_infracost(target)
+        print(f"        {len(iac_findings)} cost findings")
+        findings.extend(iac_findings)
+
+    if not args.skip_cloud:
+        print("  [2/2] Fetching cloud spend (AWS/GCP)...")
+        cloud_findings = run_cloud_cost_fetch(target)
+        print(f"        {len(cloud_findings)} spend findings")
+        findings.extend(cloud_findings)
+
+    duration = round(time.time() - start, 1)
+
+    try:
+        import infracost as _ic
+        ic_ver = getattr(_ic, "__version__", "?")
+    except ImportError:
+        available, ver_str = check_infracost()
+        ic_ver = ver_str.split()[-1] if available and ver_str else "not installed"
+
+    tool_ver = f"infracost {ic_ver}"
+
+    report = AgentReport(
+        agent="forge",
+        skill="forge-cost",
+        target=target,
+        findings=findings,
+        metadata=ReportMetadata(tool_version=tool_ver, duration_s=duration),
+    )
+
+    if args.out:
+        out_path = args.out
+    else:
+        reports_dir = os.path.join(os.getcwd(), ".reports")
+        os.makedirs(reports_dir, exist_ok=True)
+        ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        out_path = os.path.join(reports_dir, f"forge-cost-{ts}.json")
+
+    try:
+        with open(out_path, "w") as f:
+            f.write(report.to_json())
+        print(f"\n✅ Report written: {out_path}")
+    except IOError as e:
+        print(f"\nWarning: could not write report ({e}). Printing to stdout:", file=sys.stderr)
+        print(report.to_json())
+
+    s = report.summary
+    total_cost = sum(
+        float(f.detail.split("$")[1].split("/")[0].split(" ")[0])
+        for f in findings
+        if "$" in f.detail
+    )
+    print(f"\nSummary: {s.critical} critical  {s.high} high  {s.medium} medium  {s.low} low  ({s.total} total)")
+    if total_cost > 0:
+        print(f"Estimated monthly cost in findings: ${total_cost:,.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/team/forge/scripts/forge_agent/infracost_analyzer.py
+++ b/team/forge/scripts/forge_agent/infracost_analyzer.py
@@ -1,0 +1,182 @@
+"""Infracost static IaC cost analyzer — wraps infracost CLI, returns Finding list."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from team.shared.report_schema import Finding
+
+_MONTHLY_SEVERITY = [
+    (1000.0, "CRITICAL"),
+    (100.0,  "HIGH"),
+    (20.0,   "MEDIUM"),
+    (0.01,   "LOW"),
+]
+
+
+def _severity_for_cost(monthly_usd: float) -> str:
+    for threshold, sev in _MONTHLY_SEVERITY:
+        if monthly_usd >= threshold:
+            return sev
+    return "INFO"
+
+
+def check_infracost() -> tuple[bool, str]:
+    """Return (available, version_string)."""
+    try:
+        result = subprocess.run(
+            ["infracost", "--version"],
+            capture_output=True, text=True, timeout=15,
+        )
+        if result.returncode == 0:
+            return True, result.stdout.strip()
+        return False, ""
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False, ""
+
+
+def check_infracost_api_key() -> bool:
+    """Return True if an infracost API key is configured."""
+    if os.environ.get("INFRACOST_API_KEY"):
+        return True
+    try:
+        result = subprocess.run(
+            ["infracost", "configure", "get", "api_key"],
+            capture_output=True, text=True, timeout=10,
+        )
+        output = result.stdout.strip() + result.stderr.strip()
+        return result.returncode == 0 and "No API key" not in output and len(result.stdout.strip()) > 10
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def run_infracost(target_path: str) -> list[Finding]:
+    """
+    Run infracost breakdown on target_path. Returns cost findings.
+    Returns [] with message if infracost not installed or no IaC found.
+    """
+    available, version = check_infracost()
+    if not available:
+        print(
+            "infracost not installed. Install: https://www.infracost.io/docs/",
+            file=sys.stderr,
+        )
+        return []
+
+    # infracost breakdown scans for Terraform/OpenTofu configs
+    cmd = [
+        "infracost", "breakdown",
+        "--path", target_path,
+        "--format", "json",
+        "--no-color",
+    ]
+
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=180,
+        )
+    except subprocess.TimeoutExpired:
+        print("infracost timed out after 180s.", file=sys.stderr)
+        return []
+
+    if result.returncode != 0:
+        stderr_lower = result.stderr.lower()
+        if "no terraform" in stderr_lower or "no supported" in stderr_lower or "no resource" in stderr_lower:
+            return []
+        if "api_key" in stderr_lower or "infracost_api_key" in stderr_lower:
+            print(
+                "infracost API key not configured. Get a free key at https://dashboard.infracost.io "
+                "then run: infracost configure set api_key <key>",
+                file=sys.stderr,
+            )
+            return []
+        print(f"infracost error: {result.stderr[:400]}", file=sys.stderr)
+        return []
+
+    raw = result.stdout.strip()
+    if not raw:
+        return []
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        print("infracost returned invalid JSON.", file=sys.stderr)
+        return []
+
+    return _parse_infracost_output(data, target_path)
+
+
+def _parse_infracost_output(data: dict, target_path: str) -> list[Finding]:
+    findings: list[Finding] = []
+
+    for project in data.get("projects", []):
+        breakdown = project.get("breakdown", {})
+        for resource in breakdown.get("resources", []):
+            name = resource.get("name", "unknown")
+            resource_type = name.split(".")[0] if "." in name else name
+            monthly = float(resource.get("monthlyCost") or 0)
+
+            if monthly < 0.01:
+                continue
+
+            severity = _severity_for_cost(monthly)
+
+            # surface cost components as context
+            components = resource.get("costComponents", [])
+            detail_parts = [
+                f"{c['name']}: ${float(c.get('monthlyCost') or 0):.2f}/mo"
+                for c in components[:3]
+                if float(c.get("monthlyCost") or 0) > 0
+            ]
+            detail = f"${monthly:.2f}/month. " + (", ".join(detail_parts) if detail_parts else "")
+
+            recommendation = _recommendation_for_resource(resource_type, monthly, resource)
+
+            tf_file = resource.get("filePath", target_path)
+            tf_line = resource.get("startLine", 0)
+            location = f"{tf_file}:{tf_line}" if tf_line else tf_file
+
+            findings.append(Finding(
+                id=f"COST-{resource_type.upper()}",
+                severity=severity,
+                title=f"High cost: {name}",
+                detail=detail,
+                location=location,
+                recommendation=recommendation,
+                effort=_effort_for_recommendation(recommendation),
+            ))
+
+    return findings
+
+
+def _recommendation_for_resource(resource_type: str, monthly: float, resource: dict) -> str:
+    recs: dict[str, str] = {
+        "aws_instance":               "Right-size or switch to Reserved/Savings Plan (up to 72% savings).",
+        "aws_db_instance":            "Use Reserved Instance for RDS (up to 69% savings). Consider Aurora Serverless for variable workloads.",
+        "aws_rds_cluster":            "Evaluate Aurora Serverless v2 for variable workloads.",
+        "aws_elasticsearch_domain":   "Right-size data nodes; consider OpenSearch Serverless.",
+        "aws_opensearch_domain":      "Right-size data nodes; consider OpenSearch Serverless.",
+        "aws_nat_gateway":            "Consolidate NAT gateways across AZs if multi-AZ is not required.",
+        "aws_lb":                     "Remove unused load balancers or consolidate behind a single ALB.",
+        "aws_cloudfront_distribution":"Review cache behavior — low hit rate inflates origin transfer costs.",
+        "google_compute_instance":    "Right-size or commit to 1-year CUD (up to 57% savings).",
+        "google_sql_database_instance":"Use committed use discounts or consider Cloud Spanner for scale.",
+        "azurerm_virtual_machine":    "Right-size or switch to Reserved Instance (up to 72% savings).",
+    }
+    if resource_type in recs:
+        return recs[resource_type]
+    if monthly >= 100:
+        return f"Review {resource_type} sizing and consider Reserved/Committed-use pricing."
+    return f"Tag {resource_type} for cost allocation and review utilization."
+
+
+def _effort_for_recommendation(rec: str) -> str:
+    if "Reserved" in rec or "Savings Plan" in rec or "CUD" in rec:
+        return "S"
+    if "Right-size" in rec or "Serverless" in rec:
+        return "M"
+    return "S"

--- a/team/forge/scripts/pyproject.toml
+++ b/team/forge/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "forge"
-version = "0.9.7"
+version = "0.9.8"
 description = "Infrastructure engineer — cloud services, networking, IaC, cost optimization"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/forge/skills/forge-cost/SKILL.md
+++ b/team/forge/skills/forge-cost/SKILL.md
@@ -2,7 +2,7 @@
 name: forge-cost
 description: Audit cloud infrastructure costs and produce a concrete optimization plan with specific changes and estimated savings. Use when asked to "how much is this costing", "reduce cloud spend", "cost optimization", "are we overpaying", "cloud bill", or "budget for this infra".
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
-version: 0.6.4
+version: 0.9.8
 author: tonone-ai <hello@tonone.ai>
 license: MIT
 ---
@@ -17,7 +17,30 @@ Follow the output format defined in docs/output-kit.md — 40-line CLI max, box-
 
 ## Steps
 
-### Step 0: Read Everything
+### Step 0: Run Automated Scanners
+
+Run the real cost scanners first. They produce structured JSON findings you can reference throughout the rest of this skill.
+
+```bash
+# Find the cost_scan.py entry point
+find . -path "*/forge_agent/cost_scan.py" -not -path "*/__pycache__/*" 2>/dev/null | head -1
+```
+
+If found, run it:
+
+```bash
+python <path-to-cost_scan.py> <target> --out .reports/forge-cost-latest.json
+```
+
+This runs:
+1. **infracost** — static IaC cost analysis (Terraform/OpenTofu). Requires `infracost` CLI + API key.
+2. **AWS Cost Explorer** / **GCP Billing** — actual cloud spend via `aws ce` or `gcloud billing`.
+
+If infracost is not installed or has no API key, the script prints a setup message and continues. If no cloud CLIs are configured, it continues without spend data.
+
+Read the JSON report if written. Use its findings as ground truth for Steps 2-5 below. If the scanner found 0 findings (no IaC, no cloud CLI), proceed with manual analysis from Step 1.
+
+### Step 1: Read Everything
 
 Scan for all IaC and cloud configuration:
 

--- a/team/forge/tests/fixtures/terraform_sample/main.tf
+++ b/team/forge/tests/fixtures/terraform_sample/main.tf
@@ -1,0 +1,43 @@
+# FIXTURE FILE — intentionally expensive Terraform for Forge cost tests.
+# DO NOT deploy this configuration.
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+# Expensive on-demand instance — should trigger HIGH/CRITICAL cost finding
+resource "aws_instance" "web" {
+  ami           = "ami-0c55b159cbfafe1f0"
+  instance_type = "m5.4xlarge"
+
+  tags = {
+    Name = "web-server"
+  }
+}
+
+# RDS without reserved pricing — HIGH cost finding
+resource "aws_db_instance" "main" {
+  identifier        = "main-db"
+  engine            = "postgres"
+  engine_version    = "15.4"
+  instance_class    = "db.r6g.xlarge"
+  allocated_storage = 100
+  username          = "admin"
+  password          = "placeholder"
+  skip_final_snapshot = true
+}
+
+# NAT gateway — steady per-hour cost
+resource "aws_nat_gateway" "main" {
+  allocation_id = "eipalloc-placeholder"
+  subnet_id     = "subnet-placeholder"
+}

--- a/team/forge/tests/test_forge_cost.py
+++ b/team/forge/tests/test_forge_cost.py
@@ -1,0 +1,189 @@
+"""Tests for forge-cost: infracost_analyzer + cloud_cost_fetcher + report_schema."""
+
+import json
+import os
+import sys
+import pytest
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+sys.path.insert(0, ROOT)
+
+from team.shared.report_schema import AgentReport, Finding, ReportMetadata
+from team.forge.scripts.forge_agent.infracost_analyzer import run_infracost, check_infracost, check_infracost_api_key, _severity_for_cost
+from team.forge.scripts.forge_agent.cloud_cost_fetcher import run_cloud_cost_fetch, _severity_for_spend
+
+FIXTURE_DIR = os.path.join(os.path.dirname(__file__), "fixtures/terraform_sample")
+
+
+class TestSeverityMapping:
+    def test_infracost_critical(self):
+        assert _severity_for_cost(1500.0) == "CRITICAL"
+
+    def test_infracost_high(self):
+        assert _severity_for_cost(200.0) == "HIGH"
+
+    def test_infracost_medium(self):
+        assert _severity_for_cost(25.0) == "MEDIUM"
+
+    def test_infracost_low(self):
+        assert _severity_for_cost(5.0) == "LOW"
+
+    def test_infracost_info(self):
+        assert _severity_for_cost(0.0) == "INFO"
+
+    def test_spend_critical(self):
+        assert _severity_for_spend(6000.0) == "CRITICAL"
+
+    def test_spend_high(self):
+        assert _severity_for_spend(1500.0) == "HIGH"
+
+    def test_spend_medium(self):
+        assert _severity_for_spend(300.0) == "MEDIUM"
+
+
+_infracost_ready = pytest.mark.skipif(
+    not check_infracost()[0] or not check_infracost_api_key(),
+    reason="infracost not installed or API key not configured (https://dashboard.infracost.io)",
+)
+
+
+class TestInfracostAnalyzer:
+    def test_infracost_available(self):
+        available, version = check_infracost()
+        assert available, "infracost must be installed (https://www.infracost.io/docs/)"
+
+    @_infracost_ready
+    def test_fixture_has_findings(self):
+        findings = run_infracost(FIXTURE_DIR)
+        assert len(findings) >= 1, (
+            f"Expected ≥1 cost finding in fixtures/terraform_sample/, got 0. "
+            f"Check that main.tf contains detectable resources."
+        )
+
+    @_infracost_ready
+    def test_findings_have_required_fields(self):
+        findings = run_infracost(FIXTURE_DIR)
+        for f in findings:
+            assert f.severity in {"CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"}
+            assert f.title
+            assert f.recommendation
+            assert "$" in f.detail
+
+    @_infracost_ready
+    def test_empty_dir_returns_empty(self, tmp_path):
+        findings = run_infracost(str(tmp_path))
+        assert isinstance(findings, list)
+
+
+class TestInfracostErrorPaths:
+    def test_not_installed(self, monkeypatch):
+        import subprocess
+        def mock_run(*args, **kwargs):
+            raise FileNotFoundError("infracost not found")
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        findings = run_infracost("/tmp")
+        assert findings == []
+
+    def test_timeout(self, monkeypatch):
+        import subprocess
+        call_count = {"n": 0}
+        def mock_run(cmd, *args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                class R:
+                    returncode = 0
+                    stdout = "infracost v0.10.0"
+                return R()
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=180)
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        findings = run_infracost("/tmp")
+        assert findings == []
+
+    def test_invalid_json(self, monkeypatch):
+        import subprocess
+        call_count = {"n": 0}
+        def mock_run(cmd, *args, **kwargs):
+            call_count["n"] += 1
+            class R:
+                returncode = 0
+                stdout = "infracost v0.10.0" if call_count["n"] == 1 else "not-json{"
+                stderr = ""
+            return R()
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        findings = run_infracost("/tmp")
+        assert findings == []
+
+    def test_nonzero_exit_no_terraform(self, monkeypatch):
+        import subprocess
+        call_count = {"n": 0}
+        def mock_run(cmd, *args, **kwargs):
+            call_count["n"] += 1
+            class R:
+                returncode = 0 if call_count["n"] == 1 else 1
+                stdout = "infracost v0.10.0" if call_count["n"] == 1 else ""
+                stderr = "No Terraform files found"
+            return R()
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        findings = run_infracost("/tmp")
+        assert findings == []
+
+
+class TestCloudCostFetcher:
+    def test_returns_list(self):
+        # may return [] if no cloud CLIs configured — that's fine
+        findings = run_cloud_cost_fetch(os.getcwd())
+        assert isinstance(findings, list)
+
+    def test_finding_structure(self):
+        findings = run_cloud_cost_fetch(os.getcwd())
+        for f in findings:
+            assert f.severity in {"CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"}
+            assert f.title
+            assert f.location
+
+    def test_aws_not_installed(self, monkeypatch):
+        import subprocess
+        def mock_run(cmd, *args, **kwargs):
+            raise FileNotFoundError("aws not found")
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        findings = run_cloud_cost_fetch("/tmp")
+        assert findings == []
+
+    def test_aws_no_credentials(self, monkeypatch):
+        import subprocess
+        call_count = {"n": 0}
+        def mock_run(cmd, *args, **kwargs):
+            call_count["n"] += 1
+            class R:
+                returncode = 0 if "version" in cmd else 254
+                stdout = "aws-cli/2.0" if "version" in cmd else ""
+                stderr = "" if "version" in cmd else "Unable to locate credentials"
+            return R()
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        findings = run_cloud_cost_fetch("/tmp")
+        assert isinstance(findings, list)
+
+    def test_aws_invalid_json(self, monkeypatch):
+        import subprocess
+        def mock_run(cmd, *args, **kwargs):
+            class R:
+                returncode = 0
+                stdout = "aws-cli/2.0" if "--version" in cmd else "not-json{"
+                stderr = ""
+            return R()
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        findings = run_cloud_cost_fetch("/tmp")
+        assert isinstance(findings, list)
+
+
+class TestCostScanCLI:
+    def test_nonexistent_target_exits(self):
+        import subprocess
+        result = subprocess.run(
+            [sys.executable,
+             os.path.join(ROOT, "team/forge/scripts/forge_agent/cost_scan.py"),
+             "/nonexistent/path/does/not/exist"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 1
+        assert "does not exist" in result.stderr

--- a/team/shared/report_schema.py
+++ b/team/shared/report_schema.py
@@ -1,0 +1,92 @@
+"""Shared report schema for all tonone deep agents."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from typing import Optional
+
+SCHEMA_VERSION = "1.0"
+
+
+@dataclass
+class Finding:
+    severity: str          # CRITICAL | HIGH | MEDIUM | LOW | INFO
+    title: str
+    detail: str
+    location: str          # file:line, table.column, resource type, etc.
+    recommendation: str
+    effort: str            # S | M | L
+    id: Optional[str] = None   # CVE-ID, rule ID, etc.
+
+    def __post_init__(self):
+        valid = {"CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"}
+        if self.severity not in valid:
+            raise ValueError(f"severity must be one of {valid}")
+        valid_effort = {"S", "M", "L"}
+        if self.effort not in valid_effort:
+            raise ValueError(f"effort must be one of {valid_effort}")
+
+
+@dataclass
+class Summary:
+    critical: int = 0
+    high: int = 0
+    medium: int = 0
+    low: int = 0
+    info: int = 0
+
+    @property
+    def total(self) -> int:
+        return self.critical + self.high + self.medium + self.low + self.info
+
+
+@dataclass
+class ReportMetadata:
+    tool_version: str
+    duration_s: float
+    schema_version: str = SCHEMA_VERSION
+
+
+@dataclass
+class AgentReport:
+    agent: str
+    skill: str
+    target: str
+    findings: list[Finding] = field(default_factory=list)
+    timestamp: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    metadata: Optional[ReportMetadata] = None
+
+    @property
+    def summary(self) -> Summary:
+        s = Summary()
+        for f in self.findings:
+            match f.severity:
+                case "CRITICAL": s.critical += 1
+                case "HIGH":     s.high += 1
+                case "MEDIUM":   s.medium += 1
+                case "LOW":      s.low += 1
+                case "INFO":     s.info += 1
+        return s
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["summary"] = asdict(self.summary)
+        return d
+
+    def to_json(self, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "AgentReport":
+        findings = [Finding(**f) for f in d.get("findings", [])]
+        metadata = ReportMetadata(**d["metadata"]) if d.get("metadata") else None
+        return cls(
+            agent=d["agent"],
+            skill=d["skill"],
+            target=d["target"],
+            findings=findings,
+            timestamp=d.get("timestamp", ""),
+            metadata=metadata,
+        )


### PR DESCRIPTION
## Summary

**Forge depth layer** — second of 5 killer agents. Replaces prompt-only cost estimation with real tooling.

**Infrastructure**
- `team/shared/report_schema.py` (copy from warden-depth) — shared `Finding`/`AgentReport` schema; will deduplicate once warden-depth merges
- `infracost_analyzer.py` — wraps infracost CLI, parses Terraform/OpenTofu resources, maps monthly cost to `Finding` severity: CRITICAL (>$1000/mo), HIGH (>$100/mo), MEDIUM (>$20/mo), LOW (>$0.01/mo)
- `cloud_cost_fetcher.py` — queries AWS Cost Explorer (`aws ce get-cost-and-usage`) for actual spend grouped by service; GCP billing account discovery; graceful credential-not-configured handling
- `cost_scan.py` — CLI entry point, orchestrates both scanners, writes `.reports/forge-cost-<ts>.json`

**Skill update**
- `/forge-cost` now runs automated scanners as Step 0 before manual IaC analysis

**Terraform fixture**
- `tests/fixtures/terraform_sample/main.tf` — m5.4xlarge + RDS r6g.xlarge + NAT gateway for integration testing

## Test Coverage

```
Tests: 22 total (19 pass, 3 skip)
Skipped: infracost API key not configured (integration tests gate on real credentials)

Severity mapping (8 tests)
Infracost error paths (4 tests): FileNotFoundError, TimeoutExpired, invalid JSON, no TF files
Cloud cost fetcher (5 tests): not installed, no credentials, invalid JSON
CLI entry point (1 test): nonexistent target exits 1
Integration tests (3 skipped): fixture has findings, required fields, empty dir
```

## Notes

- Depends on `team/shared/report_schema.py` — currently duplicated from warden-depth. Will collapse to single copy once warden-depth merges.
- infracost requires free API key: `infracost configure set api_key <key>` (https://dashboard.infracost.io)
- AWS cost fetch requires `ce:GetCostAndUsage` IAM permission

## Test plan
- [x] 19/22 tests pass (3 skip — expected, require infracost API key)
- [x] Error paths: tool not installed, timeout, invalid JSON, missing credentials
- [x] CLI rejects nonexistent target with exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)