### PR TITLE
chore: bump root plugin to v1.2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tonone",
   "description": "Engineering + Product + Operations team \u2014 31 agents as Claude Code specialists. Infrastructure, DevOps, backend, security, ML/AI, mobile, UX, analytics, growth, revenue, content, PR, customer success, finance, people, operations, support, and more.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "tonone-ai",
     "url": "https://tonone.ai"


### PR DESCRIPTION
Root `.claude-plugin/plugin.json` was left at 1.1.0 after #88. Bumps to 1.2.0 to match ops-team agents and full-team bundle.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)