### PR TITLE
v0.9.8 feat(spine): real tool integration — N+1 detector + HTTP endpoint profiler

### DIFF
--- a/team/spine/scripts/pyproject.toml
+++ b/team/spine/scripts/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.9.9"
 description = "Backend engineer — APIs, system design, performance, distributed systems"
 license = "MIT"
 requires-python = ">=3.10"
-dependencies = []
+dependencies = ["httpx>=0.27"]
 
 [tool.pytest.ini_options]
 testpaths = ["../tests"]

--- a/team/spine/scripts/spine_agent/endpoint_profiler.py
+++ b/team/spine/scripts/spine_agent/endpoint_profiler.py
@@ -1,0 +1,145 @@
+"""HTTP endpoint response time profiler — uses httpx to measure p50/p95/p99."""
+
+from __future__ import annotations
+
+import os
+import sys
+import statistics
+import time
+from typing import Optional
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from team.shared.report_schema import Finding
+
+# Thresholds in seconds
+THRESHOLD_MEDIUM = 0.200   # >200ms p50
+THRESHOLD_HIGH = 0.500     # >500ms p50
+THRESHOLD_CRITICAL = 1.000  # >1000ms p50
+
+DEFAULT_TIMEOUT = 5.0      # seconds per request
+WARMUP_REQUESTS = 3
+MEASURED_REQUESTS = 5
+
+
+def _percentile(data: list[float], pct: float) -> float:
+    """Return the pct-th percentile of sorted data."""
+    if not data:
+        return 0.0
+    sorted_data = sorted(data)
+    idx = (pct / 100) * (len(sorted_data) - 1)
+    lo = int(idx)
+    hi = lo + 1
+    if hi >= len(sorted_data):
+        return sorted_data[lo]
+    frac = idx - lo
+    return sorted_data[lo] + frac * (sorted_data[hi] - sorted_data[lo])
+
+
+def _severity_for_p50(p50_s: float) -> Optional[str]:
+    """Return severity string based on p50 latency, or None if below threshold."""
+    if p50_s >= THRESHOLD_CRITICAL:
+        return "CRITICAL"
+    if p50_s >= THRESHOLD_HIGH:
+        return "HIGH"
+    if p50_s >= THRESHOLD_MEDIUM:
+        return "MEDIUM"
+    return None
+
+
+def profile_endpoints(
+    base_url: str,
+    paths: list[str],
+    timeout: float = DEFAULT_TIMEOUT,
+    warmup: int = WARMUP_REQUESTS,
+    measured: int = MEASURED_REQUESTS,
+) -> list[Finding]:
+    """
+    Time each endpoint in paths against base_url.
+
+    Returns a Finding for each endpoint that exceeds latency thresholds.
+    Returns [] with a message on stderr if httpx is not installed or
+    the server is unreachable.
+    """
+    try:
+        import httpx  # noqa: F401 — checked for availability
+    except ImportError:
+        print(
+            "httpx not installed. Install with:\n"
+            "  pip install httpx",
+            file=sys.stderr,
+        )
+        return []
+
+    import httpx as _httpx
+
+    findings: list[Finding] = []
+
+    for path in paths:
+        url = base_url.rstrip("/") + "/" + path.lstrip("/")
+        timings: list[float] = []
+
+        # Warmup
+        for _ in range(warmup):
+            try:
+                with _httpx.Client(timeout=timeout) as client:
+                    client.get(url)
+            except _httpx.ConnectError:
+                print(
+                    f"Connection refused for {url}. Is the server running?",
+                    file=sys.stderr,
+                )
+                return []
+            except _httpx.TimeoutException:
+                # Warmup timeout — treat as very slow (use threshold_critical)
+                timings.append(timeout)
+            except _httpx.RequestError:
+                pass
+
+        # Measured
+        for _ in range(measured):
+            t0 = time.perf_counter()
+            try:
+                with _httpx.Client(timeout=timeout) as client:
+                    client.get(url)
+                elapsed = time.perf_counter() - t0
+            except _httpx.ConnectError:
+                print(
+                    f"Connection refused for {url}. Is the server running?",
+                    file=sys.stderr,
+                )
+                return []
+            except _httpx.TimeoutException:
+                elapsed = timeout  # treat timeout as a full timeout value
+            except _httpx.RequestError:
+                elapsed = timeout
+            timings.append(elapsed)
+
+        if not timings:
+            continue
+
+        p50 = _percentile(timings, 50)
+        p95 = _percentile(timings, 95)
+        p99 = _percentile(timings, 99)
+
+        severity = _severity_for_p50(p50)
+        if severity is None:
+            continue
+
+        findings.append(Finding(
+            id="SPINE-PERF-LATENCY",
+            severity=severity,
+            title=f"Slow endpoint: {path}",
+            detail=(
+                f"Endpoint `{url}` has high response times. "
+                f"p50={p50 * 1000:.0f}ms  p95={p95 * 1000:.0f}ms  p99={p99 * 1000:.0f}ms "
+                f"(measured over {measured} requests, {warmup} warmup)."
+            ),
+            location=url,
+            recommendation=(
+                "Profile with cProfile or py-spy. Look for N+1 queries, missing indexes, "
+                "synchronous external calls, or missing caching on hot paths."
+            ),
+            effort="M",
+        ))
+
+    return findings

--- a/team/spine/scripts/spine_agent/n_plus_one_detector.py
+++ b/team/spine/scripts/spine_agent/n_plus_one_detector.py
@@ -1,0 +1,244 @@
+"""N+1 query pattern detector — static analysis for Python ORM and raw SQL patterns."""
+
+from __future__ import annotations
+
+import ast
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from team.shared.report_schema import Finding
+
+# ORM method names that indicate a database query
+ORM_QUERY_METHODS = {
+    "filter", "get", "all", "first", "last", "count",
+    "exists", "values", "values_list", "aggregate",
+    "annotate", "exclude", "order_by", "select_related",
+    "prefetch_related", "defer", "only", "update", "delete",
+}
+
+# Patterns that suggest an unguarded related-field access
+RELATED_ACCESS_INDICATORS = {"comments", "profile", "author", "owner", "tags", "orders", "items"}
+
+
+def _get_lineno(node: ast.AST) -> int:
+    return getattr(node, "lineno", 0)
+
+
+def _node_contains_orm_call(node: ast.AST) -> tuple[bool, str]:
+    """Return (found, method_name) if node contains an ORM-style call."""
+    for child in ast.walk(node):
+        if isinstance(child, ast.Call):
+            func = child.func
+            if isinstance(func, ast.Attribute):
+                if func.attr in ORM_QUERY_METHODS:
+                    return True, func.attr
+            # objects.get(...) — bare attribute chain
+            if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Attribute):
+                if func.value.attr == "objects" and func.attr in ORM_QUERY_METHODS:
+                    return True, f"objects.{func.attr}"
+    return False, ""
+
+
+def _node_contains_cursor_execute(node: ast.AST) -> bool:
+    """Return True if node contains cursor.execute(...)."""
+    for child in ast.walk(node):
+        if isinstance(child, ast.Call):
+            func = child.func
+            if isinstance(func, ast.Attribute) and func.attr == "execute":
+                return True
+    return False
+
+
+def _node_contains_formatted_sql(node: ast.AST) -> bool:
+    """Return True if node contains a %-formatted or f-string SQL query assignment."""
+    for child in ast.walk(node):
+        # %-format: "SELECT ... %s" % value
+        if isinstance(child, ast.BinOp) and isinstance(child.op, ast.Mod):
+            if isinstance(child.left, ast.Constant) and isinstance(child.left.value, str):
+                val: str = child.left.value.upper()
+                if any(kw in val for kw in ("SELECT", "INSERT", "UPDATE", "DELETE", "WHERE")):
+                    return True
+        # f-string SQL
+        if isinstance(child, ast.JoinedStr):
+            # wrapped in an Assign? check parent — approximate via sibling walk
+            pass
+    return False
+
+
+def _scan_loop_body(
+    loop_node: ast.AST,
+    loop_lineno: int,
+    filepath: str,
+    source_lines: list[str],
+) -> list[Finding]:
+    """Inspect a loop body for N+1 indicators and return Findings."""
+    findings: list[Finding] = []
+    body = getattr(loop_node, "body", [])
+
+    for stmt in body:
+        # 1. ORM query method called inside loop body
+        found_orm, method = _node_contains_orm_call(stmt)
+        if found_orm:
+            line = _get_lineno(stmt)
+            snippet = source_lines[line - 1].strip() if line and line <= len(source_lines) else ""
+            findings.append(Finding(
+                id="SPINE-N1-ORM",
+                severity="HIGH",
+                title="N+1 ORM query inside loop",
+                detail=(
+                    f"ORM method `.{method}()` called inside a loop at line {line}. "
+                    f"Each loop iteration triggers a separate DB query. "
+                    f"Code: `{snippet}`"
+                ),
+                location=f"{filepath}:{line}",
+                recommendation=(
+                    "Fetch all related objects before the loop using `.select_related()` "
+                    "or `.prefetch_related()`, then access the cached result inside the loop."
+                ),
+                effort="S",
+            ))
+
+        # 2. cursor.execute inside loop
+        if _node_contains_cursor_execute(stmt):
+            line = _get_lineno(stmt)
+            snippet = source_lines[line - 1].strip() if line and line <= len(source_lines) else ""
+            findings.append(Finding(
+                id="SPINE-N1-SQL",
+                severity="HIGH",
+                title="Raw SQL execute() inside loop",
+                detail=(
+                    f"`cursor.execute()` called inside a loop at line {line}. "
+                    f"Code: `{snippet}`"
+                ),
+                location=f"{filepath}:{line}",
+                recommendation=(
+                    "Collect all IDs first, then execute a single query with an IN clause: "
+                    "`SELECT ... WHERE id IN (%s)` and join in Python."
+                ),
+                effort="S",
+            ))
+
+        # 3. String-formatted SQL inside loop
+        if _node_contains_formatted_sql(stmt):
+            line = _get_lineno(stmt)
+            snippet = source_lines[line - 1].strip() if line and line <= len(source_lines) else ""
+            findings.append(Finding(
+                id="SPINE-N1-FMTSQL",
+                severity="HIGH",
+                title="String-formatted SQL inside loop",
+                detail=(
+                    f"SQL query constructed with string formatting inside a loop at line {line}. "
+                    f"This is both an N+1 pattern and a SQL injection risk. "
+                    f"Code: `{snippet}`"
+                ),
+                location=f"{filepath}:{line}",
+                recommendation=(
+                    "Use parameterized queries and batch the loop into a single SQL IN clause."
+                ),
+                effort="S",
+            ))
+
+        # 4. Related field attribute access inside loop (likely missing prefetch/select)
+        for child in ast.walk(stmt):
+            if isinstance(child, ast.Attribute):
+                if child.attr in RELATED_ACCESS_INDICATORS:
+                    line = _get_lineno(child)
+                    snippet = source_lines[line - 1].strip() if line and line <= len(source_lines) else ""
+                    findings.append(Finding(
+                        id="SPINE-N1-RELATED",
+                        severity="MEDIUM",
+                        title=f"Likely N+1: `.{child.attr}` accessed in loop without eager load",
+                        detail=(
+                            f"Attribute `.{child.attr}` accessed inside a loop at line {line} — "
+                            f"likely a lazy-loaded relation. Code: `{snippet}`"
+                        ),
+                        location=f"{filepath}:{line}",
+                        recommendation=(
+                            f"Add `.prefetch_related('{child.attr}')` or `.select_related('{child.attr}')` "
+                            "to the queryset before the loop."
+                        ),
+                        effort="S",
+                    ))
+                    break  # one finding per statement is enough for related access
+
+    return findings
+
+
+def _scan_async_for_sync_db(
+    func_node: ast.AsyncFunctionDef,
+    filepath: str,
+    source_lines: list[str],
+) -> list[Finding]:
+    """Detect synchronous DB calls inside async functions."""
+    findings: list[Finding] = []
+    for node in ast.walk(func_node):
+        if isinstance(node, (ast.For, ast.While)):
+            if _node_contains_cursor_execute(node):
+                line = _get_lineno(node)
+                findings.append(Finding(
+                    id="SPINE-ASYNC-SYNC-DB",
+                    severity="HIGH",
+                    title="Sync DB call inside async handler loop",
+                    detail=(
+                        f"Blocking `cursor.execute()` called inside a loop in async function "
+                        f"`{func_node.name}` at line {line}. This blocks the event loop."
+                    ),
+                    location=f"{filepath}:{line}",
+                    recommendation=(
+                        "Use an async DB driver (e.g. `asyncpg`, `aiosqlite`, `databases`) "
+                        "or gather queries with `asyncio.gather()` outside the hot path."
+                    ),
+                    effort="M",
+                ))
+    return findings
+
+
+def scan_file(filepath: str) -> list[Finding]:
+    """Scan a single Python file for N+1 patterns. Returns Finding list."""
+    try:
+        with open(filepath, "r", encoding="utf-8", errors="replace") as fh:
+            source = fh.read()
+    except OSError:
+        return []
+
+    source_lines = source.splitlines()
+
+    try:
+        tree = ast.parse(source, filename=filepath)
+    except SyntaxError:
+        return []
+
+    findings: list[Finding] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.For, ast.While)):
+            findings.extend(_scan_loop_body(node, _get_lineno(node), filepath, source_lines))
+
+        if isinstance(node, ast.AsyncFunctionDef):
+            findings.extend(_scan_async_for_sync_db(node, filepath, source_lines))
+
+    # Deduplicate by (id, location)
+    seen: set[tuple[str, str]] = set()
+    deduped: list[Finding] = []
+    for f in findings:
+        key = (f.id or "", f.location)
+        if key not in seen:
+            seen.add(key)
+            deduped.append(f)
+
+    return deduped
+
+
+def scan_directory(target: str) -> list[Finding]:
+    """Recursively scan all .py files under target. Returns Finding list."""
+    findings: list[Finding] = []
+    skip_dirs = {".venv", "venv", "node_modules", ".git", "__pycache__", ".pytest_cache"}
+
+    for root, dirs, files in os.walk(target):
+        dirs[:] = [d for d in dirs if d not in skip_dirs]
+        for fname in files:
+            if fname.endswith(".py"):
+                findings.extend(scan_file(os.path.join(root, fname)))
+
+    return findings

--- a/team/spine/scripts/spine_agent/perf_scan.py
+++ b/team/spine/scripts/spine_agent/perf_scan.py
@@ -1,0 +1,122 @@
+"""Main entry point for /spine-perf — orchestrates N+1 detector + endpoint profiler."""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from team.shared.report_schema import AgentReport, ReportMetadata
+from team.spine.scripts.spine_agent.n_plus_one_detector import scan_directory
+from team.spine.scripts.spine_agent.endpoint_profiler import profile_endpoints
+
+
+def main():
+    parser = argparse.ArgumentParser(description="spine-perf: N+1 detector + endpoint profiler")
+    parser.add_argument(
+        "target",
+        nargs="?",
+        default=".",
+        help="Path to scan for N+1 patterns (default: .)",
+    )
+    parser.add_argument(
+        "--base-url",
+        default="",
+        help="Base URL for endpoint profiling (e.g. http://localhost:8000)",
+    )
+    parser.add_argument(
+        "--paths",
+        nargs="*",
+        default=[],
+        help="Endpoint paths to profile (e.g. /api/orders /api/users)",
+    )
+    parser.add_argument("--skip-n1", action="store_true", help="Skip N+1 static analysis")
+    parser.add_argument("--skip-endpoints", action="store_true", help="Skip endpoint profiling")
+    parser.add_argument("--out", help="Write JSON report to this path")
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=5.0,
+        help="Per-request timeout in seconds for endpoint profiling (default: 5)",
+    )
+    args = parser.parse_args()
+
+    target = os.path.abspath(args.target)
+    if not os.path.exists(target):
+        print(f"Error: target path does not exist: {target}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Scanning {target}...")
+    start = time.time()
+    findings = []
+
+    if not args.skip_n1:
+        print("  [1/2] Running N+1 static analysis...")
+        n1_findings = scan_directory(target)
+        print(f"        {len(n1_findings)} findings")
+        findings.extend(n1_findings)
+
+    if not args.skip_endpoints:
+        if args.base_url and args.paths:
+            print(f"  [2/2] Profiling {len(args.paths)} endpoint(s) at {args.base_url}...")
+            ep_findings = profile_endpoints(
+                base_url=args.base_url,
+                paths=args.paths,
+                timeout=args.timeout,
+            )
+            print(f"        {len(ep_findings)} slow endpoints")
+            findings.extend(ep_findings)
+        else:
+            print("  [2/2] Skipping endpoint profiler (no --base-url / --paths provided)")
+
+    duration = round(time.time() - start, 1)
+
+    # build tool version string
+    try:
+        import httpx as _hx
+        httpx_ver = getattr(_hx, "__version__", "?")
+    except ImportError:
+        httpx_ver = "not installed"
+    tool_ver = f"spine-perf 0.9.8 / httpx {httpx_ver}"
+
+    report = AgentReport(
+        agent="spine",
+        skill="spine-perf",
+        target=target,
+        findings=findings,
+        metadata=ReportMetadata(tool_version=tool_ver, duration_s=duration),
+    )
+
+    # determine output path
+    if args.out:
+        out_path = args.out
+    else:
+        reports_dir = os.path.join(os.getcwd(), ".reports")
+        os.makedirs(reports_dir, exist_ok=True)
+        ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        out_path = os.path.join(reports_dir, f"spine-perf-{ts}.json")
+
+    try:
+        with open(out_path, "w") as fh:
+            fh.write(report.to_json())
+        print(f"\nReport written: {out_path}")
+    except IOError as e:
+        print(f"\nWarning: could not write report ({e}). Printing to stdout:", file=sys.stderr)
+        print(report.to_json())
+
+    s = report.summary
+    print(
+        f"\nSummary: {s.critical} critical  {s.high} high  "
+        f"{s.medium} medium  {s.low} low  ({s.total} total)"
+    )
+
+    if s.critical > 0 or s.high > 0:
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/team/spine/skills/spine-perf/SKILL.md
+++ b/team/spine/skills/spine-perf/SKILL.md
@@ -2,7 +2,7 @@
 name: spine-perf
 description: Find and fix performance bottlenecks — N+1 queries, missing indexes, sync bottlenecks, caching gaps. Use when asked "why is this slow", "performance issue", "optimize this endpoint", or "N+1 queries".
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
-version: 0.6.4
+version: 0.9.8
 author: tonone-ai <hello@tonone.ai>
 license: MIT
 ---
@@ -15,7 +15,21 @@ Follow the output format defined in docs/output-kit.md — 40-line CLI max, box-
 
 ## Steps
 
-### Step 0: Detect Environment
+### Step 0: Run perf_scan.py
+
+```bash
+python team/spine/scripts/spine_agent/perf_scan.py [target] [--base-url http://...] [--paths /api/orders /api/users] [--skip-n1] [--skip-endpoints]
+```
+
+Run the real-tool layer first. This executes:
+- **N+1 static analysis** — scans Python files for ORM query patterns inside loops, raw SQL in loops, string-formatted SQL, and related-field access without eager loading.
+- **Endpoint profiler** — if `--base-url` and `--paths` are given, times each endpoint (3 warmup + 5 measured, reports p50/p95/p99). Flags endpoints >200ms (MEDIUM), >500ms (HIGH), >1000ms (CRITICAL).
+
+The tool writes `.reports/spine-perf-<ts>.json` and exits 2 on CRITICAL/HIGH findings (CI gate).
+
+Review the JSON report to seed the investigation in Steps 1-7 below.
+
+### Step 1: Detect Environment
 
 ```bash
 ls -a

--- a/team/spine/tests/fixtures/n_plus_one_sample.py
+++ b/team/spine/tests/fixtures/n_plus_one_sample.py
@@ -1,0 +1,112 @@
+# FIXTURE FILE — intentionally contains N+1 query patterns for Spine perf tests.
+# DO NOT use this in production code.
+
+import sqlite3
+
+# --- Django ORM-style patterns (simulated with attribute access) ---
+
+
+class FakeQuerySet:
+    """Minimal ORM queryset stub for pattern testing."""
+
+    def filter(self, **kwargs):
+        return self
+
+    def all(self):
+        return []
+
+    def get(self, **kwargs):
+        return FakeModel()
+
+
+class FakeModel:
+    def __init__(self):
+        self.id = 1
+        self.name = "test"
+
+
+# Stub globals to mimic ORM-like access
+objects = FakeQuerySet()
+
+
+def get_all_orders_with_customers():
+    """Classic N+1: loop over orders, query customer inside loop."""
+    orders = objects.filter(status="active")
+    result = []
+    for order in orders:
+        # N+1: hits DB once per order
+        customer = objects.filter(id=order.id).get(id=order.id)
+        result.append({"order": order, "customer": customer})
+    return result
+
+
+def get_posts_with_comments():
+    """Missing prefetch_related: accesses related field in loop."""
+    posts = objects.all()
+    summaries = []
+    for post in posts:
+        # N+1: each post.comments triggers a new query
+        count = post.comments.all()
+        summaries.append({"post": post, "comment_count": count})
+    return summaries
+
+
+def load_users_missing_select_related():
+    """Missing select_related: accesses FK in loop."""
+    users = objects.filter(active=True)
+    rows = []
+    for user in users:
+        # N+1: user.profile is a FK, accessed in loop without select_related
+        profile = user.profile
+        rows.append(profile)
+    return rows
+
+
+# --- Raw SQL N+1 patterns ---
+
+
+def fetch_orders_raw(db_path: str):
+    """Raw SQL in loop: executes cursor.execute inside for-loop."""
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute("SELECT id FROM orders")
+    order_ids = cursor.fetchall()
+
+    results = []
+    for (order_id,) in order_ids:
+        # N+1: separate query per order inside loop
+        cursor.execute("SELECT * FROM customers WHERE order_id = ?", (order_id,))
+        customer = cursor.fetchone()
+        results.append(customer)
+
+    conn.close()
+    return results
+
+
+def fetch_products_formatted_sql(conn, category_ids: list):
+    """String-formatted SQL in loop (injection risk + N+1)."""
+    cursor = conn.cursor()
+    results = []
+    for cat_id in category_ids:
+        # Bad: string format inside loop — N+1 + SQL injection risk
+        query = "SELECT * FROM products WHERE category_id = %s" % cat_id
+        cursor.execute(query)
+        results.extend(cursor.fetchall())
+    return results
+
+
+# --- Async handler with sync DB call pattern ---
+
+
+async def async_handler_with_sync_db(request_ids: list):
+    """Synchronous DB call pattern inside async context."""
+    conn = sqlite3.connect(":memory:")
+    cursor = conn.cursor()
+    items = []
+    for req_id in request_ids:
+        # Sync blocking call in async handler
+        cursor.execute("SELECT * FROM requests WHERE id = ?", (req_id,))
+        row = cursor.fetchone()
+        items.append(row)
+    conn.close()
+    return items

--- a/team/spine/tests/test_spine_perf.py
+++ b/team/spine/tests/test_spine_perf.py
@@ -1,0 +1,321 @@
+"""Tests for spine-perf: N+1 detector + endpoint profiler + perf_scan CLI."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+sys.path.insert(0, ROOT)
+
+from team.shared.report_schema import AgentReport, Finding, ReportMetadata
+from team.spine.scripts.spine_agent.n_plus_one_detector import scan_file, scan_directory
+from team.spine.scripts.spine_agent.endpoint_profiler import (
+    profile_endpoints,
+    _percentile,
+    _severity_for_p50,
+    THRESHOLD_MEDIUM,
+    THRESHOLD_HIGH,
+    THRESHOLD_CRITICAL,
+)
+
+FIXTURE_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
+FIXTURE_FILE = os.path.join(FIXTURE_DIR, "n_plus_one_sample.py")
+PERF_SCAN = os.path.join(ROOT, "team/spine/scripts/spine_agent/perf_scan.py")
+
+
+# ---------------------------------------------------------------------------
+# Severity mapping helpers
+# ---------------------------------------------------------------------------
+
+class TestSeverityMapping:
+    def test_below_threshold_returns_none(self):
+        assert _severity_for_p50(0.100) is None
+
+    def test_medium_threshold(self):
+        assert _severity_for_p50(THRESHOLD_MEDIUM) == "MEDIUM"
+
+    def test_high_threshold(self):
+        assert _severity_for_p50(THRESHOLD_HIGH) == "HIGH"
+
+    def test_critical_threshold(self):
+        assert _severity_for_p50(THRESHOLD_CRITICAL) == "CRITICAL"
+
+    def test_just_below_medium(self):
+        assert _severity_for_p50(THRESHOLD_MEDIUM - 0.001) is None
+
+    def test_just_above_medium(self):
+        assert _severity_for_p50(THRESHOLD_MEDIUM + 0.001) == "MEDIUM"
+
+
+# ---------------------------------------------------------------------------
+# Percentile helper
+# ---------------------------------------------------------------------------
+
+class TestPercentile:
+    def test_empty_list(self):
+        assert _percentile([], 50) == 0.0
+
+    def test_single_element(self):
+        assert _percentile([1.0], 50) == 1.0
+
+    def test_p50_of_sorted(self):
+        data = [1.0, 2.0, 3.0, 4.0, 5.0]
+        assert _percentile(data, 50) == pytest.approx(3.0, abs=0.01)
+
+    def test_p99_of_single(self):
+        assert _percentile([0.5], 99) == 0.5
+
+
+# ---------------------------------------------------------------------------
+# N+1 detector — fixture file
+# ---------------------------------------------------------------------------
+
+class TestN1DetectorFixture:
+    def test_fixture_file_exists(self):
+        assert os.path.isfile(FIXTURE_FILE), f"Fixture not found: {FIXTURE_FILE}"
+
+    def test_detects_findings_in_fixture(self):
+        findings = scan_file(FIXTURE_FILE)
+        assert len(findings) >= 1, "Expected >=1 N+1 finding in fixture file"
+
+    def test_detects_orm_query_in_loop(self):
+        findings = scan_file(FIXTURE_FILE)
+        ids = [f.id for f in findings]
+        assert "SPINE-N1-ORM" in ids, "Expected SPINE-N1-ORM finding (ORM call inside loop)"
+
+    def test_detects_raw_sql_in_loop(self):
+        findings = scan_file(FIXTURE_FILE)
+        ids = [f.id for f in findings]
+        assert "SPINE-N1-SQL" in ids, "Expected SPINE-N1-SQL finding (cursor.execute in loop)"
+
+    def test_detects_formatted_sql_in_loop(self):
+        findings = scan_file(FIXTURE_FILE)
+        ids = [f.id for f in findings]
+        assert "SPINE-N1-FMTSQL" in ids, "Expected SPINE-N1-FMTSQL finding (string-formatted SQL in loop)"
+
+    def test_findings_have_required_fields(self):
+        findings = scan_file(FIXTURE_FILE)
+        for f in findings:
+            assert f.severity in {"CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"}
+            assert f.location
+            assert f.title
+            assert f.recommendation
+            assert f.effort in {"S", "M", "L"}
+
+    def test_findings_have_location_with_line(self):
+        findings = scan_file(FIXTURE_FILE)
+        for f in findings:
+            assert ":" in f.location, f"location should include line number, got: {f.location}"
+
+    def test_scan_directory_includes_fixture(self):
+        findings = scan_directory(FIXTURE_DIR)
+        assert len(findings) >= 1
+
+
+class TestN1DetectorEdgeCases:
+    def test_empty_file(self, tmp_path):
+        empty = tmp_path / "empty.py"
+        empty.write_text("")
+        findings = scan_file(str(empty))
+        assert findings == []
+
+    def test_syntax_error_file(self, tmp_path):
+        bad = tmp_path / "bad.py"
+        bad.write_text("def foo(: bad syntax")
+        findings = scan_file(str(bad))
+        assert findings == []
+
+    def test_nonexistent_file(self):
+        findings = scan_file("/nonexistent/path/no_file.py")
+        assert findings == []
+
+    def test_clean_file_no_findings(self, tmp_path):
+        clean = tmp_path / "clean.py"
+        clean.write_text(
+            "def good():\n"
+            "    items = get_queryset().select_related('author').all()\n"
+            "    return list(items)\n"
+        )
+        findings = scan_file(str(clean))
+        # Should have no HIGH ORM-in-loop findings (select_related call, not in a loop)
+        high_findings = [f for f in findings if f.severity == "HIGH"]
+        assert len(high_findings) == 0
+
+    def test_skips_venv_directory(self, tmp_path):
+        venv_dir = tmp_path / ".venv" / "lib"
+        venv_dir.mkdir(parents=True)
+        bad = venv_dir / "bad.py"
+        bad.write_text(
+            "for x in items:\n"
+            "    obj = Model.objects.get(id=x)\n"
+        )
+        findings = scan_directory(str(tmp_path))
+        assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Endpoint profiler — error paths
+# ---------------------------------------------------------------------------
+
+class TestEndpointProfilerErrors:
+    def test_httpx_not_installed(self, monkeypatch):
+        """If httpx is not importable, return [] and print install message."""
+        import builtins
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "httpx":
+                raise ImportError("No module named 'httpx'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+        findings = profile_endpoints("http://localhost:9999", ["/api/test"])
+        assert findings == []
+
+    def test_connection_refused(self):
+        """Connection refused on a port nothing is listening on returns []."""
+        # Port 19999 is almost certainly not in use
+        findings = profile_endpoints("http://127.0.0.1:19999", ["/ping"], timeout=2.0)
+        assert findings == []
+
+    def test_empty_paths(self):
+        """No paths to test returns empty list without error."""
+        findings = profile_endpoints("http://localhost:8000", [], timeout=1.0)
+        assert findings == []
+
+    def test_timeout_per_request(self, monkeypatch):
+        """Timeout per request is handled gracefully — returns a finding (slow)."""
+        import httpx
+
+        class FakeTimeoutClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def get(self, url, **kwargs):
+                raise httpx.TimeoutException("timed out", request=None)
+
+        monkeypatch.setattr(httpx, "Client", FakeTimeoutClient)
+        findings = profile_endpoints(
+            "http://localhost:8000",
+            ["/slow"],
+            timeout=5.0,
+            warmup=1,
+            measured=3,
+        )
+        # all requests timed out at 5s — p50 = 5.0 >= THRESHOLD_CRITICAL
+        assert len(findings) == 1
+        assert findings[0].severity == "CRITICAL"
+
+
+# ---------------------------------------------------------------------------
+# perf_scan CLI
+# ---------------------------------------------------------------------------
+
+class TestPerfScanCLI:
+    def test_nonexistent_target_exits_1(self):
+        result = subprocess.run(
+            [sys.executable, PERF_SCAN, "/nonexistent/path/that/does/not/exist"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 1
+        assert "does not exist" in result.stderr
+
+    def test_valid_target_exits_0_or_2(self, tmp_path):
+        """A scan on a clean temp dir should exit 0 (no HIGH/CRITICAL)."""
+        result = subprocess.run(
+            [sys.executable, PERF_SCAN, str(tmp_path), "--skip-endpoints"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode in (0, 2)
+
+    def test_writes_report_json(self, tmp_path):
+        out = str(tmp_path / "report.json")
+        result = subprocess.run(
+            [sys.executable, PERF_SCAN, str(tmp_path), "--skip-endpoints", "--out", out],
+            capture_output=True,
+            text=True,
+        )
+        assert os.path.isfile(out), "Report file should be written"
+        with open(out) as fh:
+            data = json.load(fh)
+        assert data["agent"] == "spine"
+        assert data["skill"] == "spine-perf"
+
+    def test_fixture_scan_exits_nonzero(self):
+        """Fixture directory has HIGH findings so exit should be 2."""
+        result = subprocess.run(
+            [sys.executable, PERF_SCAN, FIXTURE_DIR, "--skip-endpoints"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 2, (
+            f"Expected exit 2 (HIGH findings) but got {result.returncode}.\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Report schema round-trip (spine context)
+# ---------------------------------------------------------------------------
+
+class TestReportSchema:
+    def test_finding_valid_spine(self):
+        f = Finding(
+            id="SPINE-N1-ORM",
+            severity="HIGH",
+            title="N+1 ORM query inside loop",
+            detail="ORM .filter() in loop",
+            location="app/views.py:42",
+            recommendation="Use select_related()",
+            effort="S",
+        )
+        assert f.severity == "HIGH"
+
+    def test_report_summary_counts(self):
+        report = AgentReport(agent="spine", skill="spine-perf", target=".")
+        report.findings = [
+            Finding(severity="CRITICAL", title="a", detail="a", location="a", recommendation="a", effort="S"),
+            Finding(severity="HIGH", title="b", detail="b", location="b", recommendation="b", effort="S"),
+            Finding(severity="MEDIUM", title="c", detail="c", location="c", recommendation="c", effort="M"),
+        ]
+        s = report.summary
+        assert s.critical == 1
+        assert s.high == 1
+        assert s.medium == 1
+        assert s.total == 3
+
+    def test_report_json_roundtrip(self):
+        report = AgentReport(
+            agent="spine",
+            skill="spine-perf",
+            target="/some/path",
+            metadata=ReportMetadata(tool_version="spine-perf 0.9.8", duration_s=1.5),
+        )
+        report.findings = [
+            Finding(
+                id="SPINE-N1-SQL",
+                severity="HIGH",
+                title="Raw SQL in loop",
+                detail="cursor.execute in for-loop",
+                location="app.py:100",
+                recommendation="Batch query",
+                effort="S",
+            )
+        ]
+        restored = AgentReport.from_dict(json.loads(report.to_json()))
+        assert restored.agent == "spine"
+        assert len(restored.findings) == 1
+        assert restored.findings[0].id == "SPINE-N1-SQL"


### PR DESCRIPTION
## Summary

- Adds `n_plus_one_detector.py` — AST-based static analysis that finds ORM queries in loops, raw SQL `cursor.execute()` in loops, string-formatted SQL in loops, and lazy-loaded related field access without eager loading
- Adds `endpoint_profiler.py` — httpx-based HTTP profiler (3 warmup + 5 measured requests, reports p50/p95/p99, flags >200ms MEDIUM / >500ms HIGH / >1000ms CRITICAL)
- Adds `perf_scan.py` — main CLI entry point that orchestrates both scanners, writes `.reports/spine-perf-<ts>.json`, exits 2 on CRITICAL/HIGH findings (CI gate)
- Updates `spine-perf/SKILL.md` to v0.9.8 with a Step 0 that runs the real tool before AI analysis
- 34 tests: severity mapping, percentile math, fixture detection (ORM/SQL/formatted-SQL patterns), edge cases (empty/bad-syntax files, .venv skip), error paths (httpx not installed, connection refused, timeout), CLI tests (nonexistent target, report write, fixture exits 2)

## Test plan

- [ ] `cd team/spine/scripts && python -m pytest ../tests/ -v` — all 34 tests pass
- [ ] `python team/spine/scripts/spine_agent/perf_scan.py team/spine/tests/fixtures/` exits 2 with HIGH findings
- [ ] `python team/spine/scripts/spine_agent/perf_scan.py /nonexistent` exits 1 with error message
- [ ] Report JSON is valid and includes `agent: spine`, `skill: spine-perf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)