### PR TITLE
docs(readme): update to v1.2.0 — 31 agents, 214 skills, Operations team

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Tonone
 
-<img src="https://img.shields.io/badge/version-1.0.0-green"> <img src="https://img.shields.io/badge/license-MIT-green"> <img src="https://img.shields.io/badge/platform-Claude%20Code-blue">
+<img src="https://img.shields.io/badge/version-1.2.0-green"> <img src="https://img.shields.io/badge/license-MIT-green"> <img src="https://img.shields.io/badge/platform-Claude%20Code-blue">
 
 **Founder + Tonone = whole company.**
 
-27 specialists. Engineering executes. Product decides. One session, two commands, zero meetings. 186 skills across every discipline. MIT licensed.
+31 specialists. Engineering executes. Product decides. Operations runs. One session, two commands, zero meetings. 214 skills across every discipline. MIT licensed.
 
 ## The idea
 
@@ -12,9 +12,7 @@ A solo founder used to have one choice: stay small, or hire. Now there's a third
 
 Tonone is an open-source AI team you install into Claude Code. Not a generalist assistant — specialists. Each agent owns one domain deeply: infrastructure, security, user research, product strategy, growth. They share context, hand off cleanly, and produce work you can ship.
 
-The engineering team (15 agents) builds and ships. The product team (8 agents) decides what to build and why. Together, one founder can run what used to take a company.
-
-This is v1 — engineering + product. The roadmap adds sales, customer success, finance, and ops. The goal: a complete AI company in a single plugin.
+The engineering team (15 agents) builds and ships. The product team (12 agents) decides what to build and why. The operations team (4 agents) keeps the company running. Together, one founder can run what used to take a company.
 
 ## Install
 
@@ -64,6 +62,9 @@ Skills are markdown workflow documents in `skills/<name>/SKILL.md`. Read them an
 > /warden-audit Run a full security audit on this codebase
 > /echo-interview Run a user research session
 > /crest-roadmap Build a product roadmap
+> /mint-runway How long is our runway and how do we extend it?
+> /folk-hire Build a hiring pipeline for a senior engineer
+> /brace-sla Define our support SLA tiers
 ```
 
 Every specialist ships in three modes:
@@ -142,7 +143,7 @@ Phase 3 — Takeover report:
 | **Proof**  | QA & Testing                | Test strategy, E2E suites, integration testing, flaky triage  |
 | **Pave**   | Platform Engineering        | Developer experience, golden paths, service catalogs          |
 
-### Product — 8 agents
+### Product — 12 agents
 
 | Agent     | Hat               | What They Do                                                    |
 | --------- | ----------------- | --------------------------------------------------------------- |
@@ -154,10 +155,23 @@ Phase 3 — Takeover report:
 | **Crest** | Product Strategy  | Roadmap planning, prioritization, competitive analysis          |
 | **Pitch** | Product Marketing | Positioning, messaging, value prop, GTM, launch copy            |
 | **Surge** | Growth            | Acquisition channels, activation funnels, retention playbooks   |
+| **Deal**  | Revenue & Sales   | B2B pipeline, deal strategy, pricing, sales playbooks           |
+| **Keep**  | Customer Success  | Onboarding optimization, health scoring, expansion revenue      |
+| **Ink**   | Content Marketing | Blog strategy, SEO, thought leadership, developer content       |
+| **Buzz**  | PR & Community    | Press pitches, social media, open source community, DevRel      |
+
+### Operations — 4 agents
+
+| Agent     | Hat        | What They Do                                                                        |
+| --------- | ---------- | ----------------------------------------------------------------------------------- |
+| **Mint**  | Finance    | P&L, runway, unit economics, fundraising, board reporting, cap table                |
+| **Folk**  | People     | Org design, hiring pipelines, comp frameworks, onboarding, human-to-agent migration |
+| **Keel**  | Operations | Process design, vendor management, legal ops, compliance (SOC2/GDPR)                |
+| **Brace** | Support    | Ticket workflow, SLA design, knowledge base, escalation paths                       |
 
 ## How it works
 
-Each agent is a system prompt (a markdown file in `agents/`) paired with a set of skills (markdown workflow documents in `skills/<name>/SKILL.md`). The Claude Code plugin system installs all 27 agents and 186 skills in a single command. When you invoke a skill, Claude loads the workflow document and follows it — no code runs, no build step, no configuration.
+Each agent is a system prompt (a markdown file in `agents/`) paired with a set of skills (markdown workflow documents in `skills/<name>/SKILL.md`). The Claude Code plugin system installs all 31 agents and 214 skills in a single command. When you invoke a skill, Claude loads the workflow document and follows it — no code runs, no build step, no configuration.
 
 Every engineering agent detects your stack automatically:
 
@@ -169,7 +183,7 @@ Every engineering agent detects your stack automatically:
 - **Mobile:** Swift/SwiftUI, Kotlin/Compose, React Native, Flutter
 - **ML:** PyTorch, scikit-learn, Vertex AI, SageMaker, OpenAI, Anthropic
 
-## All 161 Skills
+## All 214 Skills
 
 <details>
 <summary>Click to expand full skill list</summary>
@@ -230,6 +244,7 @@ Every engineering agent detects your stack automatically:
 - `/warden-harden` — Harden a service
 - `/warden-iam` — Build IAM from scratch
 - `/warden-threat` — Threat model a system
+- `/warden-scan` — Automated SAST and dependency vulnerability scan
 - `/warden-recon` — Security reconnaissance
 
 ### Vigil (Observability + Reliability)
@@ -249,6 +264,7 @@ Every engineering agent detects your stack automatically:
 - `/prism-dashboard` — Build an internal dashboard
 - `/prism-chart` — Build data visualization
 - `/prism-audit` — Frontend audit
+- `/prism-stack` — Audit and document the frontend technology stack
 - `/prism-recon` — Frontend reconnaissance
 
 ### Cortex (ML/AI)
@@ -317,6 +333,7 @@ Every engineering agent detects your stack automatically:
 - `/pave-env` — Set up local development environments
 - `/pave-catalog` — Build a service catalog
 - `/pave-audit` — Audit developer experience
+- `/pave-contribute` — Contribute session learnings back to tonone upstream
 - `/pave-recon` — Platform reconnaissance
 
 ### Helm (Head of Product)
@@ -324,7 +341,7 @@ Every engineering agent detects your stack automatically:
 - `/helm` — Accept any product task, route internally
 - `/helm-plan` — Plan a product sprint or initiative
 - `/helm-brief` — Write a structured product brief for Apex
-- `/helm-handoff` — End-to-end Helm → Apex delivery
+- `/helm-handoff` — End-to-end Helm to Apex delivery
 - `/helm-arbiter` — Resolve product vs. engineering tension
 - `/helm-recon` — Product reconnaissance
 
@@ -403,20 +420,107 @@ Every engineering agent detects your stack automatically:
 - `/surge-landing` — Build a growth-optimized landing page
 - `/surge-recon` — Growth reconnaissance
 
+### Deal (Revenue & Sales)
+
+- `/deal` — Accept any revenue or sales task, route internally
+- `/deal-close` — Diagnose why a deal stalls and write a tailored proposal
+- `/deal-outreach` — Cold outbound sequence builder by persona
+- `/deal-pipeline` — Design or audit B2B sales pipeline
+- `/deal-playbook` — Write sales playbooks and discovery guides
+- `/deal-pricing` — Design pricing strategy and packaging
+- `/deal-proposal` — Generate a complete B2B proposal
+- `/deal-qualify` — MEDDPICC-based deal qualification worksheet
+- `/deal-recon` — Audit current pipeline, deal patterns, and ICP definitions
+
+### Keep (Customer Success)
+
+- `/keep` — Accept any customer success task, route internally
+- `/keep-churn` — Churn risk classification and intervention sequences
+- `/keep-expand` — Design expansion revenue playbooks
+- `/keep-health` — Design a customer health scoring model
+- `/keep-onboard` — Optimize customer onboarding
+- `/keep-playbook` — Write churn prevention and win-back playbooks
+- `/keep-qbr` — Generate a QBR for a customer
+- `/keep-recon` — Audit onboarding completion, health signals, and churn patterns
+- `/keep-segment` — Customer segmentation model by ARR, health, and expansion potential
+
+### Ink (Content Marketing)
+
+- `/ink` — Accept any content marketing task, route internally
+- `/ink-brief` — Content brief generator with keyword, intent, structure
+- `/ink-calendar` — Build a content calendar
+- `/ink-case` — Write customer case studies and success stories
+- `/ink-cluster` — Topic cluster architect — pillar posts and internal linking map
+- `/ink-distribute` — Distribution plan per piece
+- `/ink-post` — Write a blog post from keyword research to publish-ready draft
+- `/ink-recon` — Audit current content, SEO health, and competitor coverage
+- `/ink-seo` — SEO strategy — topic clusters, keyword gap analysis
+
+### Buzz (PR & Community)
+
+- `/buzz` — Accept any PR or community task, route internally
+- `/buzz-community` — Build and manage open source community
+- `/buzz-devrel` — Developer relations program design
+- `/buzz-hn` — Hacker News post crafter with anti-shadowban rules
+- `/buzz-launch` — Design and execute a launch plan
+- `/buzz-outreach` — Personalized media and podcast pitch
+- `/buzz-pitch` — Write media pitches and press releases
+- `/buzz-recon` — Audit press coverage, social presence, community health
+- `/buzz-social` — Social media strategy and post drafting
+
+### Mint (Finance)
+
+- `/mint-recon` — Financial recon — audit burn rate, runway, and unit economics health
+- `/mint-model` — Build or audit a 3-statement financial model with scenario analysis
+- `/mint-budget` — Design annual operating budget — headcount, spend, revenue targets
+- `/mint-runway` — Calculate runway and map levers available to extend it
+- `/mint-unit` — Audit unit economics — LTV, CAC, payback period, gross margin
+- `/mint-board` — Produce board financial package — P&L, cash, metrics, variance vs plan
+- `/mint-raise` — Prepare fundraising materials — investor model, data room, cap table
+- `/mint-report` — Generate monthly close package, variance analysis, management reports
+
+### Folk (People)
+
+- `/folk-recon` — People recon — audit org design, hiring, comp, onboarding, and perf
+- `/folk-org` — Design or review org structure — spans, reporting lines, headcount plan
+- `/folk-hire` — Build hiring pipeline — JD, sourcing strategy, interview scorecard
+- `/folk-comp` — Design compensation framework — salary bands, equity, total comp
+- `/folk-onboard` — Build onboarding playbook — day 1 through week 4, access, milestones
+- `/folk-perf` — Design performance management — review cycles, calibration, career ladder
+- `/folk-migrate` — Human-to-agent migration — audit roles, design transition playbook
+- `/folk-culture` — Document and strengthen company culture — values, norms, health check
+
+### Keel (Operations)
+
+- `/keel-recon` — Ops recon — audit processes, vendors, compliance, OKRs, and friction
+- `/keel-process` — Document or redesign a business process — SOP, process map, RACI
+- `/keel-vendor` — Manage vendors — selection scorecard, contract review, renewal tracking
+- `/keel-legal` — Draft or review legal ops docs — NDA, MSA, SaaS agreement checklist
+- `/keel-comply` — Build or audit compliance program — SOC2, GDPR, HIPAA gap analysis
+- `/keel-okr` — Design and run OKR program — objectives, key results, cascade, review
+- `/keel-cadence` — Design meeting cadence — what to run, how often, who decides what
+- `/keel-audit` — Operational efficiency audit — waste, redundancy, and friction scan
+
+### Brace (Support)
+
+- `/brace-recon` — Support recon — audit ticket volume, SLA compliance, CSAT, and KB gaps
+- `/brace-triage` — Design ticket triage — routing rules, priority tags, queue structure
+- `/brace-kb` — Build or audit knowledge base — coverage gaps, deflection, maintenance
+- `/brace-sla` — Design SLA framework — response targets, tier definitions, breach paths
+- `/brace-escalate` — Design escalation path — Tier 1 to Tier 2 to Engineering handoff
+- `/brace-onboard` — Design support onboarding flow — first-contact experience, setup check
+- `/brace-metrics` — Design support metrics dashboard — CSAT, FRT, TTR, deflection, trends
+- `/brace-playbook` — Write support playbook — response templates, runbooks, tone guide
+
 </details>
 
 ## Roadmap
 
-| Phase                       | Status     | What it covers                     |
-| --------------------------- | ---------- | ---------------------------------- |
-| **Engineering** (15 agents) | ✅ Done    | Build, ship, operate               |
-| **Product** (8 agents)      | ✅ Done    | Research, strategy, design, growth |
-| **Sales**                   | 🔲 Planned | Outreach, pipeline, RevOps         |
-| **Customer Success**        | 🔲 Planned | Support triage, onboarding, CSM    |
-| **Finance & Legal**         | 🔲 Planned | Budgets, compliance, contracts     |
-| **Ops & People**            | 🔲 Planned | HR, recruiting, office             |
-
-Star the repo to follow along. Open an issue to claim a phase.
+| Phase                       | Status | What it covers                     |
+| --------------------------- | ------ | ---------------------------------- |
+| **Engineering** (15 agents) | Done   | Build, ship, operate               |
+| **Product** (12 agents)     | Done   | Research, strategy, design, growth |
+| **Operations** (4 agents)   | Done   | Finance, people, ops, support      |
 
 ## Contributing
 
@@ -425,7 +529,7 @@ Everything is Markdown. Fork it, improve it, open a PR. Agents are system prompt
 See [CONTRIBUTING.md](CONTRIBUTING.md) to get started. The highest-leverage contributions right now:
 
 - **Sharpen existing skills** — better steps, sharper output formats, fewer hallucinations
-- **Build a new agent** — claim a phase from the roadmap above
+- **Build a new agent** — extend the roster with a domain not yet covered
 - **Test on real codebases** — try `/apex-takeover` on a production repo and file what breaks
 
 Tests run with `uv run pytest` from any agent's `scripts/` directory.


### PR DESCRIPTION
## Summary

- Badge: 1.0.0 → 1.2.0
- Tagline: 27 specialists/186 skills → 31 specialists/214 skills
- Intro: add operations team paragraph
- Product team section: 8 agents → 12 (was missing Deal/Keep/Ink/Buzz since v1.1.0)
- New Operations team section: Mint, Folk, Keel, Brace with descriptions
- How it works: 27/186 → 31/214
- Skills section: All 161 → All 214; add all missing agents (Deal/Keep/Ink/Buzz/Mint/Folk/Keel/Brace)
- Roadmap: all phases Done; remove stale Planned rows
- Usage examples: add Mint/Folk/Brace sample commands

🤖 Generated with [Claude Code](https://claude.ai/claude-code)