### PR TITLE
chore(forge-recon): add compatibility + tags, scope allowed-tools

### DIFF
--- a/skills/forge-recon/SKILL.md
+++ b/skills/forge-recon/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: forge-recon
 description: Infrastructure reconnaissance — inventory all cloud resources, map connections, flag risks. Use when asked to "inventory our infra", "what infrastructure do we have", "map our cloud resources", "infra discovery", or "what's running in our cloud".
-allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+allowed-tools: Bash(find:*), Bash(ls:*), Bash(cat:*), Bash(which:*), Bash(gcloud:*), Bash(aws:*), Bash(fly:*), Bash(wrangler:*)
 version: 0.6.4
 author: tonone-ai <hello@tonone.ai>
 license: MIT
+compatibility: Designed for Claude Code
+tags: [infrastructure, cloud, discovery, recon, devops]
 ---
 
 # Infrastructure Reconnaissance

--- a/team/forge/skills/forge-recon/SKILL.md
+++ b/team/forge/skills/forge-recon/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: forge-recon
 description: Infrastructure reconnaissance — inventory all cloud resources, map connections, flag risks. Use when asked to "inventory our infra", "what infrastructure do we have", "map our cloud resources", "infra discovery", or "what's running in our cloud".
-allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+allowed-tools: Bash(find:*), Bash(ls:*), Bash(cat:*), Bash(which:*), Bash(gcloud:*), Bash(aws:*), Bash(fly:*), Bash(wrangler:*)
 version: 0.6.4
 author: tonone-ai <hello@tonone.ai>
 license: MIT
+compatibility: Designed for Claude Code
+tags: [infrastructure, cloud, discovery, recon, devops]
 ---
 
 # Infrastructure Reconnaissance


### PR DESCRIPTION
Hey — small PR on `forge-recon` as a concrete example of getting a SKILL.md
frontmatter fully marketplace-spec-clean (issue #107 has the bigger picture + an
offer to do the rest).

Per the [AgentSkills.io spec](https://agentskills.io/specification) /
[Claude Code skills docs](https://code.claude.com/docs/en/skills/), this:
- Adds **`compatibility: Designed for Claude Code`** and **`tags`** (the two fields
  missing across the catalog).
- Scopes **`allowed-tools`** from unscoped `Bash` to the CLIs the skill actually calls
  (`gcloud` / `aws` / `fly` / `wrangler` + file reads) — clears the unscoped-Bash flag
  and drops the tools it never uses.

Frontmatter only — your `## Steps` house style is untouched (the validators prefer
`## Overview` / `## Instructions` etc., but that's an editorial call I left to you).
Synced the `team/forge/skills/forge-recon/` source and the root `skills/forge-recon/`
copy per CONTRIBUTING. Conventional-commit title.

Validated against the published schema:

```text
$ validate forge-recon SKILL.md + root copy  (marketplace tier)
  frontmatter validation: PASS (frontmatter_validity 5/5, Spec Compliance 15/15)
  tool-safety: PASS (Bash scoped to declared CLIs, no unscoped Bash)
  unicode hygiene: 0 failed (0 BLOCKER / 0 MAJOR / 0 MINOR)
  team/ source and root copy: identical
```

Happy to do the full sweep if useful. No rush.

(Drafted with AI assistance, reviewed by me.)

- Jeremy Longshore
intentsolutions.io

