### PR TITLE
v1.11.0: XS-XXL depth tiers for apex-plan and helm-plan

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "tonone",
       "description": "Engineering + Product team — 23 agents, 2 teams. All agents and skills in one install.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./",
       "author": {
         "name": "ai",
@@ -20,7 +20,7 @@
     {
       "name": "engineering-team",
       "description": "Install all 15 Engineering Team agents at once",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./bundle/engineering-team",
       "author": {
         "name": "ai",
@@ -31,7 +31,7 @@
     {
       "name": "product-team",
       "description": "Install all 8 Product Team agents at once",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./bundle/product-team",
       "author": {
         "name": "ai",
@@ -42,7 +42,7 @@
     {
       "name": "full-team",
       "description": "Install all 23 tonone agents at once — Engineering Team + Product Team",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./bundle/full-team",
       "author": {
         "name": "ai",
@@ -53,7 +53,7 @@
     {
       "name": "legal-team",
       "description": "Install all 10 Legal Team agents at once — contracts, compliance, IP, governance, regulatory",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./bundle/legal-team",
       "author": {
         "name": "ai",
@@ -64,7 +64,7 @@
     {
       "name": "apex",
       "description": "Engineering lead — orchestrates the team, scopes work, controls depth and budget",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/apex",
       "author": {
         "name": "ai",
@@ -76,7 +76,7 @@
     {
       "name": "forge",
       "description": "Infrastructure engineer — cloud services, networking, IaC, cost optimization",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/forge",
       "author": {
         "name": "ai",
@@ -88,7 +88,7 @@
     {
       "name": "relay",
       "description": "DevOps engineer — CI/CD, deployments, GitOps, developer experience",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/relay",
       "author": {
         "name": "ai",
@@ -100,7 +100,7 @@
     {
       "name": "spine",
       "description": "Backend engineer — APIs, system design, performance, distributed systems",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/spine",
       "author": {
         "name": "ai",
@@ -112,7 +112,7 @@
     {
       "name": "flux",
       "description": "Data engineer — databases, migrations, pipelines, data modeling",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/flux",
       "author": {
         "name": "ai",
@@ -124,7 +124,7 @@
     {
       "name": "warden",
       "description": "Security engineer — IAM, secrets, compliance, threat modeling",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/warden",
       "author": {
         "name": "ai",
@@ -136,7 +136,7 @@
     {
       "name": "vigil",
       "description": "Observability & reliability engineer — monitoring, alerting, SRE, incident response, SLOs",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/vigil",
       "author": {
         "name": "ai",
@@ -148,7 +148,7 @@
     {
       "name": "prism",
       "description": "Frontend & DX engineer — UI, internal tools, developer portals",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/prism",
       "author": {
         "name": "ai",
@@ -160,7 +160,7 @@
     {
       "name": "cortex",
       "description": "ML/AI engineer — model training, MLOps, feature engineering, LLM integration",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/cortex",
       "author": {
         "name": "ai",
@@ -172,7 +172,7 @@
     {
       "name": "touch",
       "description": "Mobile engineer — native iOS/Android, cross-platform, app stores, mobile performance",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/touch",
       "author": {
         "name": "ai",
@@ -184,7 +184,7 @@
     {
       "name": "volt",
       "description": "Embedded & IoT engineer — firmware, microcontrollers, edge computing, device protocols",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/volt",
       "author": {
         "name": "ai",
@@ -196,7 +196,7 @@
     {
       "name": "atlas",
       "description": "Knowledge engineer — architecture docs, ADRs, API specs, system diagrams, onboarding",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/atlas",
       "author": {
         "name": "ai",
@@ -208,7 +208,7 @@
     {
       "name": "lens",
       "description": "Data analytics & BI engineer — dashboards, metrics design, reporting, data storytelling",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/lens",
       "author": {
         "name": "ai",
@@ -220,7 +220,7 @@
     {
       "name": "proof",
       "description": "QA & testing engineer — test strategy, E2E suites, integration testing, test infrastructure, flaky test triage",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/proof",
       "author": {
         "name": "ai",
@@ -232,7 +232,7 @@
     {
       "name": "pave",
       "description": "Platform engineer — developer experience, service catalogs, internal CLIs, golden paths, environment management",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/pave",
       "author": {
         "name": "ai",
@@ -244,7 +244,7 @@
     {
       "name": "helm",
       "description": "Head of Product — product strategy, requirements, and engineering handoff via the Helm↔Apex interface",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/helm",
       "author": {
         "name": "ai",
@@ -256,7 +256,7 @@
     {
       "name": "draft",
       "description": "UX designer — user flows, information architecture, wireframes, and interaction design",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/draft",
       "author": {
         "name": "ai",
@@ -268,7 +268,7 @@
     {
       "name": "form",
       "description": "Visual designer — brand identity, color systems, typography, UI design, and design systems",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/form",
       "author": {
         "name": "ai",
@@ -287,7 +287,7 @@
     {
       "name": "echo",
       "description": "User researcher — interviews, personas, Jobs-to-Be-Done, and customer feedback synthesis",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/echo",
       "author": {
         "name": "ai",
@@ -306,7 +306,7 @@
     {
       "name": "lumen",
       "description": "Product analyst — metrics frameworks, funnel analysis, OKRs, A/B test design, and retention analysis",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/lumen",
       "author": {
         "name": "ai",
@@ -325,7 +325,7 @@
     {
       "name": "surge",
       "description": "Growth engineer — acquisition channels, activation funnels, retention playbooks, and PLG strategy",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/surge",
       "author": {
         "name": "ai",
@@ -344,7 +344,7 @@
     {
       "name": "crest",
       "description": "Product strategist — roadmap planning, prioritization frameworks, competitive analysis, and market positioning",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/crest",
       "author": {
         "name": "ai",
@@ -362,7 +362,7 @@
     {
       "name": "pitch",
       "description": "Product marketer — positioning, messaging, value proposition, GTM strategy, and launch copy",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/pitch",
       "author": {
         "name": "ai",
@@ -381,7 +381,7 @@
     {
       "name": "deal",
       "description": "Revenue & sales engineer — B2B pipeline, deal strategy, pricing, sales playbooks, and enterprise closing",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/deal",
       "author": {
         "name": "ai",
@@ -400,7 +400,7 @@
     {
       "name": "keep",
       "description": "Customer success engineer — onboarding optimization, health scoring, expansion revenue, and churn prevention",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/keep",
       "author": {
         "name": "ai",
@@ -419,7 +419,7 @@
     {
       "name": "ink",
       "description": "Content marketing engineer — blog strategy, SEO, thought leadership, developer content, and content calendar",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/ink",
       "author": {
         "name": "ai",
@@ -438,7 +438,7 @@
     {
       "name": "buzz",
       "description": "PR & community engineer — press pitches, social media, open source community, DevRel, and launch moments",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/buzz",
       "author": {
         "name": "ai",
@@ -450,7 +450,7 @@
     {
       "name": "apex-plan",
       "description": "Plan and scope a project — discovery, challenge assumptions, present S/M/L options with token and cost estimates. Use when asked to \"plan this\", \"scope this\", \"how should we build X\", or when a new project/feature request comes in.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/apex-plan",
       "author": {
         "name": "tonone-ai",
@@ -463,7 +463,7 @@
     {
       "name": "apex-recon",
       "description": "Engineering lead reconnaissance — inventory the project before planning. Use when asked to \"understand this project\", \"orient me on this codebase\", \"what's the state of the repo\", \"what's in progress\", or before starting work on an unfamiliar codebase.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/apex-recon",
       "author": {
         "name": "tonone-ai",
@@ -476,7 +476,7 @@
     {
       "name": "apex-review",
       "description": "Cross-cutting review of recent work — catches gaps between specialists. Use when asked to \"review what we built\", \"check the work\", \"pre-launch review\", or after completing a significant chunk of work.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/apex-review",
       "author": {
         "name": "tonone-ai",
@@ -489,7 +489,7 @@
     {
       "name": "apex-status",
       "description": "CTO-level project status from git and codebase state. Use when asked \"where are we\", \"project status\", \"what's done\", or at the start of a work session.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/apex-status",
       "author": {
         "name": "tonone-ai",
@@ -502,7 +502,7 @@
     {
       "name": "apex-takeover",
       "description": "System takeover — take ownership of an existing codebase or inherited system. Use when \"we acquired this\", \"previous team left\", \"take over this system\", \"inherited this codebase\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/apex-takeover",
       "author": {
         "name": "tonone-ai",
@@ -515,7 +515,7 @@
     {
       "name": "atlas-adr",
       "description": "Write an Architecture Decision Record — document what was decided, why, what alternatives were considered, and what trade-offs were accepted. Use when asked to \"write an ADR\", \"document this decision\", or \"why did we choose X\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/atlas-adr",
       "author": {
         "name": "tonone-ai",
@@ -528,7 +528,7 @@
     {
       "name": "atlas-changelog",
       "description": "Maintain per-repo and cross-repo changelogs — append structured entries after agent work. Use when asked to \"log this change\", \"update changelog\", \"what changed\", \"change history\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/atlas-changelog",
       "author": {
         "name": "tonone-ai",
@@ -541,7 +541,7 @@
     {
       "name": "atlas-map",
       "description": "Map the system architecture — read the codebase, identify services and connections, output a C4-level architecture map as Mermaid diagrams with component descriptions. Use when asked to \"map the architecture\", \"system diagram\", \"how does this work\", or \"architecture overview\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/atlas-map",
       "author": {
         "name": "tonone-ai",
@@ -554,7 +554,7 @@
     {
       "name": "atlas-onboard",
       "description": "Generate onboarding documentation — what this project does, how to set up locally, where things live, key decisions, how to deploy. Written for day-one engineers who know nothing. Use when asked for \"onboarding docs\", \"new engineer guide\", \"how to get started\", or \"developer setup\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/atlas-onboard",
       "author": {
         "name": "tonone-ai",
@@ -567,7 +567,7 @@
     {
       "name": "atlas-present",
       "description": "Generate a polished HTML presentation page and Obsidian Canvas for big releases — new products, takeovers, major migrations. Non-technical audience. Use when asked to \"present this\", \"release announcement\", \"show what we built\", or \"stakeholder update\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/atlas-present",
       "author": {
         "name": "tonone-ai",
@@ -580,7 +580,7 @@
     {
       "name": "atlas-recon",
       "description": "Documentation reconnaissance for takeover — find all docs, assess accuracy, freshness, coverage, and discoverability, and identify critical knowledge gaps. Use when asked \"what docs exist\", \"documentation assessment\", or \"knowledge gaps\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/atlas-recon",
       "author": {
         "name": "tonone-ai",
@@ -593,7 +593,7 @@
     {
       "name": "atlas-report",
       "description": "Render agent findings as a styled HTML report in the browser. Use when asked for \"full report\", \"detailed report\", \"show in browser\", or when CLI output exceeds the 40-line budget.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/atlas-report",
       "author": {
         "name": "tonone-ai",
@@ -606,7 +606,7 @@
     {
       "name": "cortex-eval",
       "description": "Evaluate model performance — check for accuracy drops, data drift, and error patterns. Use when asked about \"model accuracy dropped\", \"evaluate the model\", \"check for drift\", or \"model performance\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/cortex-eval",
       "author": {
         "name": "tonone-ai",
@@ -619,7 +619,7 @@
     {
       "name": "cortex-integrate",
       "description": "Design and implement an AI feature integration — model selection, architecture pattern, system prompt, data flow, error handling, cost estimate. Use when asked to \"add AI to this\", \"LLM integration\", \"add Claude/GPT\", or \"AI-powered feature\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/cortex-integrate",
       "author": {
         "name": "tonone-ai",
@@ -632,7 +632,7 @@
     {
       "name": "cortex-model",
       "description": "Build an ML pipeline — from data to trained model to serving endpoint. Use when asked to \"build ML model\", \"train a model\", \"prediction pipeline\", \"classification\", or \"regression\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/cortex-model",
       "author": {
         "name": "tonone-ai",
@@ -645,7 +645,7 @@
     {
       "name": "cortex-prompt",
       "description": "Build a production-ready prompt package — system prompt, few-shot examples, output format, edge case handling, eval criteria. Use when asked to \"prompt engineering\", \"build a prompt\", \"write a system prompt\", or \"improve this prompt\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/cortex-prompt",
       "author": {
         "name": "tonone-ai",
@@ -658,7 +658,7 @@
     {
       "name": "cortex-recon",
       "description": "ML reconnaissance — inventory all models, pipelines, data sources, and monitoring. Use when asked \"what ML do we have\", \"model inventory\", or \"ML assessment\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/cortex-recon",
       "author": {
         "name": "tonone-ai",
@@ -671,7 +671,7 @@
     {
       "name": "crest-compete",
       "description": "Competitive analysis ending in a clear positioning call — where to play, how to win. Use when asked to \"analyze competitors\", \"competitive landscape\", \"how do we compare to X\", \"competitive positioning\", \"where should we play\", \"find our white space\", or \"who else does this\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/crest-compete",
       "author": {
         "name": "tonone-ai",
@@ -684,7 +684,7 @@
     {
       "name": "crest-narrative",
       "description": "Strategic narrative — write a standalone strategy memo that frames product direction, bets, and rationale for a planning horizon. Use when asked to \"write a strategy doc\", \"product vision\", \"strategic narrative\", \"company strategy memo\", \"planning memo\", or \"explain our product direction\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/crest-narrative",
       "author": {
         "name": "tonone-ai",
@@ -697,7 +697,7 @@
     {
       "name": "crest-okr",
       "description": "OKR design — create objectives and key results with a North Star metric, input metrics tree, and cadence. Use when asked to \"set OKRs\", \"define our objectives\", \"what should we measure this quarter\", \"design our OKR framework\", \"build a metrics tree\", or \"what's our North Star\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/crest-okr",
       "author": {
         "name": "tonone-ai",
@@ -710,7 +710,7 @@
     {
       "name": "crest-recon",
       "description": "Strategic context reconnaissance — read existing roadmaps, OKRs, competitive docs, and briefs to establish context before planning. Use when asked to \"understand our strategy\", \"what's the current roadmap\", \"what OKRs do we have\", \"strategic context\", or before starting any prioritization or roadmap work.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/crest-recon",
       "author": {
         "name": "tonone-ai",
@@ -723,7 +723,7 @@
     {
       "name": "crest-roadmap",
       "description": "Build a product roadmap with sequenced bets and explicit tradeoffs. Use when asked to \"build a roadmap\", \"prioritize the backlog strategically\", \"what do we build next quarter\", \"sequence our bets\", \"what should we focus on\", or \"product strategy for the next N months\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/crest-roadmap",
       "author": {
         "name": "tonone-ai",
@@ -736,7 +736,7 @@
     {
       "name": "draft-flow",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/draft-flow",
       "author": {
         "name": "tonone-ai",
@@ -749,7 +749,7 @@
     {
       "name": "draft-ia",
       "description": "Information architecture — design navigation structure, content hierarchy, sitemap, and taxonomy for a product or feature set. Use when asked to \"organize the navigation\", \"information architecture\", \"how should content be structured\", \"sitemap\", \"nav redesign\", \"where should X live\", or \"content hierarchy\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/draft-ia",
       "author": {
         "name": "tonone-ai",
@@ -762,7 +762,7 @@
     {
       "name": "draft-landing",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/draft-landing",
       "author": {
         "name": "tonone-ai",
@@ -775,7 +775,7 @@
     {
       "name": "draft-patterns",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/draft-patterns",
       "author": {
         "name": "tonone-ai",
@@ -788,7 +788,7 @@
     {
       "name": "draft-recon",
       "description": "UI and UX reconnaissance — scan existing frontend routes, components, navigation, and flows to understand the current UX state before designing. Use when asked to \"understand the current UI\", \"what UX patterns exist\", \"map the navigation\", \"what screens exist\", or before starting any flow or wireframe work.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/draft-recon",
       "author": {
         "name": "tonone-ai",
@@ -801,7 +801,7 @@
     {
       "name": "draft-review",
       "description": "Usability review — evaluate an existing flow or UI against usability heuristics, flag friction points, and recommend fixes. Use when asked to \"review the UX\", \"usability audit\", \"what's wrong with this flow\", \"UX feedback\", \"critique this design\", or \"why are users dropping off here\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/draft-review",
       "author": {
         "name": "tonone-ai",
@@ -814,7 +814,7 @@
     {
       "name": "draft-wireframe",
       "description": "Text and Mermaid wireframes — produce screen-level layouts with content hierarchy, component placement, and interaction annotations. Use when asked to \"wireframe this\", \"sketch the UI\", \"layout for this screen\", \"lo-fi mockup\", \"screen design\", or \"what should this page look like\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/draft-wireframe",
       "author": {
         "name": "tonone-ai",
@@ -827,7 +827,7 @@
     {
       "name": "echo-feedback",
       "description": "Feedback synthesis — cluster support tickets, NPS verbatims, app store reviews, and churn surveys by theme, separate signal from noise, and produce an actionable insight report. Use when asked to \"synthesize this feedback\", \"analyze support tickets\", \"what are users complaining about\", \"NPS analysis\", \"churn feedback synthesis\", or \"what's the feedback telling us\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/echo-feedback",
       "author": {
         "name": "tonone-ai",
@@ -840,7 +840,7 @@
     {
       "name": "echo-interview",
       "description": "Run a user interview — produce an interview guide and synthesize the output into an actionable insight report. Use when asked to \"run a user interview\", \"synthesize these interview notes\", \"what do users actually want\", \"build a persona from this feedback\", \"find the JTBD in these transcripts\", or \"analyze this interview data\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/echo-interview",
       "author": {
         "name": "tonone-ai",
@@ -853,7 +853,7 @@
     {
       "name": "echo-jobs",
       "description": "Jobs-to-Be-Done analysis — given a product, user descriptions, transcripts, or tickets, produce a JTBD job map with switching forces analysis and opportunity ranking. Use when asked to \"find the JTBD\", \"what jobs are users hiring us for\", \"job mapping\", \"what are users really trying to do\", \"JTBD framework\", or \"why are users switching\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/echo-jobs",
       "author": {
         "name": "tonone-ai",
@@ -866,7 +866,7 @@
     {
       "name": "echo-recon",
       "description": "User research reconnaissance — survey existing personas, research docs, interview notes, and feedback artifacts to establish what is already known about users. Use when asked to \"what research exists\", \"review existing personas\", \"what do we know about our users\", or before starting new research or synthesis work.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/echo-recon",
       "author": {
         "name": "tonone-ai",
@@ -879,7 +879,7 @@
     {
       "name": "echo-segment",
       "description": "User segmentation and persona creation from mixed data sources — analytics, CRM, support tickets, reviews, or any combination. Use when asked to \"build personas\", \"who are our users\", \"segment our users\", \"create user profiles\", \"define user archetypes\", or \"who is the target user\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/echo-segment",
       "author": {
         "name": "tonone-ai",
@@ -892,7 +892,7 @@
     {
       "name": "flux-health",
       "description": "Data quality and pipeline health check — freshness, schema drift, null rates, orphaned records, pipeline status. Use when asked about \"data quality check\", \"pipeline health\", \"is our data fresh\", or \"schema drift\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/flux-health",
       "author": {
         "name": "tonone-ai",
@@ -905,7 +905,7 @@
     {
       "name": "flux-migrate",
       "description": "Build zero-downtime database migrations — forward SQL, rollback SQL, deployment sequence. Use when asked to \"write migration\", \"schema change\", \"add column\", \"rename table\", \"drop column\", or \"migrate safely\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/flux-migrate",
       "author": {
         "name": "tonone-ai",
@@ -918,7 +918,7 @@
     {
       "name": "flux-pipeline",
       "description": "Build a data pipeline — ETL/ELT with extraction, transformation, loading, error handling, and scheduling. Use when asked to \"build ETL\", \"data pipeline\", \"move data from X to Y\", or \"sync data\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/flux-pipeline",
       "author": {
         "name": "tonone-ai",
@@ -931,7 +931,7 @@
     {
       "name": "flux-query",
       "description": "Optimize slow database queries — analyze execution plans, add indexes, rewrite queries. Use when asked about \"slow query\", \"optimize SQL\", \"query performance\", or \"explain this query\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/flux-query",
       "author": {
         "name": "tonone-ai",
@@ -944,7 +944,7 @@
     {
       "name": "flux-recon",
       "description": "Database reconnaissance — full inventory of schema, migrations, data volume, backups, connection pooling, and query patterns. Use when asked to \"assess this database\", \"understand the schema\", or \"database health check\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/flux-recon",
       "author": {
         "name": "tonone-ai",
@@ -957,7 +957,7 @@
     {
       "name": "flux-schema",
       "description": "Design and build database schema — tables, columns, types, indexes, constraints, relationships. Given a domain description, output the schema and write the files. Use when asked to \"design schema\", \"database design\", \"create tables\", or \"data model\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/flux-schema",
       "author": {
         "name": "tonone-ai",
@@ -970,7 +970,7 @@
     {
       "name": "forge-audit",
       "description": "Audit existing infrastructure for security issues, waste, and misconfigurations. Use when asked to \"audit my infra\", \"check cloud setup\", \"infra review\", \"are we wasting money\", \"security check on infra\", or \"review my terraform\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/forge-audit",
       "author": {
         "name": "tonone-ai",
@@ -983,7 +983,7 @@
     {
       "name": "forge-cost",
       "description": "Audit cloud infrastructure costs and produce a concrete optimization plan with specific changes and estimated savings. Use when asked to \"how much is this costing\", \"reduce cloud spend\", \"cost optimization\", \"are we overpaying\", \"cloud bill\", or \"budget for this infra\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/forge-cost",
       "author": {
         "name": "tonone-ai",
@@ -996,7 +996,7 @@
     {
       "name": "forge-diagnose",
       "description": "Diagnose runtime infrastructure issues — cold starts, timeouts, scaling problems, network failures. Use when asked about \"infra is slow\", \"cold starts\", \"network issues\", \"why is this timing out\", \"scaling problem\", \"latency spikes\", or \"service is down\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/forge-diagnose",
       "author": {
         "name": "tonone-ai",
@@ -1009,7 +1009,7 @@
     {
       "name": "forge-infra",
       "description": "Build production-grade infrastructure as code for a service or project. Use when asked to \"set up infra\", \"provision infrastructure\", \"create cloud resources\", \"IaC for this project\", \"terraform for this\", or \"deploy this service\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/forge-infra",
       "author": {
         "name": "tonone-ai",
@@ -1022,7 +1022,7 @@
     {
       "name": "forge-network",
       "description": "Design and build networking infrastructure — VPCs, subnets, DNS, load balancers, firewall rules. Use when asked to \"set up networking\", \"VPC design\", \"configure DNS\", \"load balancer setup\", \"network architecture\", or \"firewall rules\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/forge-network",
       "author": {
         "name": "tonone-ai",
@@ -1035,7 +1035,7 @@
     {
       "name": "forge-recon",
       "description": "Infrastructure reconnaissance — inventory all cloud resources, map connections, flag risks. Use when asked to \"inventory our infra\", \"what infrastructure do we have\", \"map our cloud resources\", \"infra discovery\", or \"what's running in our cloud\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/forge-recon",
       "author": {
         "name": "tonone-ai",
@@ -1048,7 +1048,7 @@
     {
       "name": "form-audit",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/form-audit",
       "author": {
         "name": "tonone-ai",
@@ -1061,7 +1061,7 @@
     {
       "name": "form-brand",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/form-brand",
       "author": {
         "name": "tonone-ai",
@@ -1074,7 +1074,7 @@
     {
       "name": "form-component",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/form-component",
       "author": {
         "name": "tonone-ai",
@@ -1087,7 +1087,7 @@
     {
       "name": "form-deck",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/form-deck",
       "author": {
         "name": "tonone-ai",
@@ -1100,7 +1100,7 @@
     {
       "name": "form-email",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/form-email",
       "author": {
         "name": "tonone-ai",
@@ -1113,7 +1113,7 @@
     {
       "name": "form-exam",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/form-exam",
       "author": {
         "name": "tonone-ai",
@@ -1126,7 +1126,7 @@
     {
       "name": "form-logo",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/form-logo",
       "author": {
         "name": "tonone-ai",
@@ -1139,7 +1139,7 @@
     {
       "name": "form-mobile",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/form-mobile",
       "author": {
         "name": "tonone-ai",
@@ -1152,7 +1152,7 @@
     {
       "name": "form-palette",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/form-palette",
       "author": {
         "name": "tonone-ai",
@@ -1165,7 +1165,7 @@
     {
       "name": "form-social",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/form-social",
       "author": {
         "name": "tonone-ai",
@@ -1178,7 +1178,7 @@
     {
       "name": "form-style",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/form-style",
       "author": {
         "name": "tonone-ai",
@@ -1191,7 +1191,7 @@
     {
       "name": "form-tokens",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/form-tokens",
       "author": {
         "name": "tonone-ai",
@@ -1204,7 +1204,7 @@
     {
       "name": "form-web",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/form-web",
       "author": {
         "name": "tonone-ai",
@@ -1217,7 +1217,7 @@
     {
       "name": "helm-arbiter",
       "description": "Scope arbitration — resolve disagreements between product and engineering on what is in or out of scope, with a decision log and escalation path. Use when asked to \"resolve this scope disagreement\", \"arbitrate between product and eng\", \"scope is creeping\", \"we can't agree on what's in scope\", or \"help us decide what to cut\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/helm-arbiter",
       "author": {
         "name": "tonone-ai",
@@ -1230,7 +1230,7 @@
     {
       "name": "helm-brief",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/helm-brief",
       "author": {
         "name": "tonone-ai",
@@ -1243,7 +1243,7 @@
     {
       "name": "helm-handoff",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/helm-handoff",
       "author": {
         "name": "tonone-ai",
@@ -1256,7 +1256,7 @@
     {
       "name": "helm-plan",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/helm-plan",
       "author": {
         "name": "tonone-ai",
@@ -1269,7 +1269,7 @@
     {
       "name": "helm-recon",
       "description": "Product landscape reconnaissance — survey existing briefs, research, strategy, and team output before writing new briefs or dispatching specialists. Use when asked to \"understand the product state\", \"what briefs exist\", \"what has the team produced\", \"orient me on this product\", or before starting a new product initiative.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/helm-recon",
       "author": {
         "name": "tonone-ai",
@@ -1282,7 +1282,7 @@
     {
       "name": "lens-audit",
       "description": "Review existing analytics — find all dashboards and reports, check who uses them, whether metrics are defined, and whether they drive decisions. Recommend what to keep, kill, or add. Use when asked \"are our dashboards useful\", \"analytics review\", or \"metrics audit\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/lens-audit",
       "author": {
         "name": "tonone-ai",
@@ -1295,7 +1295,7 @@
     {
       "name": "lens-chart",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/lens-chart",
       "author": {
         "name": "tonone-ai",
@@ -1308,7 +1308,7 @@
     {
       "name": "lens-dashboard",
       "description": "Design and spec an analytical dashboard — define the question each chart answers, write the SQL queries, spec the layout and refresh cadence. Produces a complete dashboard spec ready to implement. Use when asked to \"build a dashboard\", \"analytics dashboard\", \"BI dashboard\", \"weekly product health\", or \"visualize this data\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/lens-dashboard",
       "author": {
         "name": "tonone-ai",
@@ -1321,7 +1321,7 @@
     {
       "name": "lens-metrics",
       "description": "Produce a complete metrics definition doc — metric name, formula, data source, segmentation, SQL or event tracking spec, and what good/bad looks like. Given a product area, outputs the full metrics spec. Use when asked to \"define KPIs\", \"metrics framework\", \"what should we measure\", \"north star metric\", or \"instrument this feature\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/lens-metrics",
       "author": {
         "name": "tonone-ai",
@@ -1334,7 +1334,7 @@
     {
       "name": "lens-recon",
       "description": "Analytics reconnaissance for takeover — find all analytics tools, inventory what's tracked and dashboarded, assess data freshness and metric definitions, and present a coverage map. Use when asked \"what analytics exist\", \"BI assessment\", or \"what do we track\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/lens-recon",
       "author": {
         "name": "tonone-ai",
@@ -1347,7 +1347,7 @@
     {
       "name": "lens-report",
       "description": "Build a reporting pipeline — scheduled reports with SQL queries, delivery via Slack or email, threshold alerts, and historical comparison. Use when asked for \"automated reports\", \"scheduled report\", \"email digest\", or \"Slack alerts for metrics\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/lens-report",
       "author": {
         "name": "tonone-ai",
@@ -1360,7 +1360,7 @@
     {
       "name": "lumen-abtest",
       "description": "A/B test design — produce an experiment spec with hypothesis, primary metric, MDE, sample size, run time, and decision rule. Also determines when NOT to A/B test and what to do instead. Use when asked to \"design an A/B test\", \"should we test this\", \"experiment design\", \"how do we know if this works\", \"what's the sample size\", or \"set up an experiment\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/lumen-abtest",
       "author": {
         "name": "tonone-ai",
@@ -1373,7 +1373,7 @@
     {
       "name": "lumen-funnel",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/lumen-funnel",
       "author": {
         "name": "tonone-ai",
@@ -1386,7 +1386,7 @@
     {
       "name": "lumen-instrument",
       "description": "Instrumentation plan — design event taxonomy, property schema, and tracking plan for analytics tools. Use when asked to \"what should we track\", \"instrumentation plan\", \"set up analytics events\", \"analytics event schema\", \"tracking plan\", or \"instrument this feature\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/lumen-instrument",
       "author": {
         "name": "tonone-ai",
@@ -1399,7 +1399,7 @@
     {
       "name": "lumen-metrics",
       "description": "Metrics architecture — produce a complete metrics plan given a product description. North Star, input metrics tree, instrumentation spec, action triggers, and counter-metrics. Use when asked to \"design a metrics framework\", \"what should we measure\", \"build a metrics system\", \"define our KPIs\", \"what are our success metrics\", \"metrics strategy\", or \"what do we track\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/lumen-metrics",
       "author": {
         "name": "tonone-ai",
@@ -1412,7 +1412,7 @@
     {
       "name": "lumen-recon",
       "description": "Analytics reconnaissance — scan existing event tracking, metric definitions, dashboards, and analytics configuration to understand what is currently being measured. Use when asked to \"what are we tracking\", \"audit our analytics\", \"what metrics exist\", \"analytics inventory\", or before designing new metrics or instrumentation.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/lumen-recon",
       "author": {
         "name": "tonone-ai",
@@ -1425,7 +1425,7 @@
     {
       "name": "pave-audit",
       "description": "Audit developer experience — measure onboarding time, build speed, deployment friction, and developer satisfaction. Use when asked to \"DX audit\", \"developer experience review\", \"why is development slow\", \"onboarding assessment\", or \"DORA metrics\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/pave-audit",
       "author": {
         "name": "tonone-ai",
@@ -1438,7 +1438,7 @@
     {
       "name": "pave-catalog",
       "description": "Build a service catalog — schema, starter entries, and governance model. Produces what information to capture per service, how it's maintained, and where it lives. Use when asked to \"service catalog\", \"what services do we have\", \"catalog our services\", \"service inventory\", or \"who owns what\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/pave-catalog",
       "author": {
         "name": "tonone-ai",
@@ -1451,7 +1451,7 @@
     {
       "name": "pave-env",
       "description": "Set up local development environments — devcontainers, Docker Compose, one-command setup, dev/prod parity. Use when asked to \"set up dev environment\", \"devcontainer\", \"docker compose for dev\", \"local development setup\", or \"one command to run\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/pave-env",
       "author": {
         "name": "tonone-ai",
@@ -1464,7 +1464,7 @@
     {
       "name": "pave-golden",
       "description": "Define a golden path — the opinionated, supported way to do a common developer task (create a new service, set up an environment, deploy a feature). Produces concrete steps, templates, and tooling. Use when asked to \"golden path\", \"create project template\", \"scaffold a new service\", \"how should we create services\", or \"standardize our setup\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/pave-golden",
       "author": {
         "name": "tonone-ai",
@@ -1477,7 +1477,7 @@
     {
       "name": "pave-recon",
       "description": "Platform reconnaissance — inventory all developer tooling, environments, build systems, and developer workflows for project takeover. Use when asked to \"understand the dev setup\", \"developer tooling assessment\", \"platform assessment\", or \"how do developers work here\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/pave-recon",
       "author": {
         "name": "tonone-ai",
@@ -1490,7 +1490,7 @@
     {
       "name": "pitch-copy",
       "description": "Landing page and marketing copy — write hero section, problem/solution blocks, proof points, and CTAs. Use when asked to \"write landing page copy\", \"write the homepage\", \"marketing copy for this feature\", \"product page copy\", \"write the hero section\", or \"write copy for [surface]\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/pitch-copy",
       "author": {
         "name": "tonone-ai",
@@ -1503,7 +1503,7 @@
     {
       "name": "pitch-landing",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/pitch-landing",
       "author": {
         "name": "tonone-ai",
@@ -1516,7 +1516,7 @@
     {
       "name": "pitch-launch",
       "description": "Produce an actual launch plan with announcement copy, channel sequence, and day-1 checklist. Use when asked to \"plan a launch\", \"GTM strategy\", \"how do we announce this\", \"launch plan for [feature]\", \"go-to-market\", \"write our Product Hunt post\", or \"how do we get people to notice this\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/pitch-launch",
       "author": {
         "name": "tonone-ai",
@@ -1529,7 +1529,7 @@
     {
       "name": "pitch-message",
       "description": "Messaging framework — produce a full headline, subheadline, proof points, and CTA hierarchy for use across all surfaces. Use when asked to \"write our messaging\", \"messaging framework\", \"what should our headline say\", \"copy hierarchy\", \"tagline and messaging\", or \"how do we talk about the product\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/pitch-message",
       "author": {
         "name": "tonone-ai",
@@ -1542,7 +1542,7 @@
     {
       "name": "pitch-position",
       "description": "Produce a complete positioning document using the Dunford framework — competitive alternatives, unique attributes, value, best-fit customer, market category, positioning statement, and tagline. Use when asked to \"write our positioning\", \"define our value prop\", \"positioning statement\", \"what market are we in\", \"how do we position against X\", \"what's our tagline\", or \"write our messaging foundation\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/pitch-position",
       "author": {
         "name": "tonone-ai",
@@ -1555,7 +1555,7 @@
     {
       "name": "pitch-recon",
       "description": "Marketing and messaging reconnaissance — read existing landing pages, copy, positioning docs, and marketing materials to understand the current messaging state. Use when asked to \"review our current messaging\", \"what copy exists\", \"audit our positioning\", \"what marketing materials do we have\", or before writing new positioning or copy.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/pitch-recon",
       "author": {
         "name": "tonone-ai",
@@ -1568,7 +1568,7 @@
     {
       "name": "prism-audit",
       "description": "Frontend audit — bundle size, dependencies, accessibility, performance, component quality. Use when asked for \"frontend review\", \"performance audit\", \"accessibility check\", or \"bundle size\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/prism-audit",
       "author": {
         "name": "tonone-ai",
@@ -1581,7 +1581,7 @@
     {
       "name": "prism-chart",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/prism-chart",
       "author": {
         "name": "tonone-ai",
@@ -1594,7 +1594,7 @@
     {
       "name": "prism-component",
       "description": "Implement a reusable, accessible, typed component from a design spec. Use when asked to \"create a component\", \"build a widget\", \"implement this design\", or \"reusable UI element\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/prism-component",
       "author": {
         "name": "tonone-ai",
@@ -1607,7 +1607,7 @@
     {
       "name": "prism-dashboard",
       "description": "Build an internal dashboard with data tables, filters, detail views, and CRUD. Use when asked to build an \"admin panel\", \"internal dashboard\", \"back office\", or \"data dashboard UI\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/prism-dashboard",
       "author": {
         "name": "tonone-ai",
@@ -1620,7 +1620,7 @@
     {
       "name": "prism-recon",
       "description": "Frontend reconnaissance — map the component tree, routing, state management, build config, and assess quality. Use when asked to \"understand this frontend\", \"frontend assessment\", or \"what's the UI built with\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/prism-recon",
       "author": {
         "name": "tonone-ai",
@@ -1633,7 +1633,7 @@
     {
       "name": "prism-stack",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/prism-stack",
       "author": {
         "name": "tonone-ai",
@@ -1646,7 +1646,7 @@
     {
       "name": "prism-ui",
       "description": "Implement a complete UI screen or feature from a Form visual spec. Use when asked to \"build a page\", \"implement this screen\", \"build the frontend for this feature\", or \"create this UI\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/prism-ui",
       "author": {
         "name": "tonone-ai",
@@ -1659,7 +1659,7 @@
     {
       "name": "proof-api",
       "description": "Build API test suites — endpoint testing, contract testing, load testing for REST/GraphQL/gRPC APIs. Use when asked to \"test this API\", \"API tests\", \"endpoint testing\", \"contract tests\", or \"load test\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/proof-api",
       "author": {
         "name": "tonone-ai",
@@ -1672,7 +1672,7 @@
     {
       "name": "proof-audit",
       "description": "Audit test suite health — find flaky tests, slow tests, coverage gaps, and testing anti-patterns. Use when asked to \"audit tests\", \"fix flaky tests\", \"why are tests slow\", \"test health\", or \"improve test suite\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/proof-audit",
       "author": {
         "name": "tonone-ai",
@@ -1685,7 +1685,7 @@
     {
       "name": "proof-design",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/proof-design",
       "author": {
         "name": "tonone-ai",
@@ -1698,7 +1698,7 @@
     {
       "name": "proof-e2e",
       "description": "Build E2E test specs for critical user journeys — Playwright or Cypress, page objects, setup/teardown, CI config. Use when asked to \"write E2E tests\", \"end-to-end testing\", \"browser tests\", \"UI tests\", or \"Playwright tests\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/proof-e2e",
       "author": {
         "name": "tonone-ai",
@@ -1711,7 +1711,7 @@
     {
       "name": "proof-recon",
       "description": "Testing reconnaissance — inventory all tests, frameworks, coverage, CI integration, and assess testing maturity for project takeover. Use when asked to \"understand the tests\", \"testing assessment\", \"what's tested\", or \"test inventory\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/proof-recon",
       "author": {
         "name": "tonone-ai",
@@ -1724,7 +1724,7 @@
     {
       "name": "proof-strategy",
       "description": "Produce a test strategy for a project or feature — risk map, test type decisions, coverage targets, CI config. Use when asked to \"create test strategy\", \"what should we test\", \"testing plan\", or \"improve test coverage\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/proof-strategy",
       "author": {
         "name": "tonone-ai",
@@ -1737,7 +1737,7 @@
     {
       "name": "relay-audit",
       "description": "Audit an existing CI/CD pipeline for slowness, security issues, and reliability gaps. Use when asked to \"audit pipeline\", \"why is CI slow\", \"pipeline review\", or \"deployment review\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/relay-audit",
       "author": {
         "name": "tonone-ai",
@@ -1750,7 +1750,7 @@
     {
       "name": "relay-deploy",
       "description": "Set up a complete deployment configuration — Dockerfile, deployment manifest, environment config, and rollback procedure. Use when asked about \"deployment setup\", \"how do I deploy this\", \"deployment strategy\", or \"rollback plan\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/relay-deploy",
       "author": {
         "name": "tonone-ai",
@@ -1763,7 +1763,7 @@
     {
       "name": "relay-docker",
       "description": "Build production-ready Dockerfiles with multi-stage builds, security hardening, and docker-compose for local dev. Use when asked to \"create Dockerfile\", \"optimize container\", or \"dockerize this\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/relay-docker",
       "author": {
         "name": "tonone-ai",
@@ -1776,7 +1776,7 @@
     {
       "name": "relay-pipeline",
       "description": "Build a full CI/CD pipeline from scratch. Use when asked to \"set up CI/CD\", \"create pipeline\", or \"automate deploys\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/relay-pipeline",
       "author": {
         "name": "tonone-ai",
@@ -1789,7 +1789,7 @@
     {
       "name": "relay-recon",
       "description": "Map the full CI/CD pipeline — triggers, build, test, deploy flow — with risk assessment. Use when asked \"how does this deploy\", \"map the pipeline\", or \"understand CI/CD\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/relay-recon",
       "author": {
         "name": "tonone-ai",
@@ -1802,7 +1802,7 @@
     {
       "name": "relay-ship",
       "description": "End-to-end ship workflow — merge base, run tests, review diff, bump version, commit, push, create PR. Use when asked to \"ship\", \"push to main\", \"create a PR\", \"get this merged\", or \"deploy this branch\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/relay-ship",
       "author": {
         "name": "tonone-ai",
@@ -1815,7 +1815,7 @@
     {
       "name": "spine-api",
       "description": "Design and spec an API — endpoints, request/response shapes, error codes, auth pattern, pagination. Applies Stripe's consistency principles. Use when asked to \"design an API\", \"build API endpoints\", \"create REST API\", or \"API for this feature\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/spine-api",
       "author": {
         "name": "tonone-ai",
@@ -1828,7 +1828,7 @@
     {
       "name": "spine-design",
       "description": "Produce a system design doc — components, data flow, decisions made, tradeoffs, failure modes. Not a list of options. An actual design with calls made. Use when asked for \"system design for\", \"architect this\", \"how should we build\", or \"design the backend\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/spine-design",
       "author": {
         "name": "tonone-ai",
@@ -1841,7 +1841,7 @@
     {
       "name": "spine-perf",
       "description": "Find and fix performance bottlenecks — N+1 queries, missing indexes, sync bottlenecks, caching gaps. Use when asked \"why is this slow\", \"performance issue\", \"optimize this endpoint\", or \"N+1 queries\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/spine-perf",
       "author": {
         "name": "tonone-ai",
@@ -1854,7 +1854,7 @@
     {
       "name": "spine-recon",
       "description": "Backend reconnaissance — map all routes, middleware, models, dependencies, auth, and assess code quality for project takeover. Use when asked to \"understand this backend\", \"map the API\", or \"assess code quality\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/spine-recon",
       "author": {
         "name": "tonone-ai",
@@ -1867,7 +1867,7 @@
     {
       "name": "spine-review",
       "description": "API and backend code review — REST conventions, auth, validation, error handling, pagination, rate limiting, test coverage. Use when asked to \"review this API\", \"code review\", \"review backend\", or \"pre-launch backend check\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/spine-review",
       "author": {
         "name": "tonone-ai",
@@ -1880,7 +1880,7 @@
     {
       "name": "spine-service",
       "description": "Build a new production-ready service from scratch — config management, health checks, graceful shutdown, structured logging. Use when asked to \"new service\", \"scaffold a backend\", \"bootstrap service\", or \"create microservice\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/spine-service",
       "author": {
         "name": "tonone-ai",
@@ -1893,7 +1893,7 @@
     {
       "name": "surge-activation",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/surge-activation",
       "author": {
         "name": "tonone-ai",
@@ -1906,7 +1906,7 @@
     {
       "name": "surge-experiment",
       "description": "Growth experiment design — structure a growth hypothesis, define metric, baseline, expected lift, and kill condition for a single experiment. Use when asked to \"design a growth experiment\", \"test this growth idea\", \"experiment framework\", \"how do we test if this works\", or \"growth hypothesis\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/surge-experiment",
       "author": {
         "name": "tonone-ai",
@@ -1919,7 +1919,7 @@
     {
       "name": "surge-landing",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/surge-landing",
       "author": {
         "name": "tonone-ai",
@@ -1932,7 +1932,7 @@
     {
       "name": "surge-plg",
       "description": "PLG motion design — free tier definition, activation sequence, expansion trigger points, viral mechanic assessment. Given a product, output the PLG architecture and make the calls. Use when asked to \"PLG strategy\", \"freemium model\", \"product-led growth plan\", \"self-serve motion\", \"how do we add a free tier\", \"upgrade triggers\", or \"viral loop design\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/surge-plg",
       "author": {
         "name": "tonone-ai",
@@ -1945,7 +1945,7 @@
     {
       "name": "surge-recon",
       "description": "Growth state reconnaissance — scan existing onboarding flows, acquisition channels, conversion funnels, and growth experiment logs to understand current growth state. Use when asked to \"what's our growth state\", \"audit the funnel\", \"what growth experiments have we run\", \"acquisition channel inventory\", or before designing new growth experiments.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/surge-recon",
       "author": {
         "name": "tonone-ai",
@@ -1958,7 +1958,7 @@
     {
       "name": "surge-retention",
       "description": "Retention diagnosis + intervention plan — analyze the retention curve, identify the primary drop-off point, and produce a specific intervention plan with expected impact. Use when asked to \"improve retention\", \"why are users churning\", \"build a retention playbook\", \"reduce churn\", \"win-back campaign\", or \"users aren't coming back\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/surge-retention",
       "author": {
         "name": "tonone-ai",
@@ -1971,7 +1971,7 @@
     {
       "name": "touch-app",
       "description": "Produce a complete mobile app architecture design — platform choice, navigation structure, state management, data layer, key screens. Use when asked to \"build a mobile app\", \"new app\", \"create iOS/Android app\", \"app architecture\", or \"cross-platform app\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/touch-app",
       "author": {
         "name": "tonone-ai",
@@ -1984,7 +1984,7 @@
     {
       "name": "touch-audit",
       "description": "Mobile audit — app size, startup time, crash reporting, store compliance, accessibility, offline behavior. Use when asked for \"mobile review\", \"app store readiness\", \"mobile performance\", or \"crash analysis\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/touch-audit",
       "author": {
         "name": "tonone-ai",
@@ -1997,7 +1997,7 @@
     {
       "name": "touch-feature",
       "description": "Produce a mobile feature spec — user story, technical approach, component breakdown, platform-specific considerations, edge cases. Use when asked to \"add a screen\", \"spec this feature\", \"mobile feature\", \"new tab\", \"push notifications\", or \"deep link\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/touch-feature",
       "author": {
         "name": "tonone-ai",
@@ -2010,7 +2010,7 @@
     {
       "name": "touch-recon",
       "description": "Mobile reconnaissance — understand the app's tech stack, architecture, dependencies, and health for takeover. Use when asked to \"understand this app\", \"mobile assessment\", or \"app health\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/touch-recon",
       "author": {
         "name": "tonone-ai",
@@ -2023,7 +2023,7 @@
     {
       "name": "touch-release",
       "description": "Set up mobile release pipeline — Fastlane, code signing, CI, beta distribution, versioning. Use when asked about \"app store setup\", \"release pipeline\", \"fastlane\", \"beta distribution\", or \"signing\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/touch-release",
       "author": {
         "name": "tonone-ai",
@@ -2036,7 +2036,7 @@
     {
       "name": "touch-ui",
       "description": "|",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/touch-ui",
       "author": {
         "name": "tonone-ai",
@@ -2049,7 +2049,7 @@
     {
       "name": "vigil-alert",
       "description": "Write SLO-based alert rules with burn rate thresholds and paired runbooks. Outputs actual alert configs, not a strategy doc. Use when asked to \"set up alerts\", \"create runbooks\", \"define SLOs\", or \"alerting strategy\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/vigil-alert",
       "author": {
         "name": "tonone-ai",
@@ -2062,7 +2062,7 @@
     {
       "name": "vigil-check",
       "description": "Verify observability posture — audit monitoring coverage, find blind spots, prioritize gaps. Use when asked \"is monitoring sufficient\", \"observability review\", \"are we covered\", or \"pre-launch monitoring check\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/vigil-check",
       "author": {
         "name": "tonone-ai",
@@ -2075,7 +2075,7 @@
     {
       "name": "vigil-incident",
       "description": "Incident response — diagnose production issues, find root cause, propose fix with rollback. Use when asked about \"something is broken\", \"production issue\", \"why is this down\", \"incident\", or \"debug production\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/vigil-incident",
       "author": {
         "name": "tonone-ai",
@@ -2088,7 +2088,7 @@
     {
       "name": "vigil-instrument",
       "description": "Instrument a service with OpenTelemetry — RED metrics, structured logs, distributed tracing, and health checks. Outputs actual code and config, not a plan. Use when asked to \"add monitoring\", \"instrument this\", \"add logging\", \"set up tracing\", or \"observability\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/vigil-instrument",
       "author": {
         "name": "tonone-ai",
@@ -2101,7 +2101,7 @@
     {
       "name": "vigil-recon",
       "description": "Observability reconnaissance — inventory what monitoring exists, map coverage, highlight blind spots. Use when asked \"what monitoring exists\", \"observability assessment\", or \"what can we see\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/vigil-recon",
       "author": {
         "name": "tonone-ai",
@@ -2114,7 +2114,7 @@
     {
       "name": "volt-driver",
       "description": "Build a device driver or protocol handler — I2C sensors, BLE services, MQTT clients, SPI peripherals with interrupt-driven I/O and clean HAL abstraction. Use when asked to \"write a driver\", \"I2C device\", \"BLE service\", \"MQTT client\", or \"sensor integration\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/volt-driver",
       "author": {
         "name": "tonone-ai",
@@ -2127,7 +2127,7 @@
     {
       "name": "volt-firmware",
       "description": "Produce a complete firmware architecture spec for a described device — layer diagram, module responsibilities, HAL interface definitions, key state machines, RTOS decision. Use when asked to \"design firmware architecture\", \"plan embedded firmware\", \"architect an IoT device\", \"how should I structure this firmware\", or given a device description and asked what the firmware should look like.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/volt-firmware",
       "author": {
         "name": "tonone-ai",
@@ -2140,7 +2140,7 @@
     {
       "name": "volt-ota",
       "description": "Produce a complete OTA update system design — partition layout, update flow, rollback conditions, validation checks, fleet management approach, failure modes and recovery. Use when asked about \"OTA updates\", \"firmware updates over the air\", \"how do I update devices in the field\", \"OTA strategy\", or \"remote firmware update design\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/volt-ota",
       "author": {
         "name": "tonone-ai",
@@ -2153,7 +2153,7 @@
     {
       "name": "volt-power",
       "description": "Power management audit — analyze sleep modes, wake sources, power state machines, radio duty cycles, and battery life estimates. Use when asked to \"audit power usage\", \"optimize battery life\", \"review power management\", \"why is my battery draining\", \"power budget analysis\", or \"sleep mode review\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/volt-power",
       "author": {
         "name": "tonone-ai",
@@ -2166,7 +2166,7 @@
     {
       "name": "volt-recon",
       "description": "Firmware reconnaissance for takeover — inventory the MCU, peripherals, RTOS, protocols, OTA, power management, and assess code quality with risk flags. Use when asked to \"understand this firmware\", \"device inventory\", or \"embedded assessment\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/volt-recon",
       "author": {
         "name": "tonone-ai",
@@ -2179,7 +2179,7 @@
     {
       "name": "warden-audit",
       "description": "Full security audit — secrets, dependencies, IAM, auth, injection, XSS, HTTPS, rate limiting, public storage. Use when asked for \"security audit\", \"check for vulnerabilities\", \"security review\", or \"are we secure\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/warden-audit",
       "author": {
         "name": "tonone-ai",
@@ -2192,7 +2192,7 @@
     {
       "name": "warden-harden",
       "description": "Produce a hardening spec and implement it — auth patterns, security headers, rate limiting, input validation, secrets management, dependency hygiene. Use when asked to \"harden this\", \"add security to this service\", \"what security do I need\", or \"secure this before launch\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/warden-harden",
       "author": {
         "name": "tonone-ai",
@@ -2205,7 +2205,7 @@
     {
       "name": "warden-iam",
       "description": "Build IAM from scratch — roles, policies, service accounts with least privilege. Use when asked to \"set up IAM\", \"create roles\", \"service accounts\", or \"access control\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/warden-iam",
       "author": {
         "name": "tonone-ai",
@@ -2218,7 +2218,7 @@
     {
       "name": "warden-recon",
       "description": "Security reconnaissance — full inventory of secrets management, IAM, dependencies, auth, encryption, audit logging, and compliance gaps. Use when asked about \"security posture\", \"how secure is this\", or \"security assessment\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/warden-recon",
       "author": {
         "name": "tonone-ai",
@@ -2231,7 +2231,7 @@
     {
       "name": "warden-threat",
       "description": "Produce a threat model — assets, ranked threats, mitigations, accepted risks. Use when asked to \"threat model this\", \"what could go wrong security-wise\", \"map our attack surface\", or before designing any security-sensitive feature.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/warden-threat",
       "author": {
         "name": "tonone-ai",
@@ -2244,7 +2244,7 @@
     {
       "name": "tonone-onboard",
       "description": "First-run onboarding tour — guided walkthrough of tonone's 23 agents, key skills, and worktree sessions. Two paths: expert (~90 sec) and newcomer (~8 min). Use when asked \"how do I use tonone\", \"what can tonone do\", \"show me around\", or \"first steps\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/tonone-onboard",
       "author": {
         "name": "tonone-ai",
@@ -2257,7 +2257,7 @@
     {
       "name": "contribute",
       "description": "Contribute a discovery back to the upstream tonone repo — new skill, improved agent prompt, better routing rule. Use when you hit a gap, found a better pattern, or built something reusable that others would benefit from.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/contribute",
       "author": {
         "name": "tonone-ai",
@@ -2270,7 +2270,7 @@
     {
       "name": "mint",
       "description": "Finance engineer — P&L, runway, unit economics, fundraising, board reporting, and cap table management",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/mint",
       "author": {
         "name": "tonone-ai",
@@ -2289,7 +2289,7 @@
     {
       "name": "folk",
       "description": "People engineer — org design, hiring pipelines, compensation frameworks, onboarding playbooks, performance management, and human-to-agent migration",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/folk",
       "author": {
         "name": "tonone-ai",
@@ -2309,7 +2309,7 @@
     {
       "name": "keel",
       "description": "Operations engineer — process design, vendor management, legal ops, compliance (SOC2/GDPR), OKR execution, and cross-functional coordination",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/keel",
       "author": {
         "name": "tonone-ai",
@@ -2329,7 +2329,7 @@
     {
       "name": "brace",
       "description": "Support engineer — ticket workflow design, SLA architecture, knowledge base, escalation paths, and support operations at scale",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/brace",
       "author": {
         "name": "tonone-ai",
@@ -2349,7 +2349,7 @@
     {
       "name": "brief",
       "description": "Contract & Policy Drafter — NDA, MSA, employment agreements, SLAs, vendor contracts",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/brief",
       "author": {
         "name": "ai",
@@ -2360,7 +2360,7 @@
     {
       "name": "clause",
       "description": "Contract Clause Analyst — redlining, risk scoring, negotiation playbooks",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/clause",
       "author": {
         "name": "ai",
@@ -2371,7 +2371,7 @@
     {
       "name": "bind",
       "description": "Compliance Framework Engineer — SOC2, GDPR, HIPAA, ISO 27001 gap analysis",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/bind",
       "author": {
         "name": "ai",
@@ -2382,7 +2382,7 @@
     {
       "name": "frame",
       "description": "Corporate Governance Advisor — board resolutions, cap table, equity plan docs",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/frame",
       "author": {
         "name": "ai",
@@ -2393,7 +2393,7 @@
     {
       "name": "shield",
       "description": "Regulatory Risk Advisor — GDPR, CCPA, FTC, financial regulation, export controls",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/shield",
       "author": {
         "name": "ai",
@@ -2404,7 +2404,7 @@
     {
       "name": "scope",
       "description": "IP & Trademark Advisor — trademark clearance, patent landscape, OSS license compliance",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/scope",
       "author": {
         "name": "ai",
@@ -2415,7 +2415,7 @@
     {
       "name": "audit",
       "description": "Legal Compliance Auditor — internal controls, legal risk register, audit trail",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/audit",
       "author": {
         "name": "ai",
@@ -2426,7 +2426,7 @@
     {
       "name": "cite",
       "description": "Legal Researcher — case law synthesis, statute analysis, jurisdiction comparison",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/cite",
       "author": {
         "name": "ai",
@@ -2437,7 +2437,7 @@
     {
       "name": "lodge",
       "description": "Regulatory Filing Advisor — DMCA, FTC disclosures, GDPR DPAs, government filings",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/lodge",
       "author": {
         "name": "ai",
@@ -2448,7 +2448,7 @@
     {
       "name": "terms",
       "description": "Privacy & ToS Drafter — GDPR-compliant privacy policies, ToS, cookie policies, DPAs",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/terms",
       "author": {
         "name": "ai",
@@ -2459,7 +2459,7 @@
     {
       "name": "brief-draft",
       "description": "Draft a contract or policy document from a description",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/brief/skills/brief-draft",
       "author": {
         "name": "ai",
@@ -2470,7 +2470,7 @@
     {
       "name": "brief-review",
       "description": "Review and redline a contract — risk and missing clauses",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/brief/skills/brief-review",
       "author": {
         "name": "ai",
@@ -2481,7 +2481,7 @@
     {
       "name": "brief-recon",
       "description": "Survey existing contracts and policy documents",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/brief/skills/brief-recon",
       "author": {
         "name": "ai",
@@ -2492,7 +2492,7 @@
     {
       "name": "clause-analyze",
       "description": "Deep clause-by-clause analysis with risk scores",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/clause/skills/clause-analyze",
       "author": {
         "name": "ai",
@@ -2503,7 +2503,7 @@
     {
       "name": "clause-playbook",
       "description": "Generate negotiation playbook for a contract type",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/clause/skills/clause-playbook",
       "author": {
         "name": "ai",
@@ -2514,7 +2514,7 @@
     {
       "name": "clause-recon",
       "description": "Scan existing contracts for risk patterns",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/clause/skills/clause-recon",
       "author": {
         "name": "ai",
@@ -2525,7 +2525,7 @@
     {
       "name": "bind-gap",
       "description": "Compliance gap analysis — SOC2, GDPR, HIPAA, ISO 27001",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/bind/skills/bind-gap",
       "author": {
         "name": "ai",
@@ -2536,7 +2536,7 @@
     {
       "name": "bind-policy",
       "description": "Draft compliance policies required by a framework",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/bind/skills/bind-policy",
       "author": {
         "name": "ai",
@@ -2547,7 +2547,7 @@
     {
       "name": "bind-recon",
       "description": "Survey existing compliance artifacts and certifications",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/bind/skills/bind-recon",
       "author": {
         "name": "ai",
@@ -2558,7 +2558,7 @@
     {
       "name": "frame-board",
       "description": "Draft board resolutions and corporate consent documents",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/frame/skills/frame-board",
       "author": {
         "name": "ai",
@@ -2569,7 +2569,7 @@
     {
       "name": "frame-equity",
       "description": "Draft equity plan documents and option grant agreements",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/frame/skills/frame-equity",
       "author": {
         "name": "ai",
@@ -2580,7 +2580,7 @@
     {
       "name": "frame-recon",
       "description": "Survey corporate governance artifacts and flag gaps",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/frame/skills/frame-recon",
       "author": {
         "name": "ai",
@@ -2591,7 +2591,7 @@
     {
       "name": "shield-assess",
       "description": "Regulatory exposure assessment for a product or geography",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/shield/skills/shield-assess",
       "author": {
         "name": "ai",
@@ -2602,7 +2602,7 @@
     {
       "name": "shield-respond",
       "description": "Draft regulatory response letters and regulator comms",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/shield/skills/shield-respond",
       "author": {
         "name": "ai",
@@ -2613,7 +2613,7 @@
     {
       "name": "shield-recon",
       "description": "Map product data flows and identify regulatory triggers",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/shield/skills/shield-recon",
       "author": {
         "name": "ai",
@@ -2624,7 +2624,7 @@
     {
       "name": "scope-trademark",
       "description": "Trademark clearance research and filing preparation",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/scope/skills/scope-trademark",
       "author": {
         "name": "ai",
@@ -2635,7 +2635,7 @@
     {
       "name": "scope-oss",
       "description": "Open source license compliance audit — GPL, LGPL, AGPL risks",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/scope/skills/scope-oss",
       "author": {
         "name": "ai",
@@ -2646,7 +2646,7 @@
     {
       "name": "scope-recon",
       "description": "Survey IP assets, license obligations, and assignment gaps",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/scope/skills/scope-recon",
       "author": {
         "name": "ai",
@@ -2657,7 +2657,7 @@
     {
       "name": "audit-legal",
       "description": "Full legal compliance audit and risk register",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/audit/skills/audit-legal",
       "author": {
         "name": "ai",
@@ -2668,7 +2668,7 @@
     {
       "name": "audit-controls",
       "description": "Internal legal controls review — approval workflows, doc governance",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/audit/skills/audit-controls",
       "author": {
         "name": "ai",
@@ -2679,7 +2679,7 @@
     {
       "name": "audit-recon",
       "description": "Assess legal artifact completeness and audit readiness",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/audit/skills/audit-recon",
       "author": {
         "name": "ai",
@@ -2690,7 +2690,7 @@
     {
       "name": "cite-research",
       "description": "Legal research — case law, statutes, regulatory guidance",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/cite/skills/cite-research",
       "author": {
         "name": "ai",
@@ -2701,7 +2701,7 @@
     {
       "name": "cite-compare",
       "description": "Jurisdiction comparison for a legal requirement or clause",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/cite/skills/cite-compare",
       "author": {
         "name": "ai",
@@ -2712,7 +2712,7 @@
     {
       "name": "cite-recon",
       "description": "Identify open legal questions and research gaps",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/cite/skills/cite-recon",
       "author": {
         "name": "ai",
@@ -2723,7 +2723,7 @@
     {
       "name": "lodge-filing",
       "description": "Prepare regulatory filing, disclosure notice, or government submission",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/lodge/skills/lodge-filing",
       "author": {
         "name": "ai",
@@ -2734,7 +2734,7 @@
     {
       "name": "lodge-dmca",
       "description": "Draft DMCA takedown notice or counter-notice",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/lodge/skills/lodge-dmca",
       "author": {
         "name": "ai",
@@ -2745,7 +2745,7 @@
     {
       "name": "lodge-recon",
       "description": "Identify required regulatory filings and their status",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/lodge/skills/lodge-recon",
       "author": {
         "name": "ai",
@@ -2756,7 +2756,7 @@
     {
       "name": "terms-privacy",
       "description": "Draft GDPR-compliant privacy policy for the product",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/terms/skills/terms-privacy",
       "author": {
         "name": "ai",
@@ -2767,7 +2767,7 @@
     {
       "name": "terms-tos",
       "description": "Draft Terms of Service for the product",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/terms/skills/terms-tos",
       "author": {
         "name": "ai",
@@ -2778,7 +2778,7 @@
     {
       "name": "terms-recon",
       "description": "Check privacy policy and ToS for completeness and compliance",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/terms/skills/terms-recon",
       "author": {
         "name": "ai",
@@ -2789,1694 +2789,1694 @@
     {
       "name": "design-team",
       "description": "Design Team bundle — 10 agents: Hue, Grid, Glyph, Move, Wire, Mark, Cut, Axe, Tone, Copy",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./bundle/design-team",
       "tags": ["bundle", "design-team", "design"]
     },
     {
       "name": "hue",
       "description": "Color Systems Designer — Color palette design — semantic tokens, dark/light mode, WCAG contrast",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/hue",
       "tags": ["agent", "design-team", "hue", "design"]
     },
     {
       "name": "hue-palette",
       "description": "Design a color palette with semantic tokens for a brand or product",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/hue/skills/hue-palette",
       "tags": ["skill", "design-team", "hue", "design"]
     },
     {
       "name": "hue-token",
       "description": "Audit or refactor a design token system for color",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/hue/skills/hue-token",
       "tags": ["skill", "design-team", "hue", "design"]
     },
     {
       "name": "hue-recon",
       "description": "Audit existing color usage in a codebase",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/hue/skills/hue-recon",
       "tags": ["skill", "design-team", "hue", "design"]
     },
     {
       "name": "grid",
       "description": "Layout Systems Designer — Layout system design — spacing scales, responsive grids, layout primitives",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/grid",
       "tags": ["agent", "design-team", "grid", "design"]
     },
     {
       "name": "grid-layout",
       "description": "Design a layout system — spacing scale, grid columns, and layout primitives",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/grid/skills/grid-layout",
       "tags": ["skill", "design-team", "grid", "design"]
     },
     {
       "name": "grid-responsive",
       "description": "Audit or redesign responsive behavior of a layout",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/grid/skills/grid-responsive",
       "tags": ["skill", "design-team", "grid", "design"]
     },
     {
       "name": "grid-recon",
       "description": "Audit existing layout patterns in a codebase",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/grid/skills/grid-recon",
       "tags": ["skill", "design-team", "grid", "design"]
     },
     {
       "name": "glyph",
       "description": "Typography Designer — Typography system design — font pairing, type scale, hierarchy tokens",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/glyph",
       "tags": ["agent", "design-team", "glyph", "design"]
     },
     {
       "name": "glyph-pair",
       "description": "Select and pair fonts for a product",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/glyph/skills/glyph-pair",
       "tags": ["skill", "design-team", "glyph", "design"]
     },
     {
       "name": "glyph-scale",
       "description": "Design a type scale and hierarchy",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/glyph/skills/glyph-scale",
       "tags": ["skill", "design-team", "glyph", "design"]
     },
     {
       "name": "glyph-recon",
       "description": "Audit existing typography in a codebase",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/glyph/skills/glyph-recon",
       "tags": ["skill", "design-team", "glyph", "design"]
     },
     {
       "name": "move",
       "description": "Motion Designer — Motion design — animation principles, transition systems, micro-interaction specs",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/move",
       "tags": ["agent", "design-team", "move", "design"]
     },
     {
       "name": "move-animate",
       "description": "Design an animation spec for a component or interaction",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/move/skills/move-animate",
       "tags": ["skill", "design-team", "move", "design"]
     },
     {
       "name": "move-system",
       "description": "Design a motion system for a product",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/move/skills/move-system",
       "tags": ["skill", "design-team", "move", "design"]
     },
     {
       "name": "move-recon",
       "description": "Audit existing animations in a codebase",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/move/skills/move-recon",
       "tags": ["skill", "design-team", "move", "design"]
     },
     {
       "name": "wire",
       "description": "Prototyping Engineer — Prototyping and handoff — interactive flow docs, component specs, developer handoff",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/wire",
       "tags": ["agent", "design-team", "wire", "design"]
     },
     {
       "name": "wire-prototype",
       "description": "Document a prototype or user flow",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/wire/skills/wire-prototype",
       "tags": ["skill", "design-team", "wire", "design"]
     },
     {
       "name": "wire-spec",
       "description": "Write a developer handoff spec for a component or feature",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/wire/skills/wire-spec",
       "tags": ["skill", "design-team", "wire", "design"]
     },
     {
       "name": "wire-recon",
       "description": "Audit existing design documentation",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/wire/skills/wire-recon",
       "tags": ["skill", "design-team", "wire", "design"]
     },
     {
       "name": "mark",
       "description": "Brand Designer — Brand identity design — logo usage rules, brand guidelines, visual identity systems",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/mark",
       "tags": ["agent", "design-team", "mark", "design"]
     },
     {
       "name": "mark-brand",
       "description": "Write brand guidelines — logo usage, color, typography, voice",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/mark/skills/mark-brand",
       "tags": ["skill", "design-team", "mark", "design"]
     },
     {
       "name": "mark-asset",
       "description": "Design an asset library structure — naming, formats, delivery specs",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/mark/skills/mark-asset",
       "tags": ["skill", "design-team", "mark", "design"]
     },
     {
       "name": "mark-recon",
       "description": "Audit existing brand assets and usage",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/mark/skills/mark-recon",
       "tags": ["skill", "design-team", "mark", "design"]
     },
     {
       "name": "cut",
       "description": "Illustration & Icon Designer — Illustration and icon design — custom assets, icon systems, SVG optimization",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/cut",
       "tags": ["agent", "design-team", "cut", "design"]
     },
     {
       "name": "cut-icon",
       "description": "Design an icon system spec or audit existing icons",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/cut/skills/cut-icon",
       "tags": ["skill", "design-team", "cut", "design"]
     },
     {
       "name": "cut-illustrate",
       "description": "Spec or critique custom illustrations",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/cut/skills/cut-illustrate",
       "tags": ["skill", "design-team", "cut", "design"]
     },
     {
       "name": "cut-recon",
       "description": "Audit existing icons and illustrations in a codebase",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/cut/skills/cut-recon",
       "tags": ["skill", "design-team", "cut", "design"]
     },
     {
       "name": "axe",
       "description": "Accessibility Engineer — Accessibility engineering — WCAG audits, keyboard nav, screen reader testing, ARIA",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/axe",
       "tags": ["agent", "design-team", "axe", "design"]
     },
     {
       "name": "axe-audit",
       "description": "Run a WCAG accessibility audit",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/axe/skills/axe-audit",
       "tags": ["skill", "design-team", "axe", "design"]
     },
     {
       "name": "axe-fix",
       "description": "Write accessibility fixes for specific WCAG failures",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/axe/skills/axe-fix",
       "tags": ["skill", "design-team", "axe", "design"]
     },
     {
       "name": "axe-recon",
       "description": "Survey a codebase for accessibility debt",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/axe/skills/axe-recon",
       "tags": ["skill", "design-team", "axe", "design"]
     },
     {
       "name": "tone",
       "description": "Design Token Engineer — Design token engineering — token architecture, theming systems, style-dictionary pipelines",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/tone",
       "tags": ["agent", "design-team", "tone", "design"]
     },
     {
       "name": "tone-token",
       "description": "Design or refactor a design token architecture",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/tone/skills/tone-token",
       "tags": ["skill", "design-team", "tone", "design"]
     },
     {
       "name": "tone-theme",
       "description": "Build or fix a theming system",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/tone/skills/tone-theme",
       "tags": ["skill", "design-team", "tone", "design"]
     },
     {
       "name": "tone-recon",
       "description": "Audit existing token usage in a codebase",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/tone/skills/tone-recon",
       "tags": ["skill", "design-team", "tone", "design"]
     },
     {
       "name": "copy",
       "description": "Content Designer — UX writing and content design — microcopy, error messages, onboarding, UI content strategy",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/copy",
       "tags": ["agent", "design-team", "copy", "design"]
     },
     {
       "name": "copy-write",
       "description": "Write UX copy for a feature, flow, or component",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/copy/skills/copy-write",
       "tags": ["skill", "design-team", "copy", "design"]
     },
     {
       "name": "copy-audit",
       "description": "Audit UX copy in a product or codebase",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/copy/skills/copy-audit",
       "tags": ["skill", "design-team", "copy", "design"]
     },
     {
       "name": "copy-recon",
       "description": "Survey all user-facing strings in a codebase",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/copy/skills/copy-recon",
       "tags": ["skill", "design-team", "copy", "design"]
     },
     {
       "name": "data-science-team",
       "description": "Data Science Team bundle — 10 agents: Cast, Feat, Fit, Score, Drift, Vect, Tune, Plot, Clean, Eval",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./bundle/data-science-team",
       "tags": ["bundle", "data-science-team", "ml"]
     },
     {
       "name": "cast",
       "description": "Forecasting Engineer — Time series forecasting — demand prediction, trend analysis, seasonal decomposition",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/cast",
       "tags": ["agent", "data-science-team", "cast", "ml"]
     },
     {
       "name": "cast-forecast",
       "description": "Build a forecasting model for a time series",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/cast/skills/cast-forecast",
       "tags": ["skill", "data-science-team", "cast", "ml"]
     },
     {
       "name": "cast-validate",
       "description": "Validate and benchmark a forecasting model",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/cast/skills/cast-validate",
       "tags": ["skill", "data-science-team", "cast", "ml"]
     },
     {
       "name": "cast-recon",
       "description": "Survey existing forecasting code or models",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/cast/skills/cast-recon",
       "tags": ["skill", "data-science-team", "cast", "ml"]
     },
     {
       "name": "feat",
       "description": "Feature Engineer — Feature engineering — transformations, encodings, feature stores, pipeline design",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/feat",
       "tags": ["agent", "data-science-team", "feat", "ml"]
     },
     {
       "name": "feat-engineer",
       "description": "Design a feature engineering pipeline for a ML problem",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/feat/skills/feat-engineer",
       "tags": ["skill", "data-science-team", "feat", "ml"]
     },
     {
       "name": "feat-store",
       "description": "Design or audit a feature store",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/feat/skills/feat-store",
       "tags": ["skill", "data-science-team", "feat", "ml"]
     },
     {
       "name": "feat-recon",
       "description": "Audit feature engineering code for leakage and quality issues",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/feat/skills/feat-recon",
       "tags": ["skill", "data-science-team", "feat", "ml"]
     },
     {
       "name": "fit",
       "description": "Model Training Engineer — Model training — algorithm selection, hyperparameter tuning, training infrastructure",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/fit",
       "tags": ["agent", "data-science-team", "fit", "ml"]
     },
     {
       "name": "fit-train",
       "description": "Design a model training pipeline",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/fit/skills/fit-train",
       "tags": ["skill", "data-science-team", "fit", "ml"]
     },
     {
       "name": "fit-tune",
       "description": "Design a hyperparameter tuning strategy",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/fit/skills/fit-tune",
       "tags": ["skill", "data-science-team", "fit", "ml"]
     },
     {
       "name": "fit-recon",
       "description": "Audit existing model training code",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/fit/skills/fit-recon",
       "tags": ["skill", "data-science-team", "fit", "ml"]
     },
     {
       "name": "score",
       "description": "Model Evaluation Engineer — Model evaluation — metrics design, statistical significance, model comparison",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/score",
       "tags": ["agent", "data-science-team", "score", "ml"]
     },
     {
       "name": "score-eval",
       "description": "Design an evaluation framework for a ML model",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/score/skills/score-eval",
       "tags": ["skill", "data-science-team", "score", "ml"]
     },
     {
       "name": "score-compare",
       "description": "Compare two or more models statistically",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/score/skills/score-compare",
       "tags": ["skill", "data-science-team", "score", "ml"]
     },
     {
       "name": "score-recon",
       "description": "Audit existing model evaluation code",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/score/skills/score-recon",
       "tags": ["skill", "data-science-team", "score", "ml"]
     },
     {
       "name": "drift",
       "description": "ML Monitoring Engineer — ML monitoring — data drift, concept drift, model degradation, production ML health",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/drift",
       "tags": ["agent", "data-science-team", "drift", "ml"]
     },
     {
       "name": "drift-monitor",
       "description": "Design a drift monitoring system for a production ML model",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/drift/skills/drift-monitor",
       "tags": ["skill", "data-science-team", "drift", "ml"]
     },
     {
       "name": "drift-alert",
       "description": "Design drift alerts and escalation",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/drift/skills/drift-alert",
       "tags": ["skill", "data-science-team", "drift", "ml"]
     },
     {
       "name": "drift-recon",
       "description": "Audit existing ML monitoring",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/drift/skills/drift-recon",
       "tags": ["skill", "data-science-team", "drift", "ml"]
     },
     {
       "name": "vect",
       "description": "Embeddings & Vector Search Engineer — Embeddings and vector search — semantic search, RAG pipelines, vector database design",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/vect",
       "tags": ["agent", "data-science-team", "vect", "ml"]
     },
     {
       "name": "vect-embed",
       "description": "Design an embedding pipeline",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/vect/skills/vect-embed",
       "tags": ["skill", "data-science-team", "vect", "ml"]
     },
     {
       "name": "vect-search",
       "description": "Design a vector search or RAG system",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/vect/skills/vect-search",
       "tags": ["skill", "data-science-team", "vect", "ml"]
     },
     {
       "name": "vect-recon",
       "description": "Audit existing vector search or RAG implementation",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/vect/skills/vect-recon",
       "tags": ["skill", "data-science-team", "vect", "ml"]
     },
     {
       "name": "tune",
       "description": "LLM Fine-tuning Engineer — LLM fine-tuning — PEFT/LoRA, RLHF, instruction tuning, prompt optimization",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/tune",
       "tags": ["agent", "data-science-team", "tune", "ml"]
     },
     {
       "name": "tune-finetune",
       "description": "Design a fine-tuning pipeline",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/tune/skills/tune-finetune",
       "tags": ["skill", "data-science-team", "tune", "ml"]
     },
     {
       "name": "tune-prompt",
       "description": "Systematically optimize prompts for a task",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/tune/skills/tune-prompt",
       "tags": ["skill", "data-science-team", "tune", "ml"]
     },
     {
       "name": "tune-recon",
       "description": "Audit existing fine-tuning or prompt engineering work",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/tune/skills/tune-recon",
       "tags": ["skill", "data-science-team", "tune", "ml"]
     },
     {
       "name": "plot",
       "description": "Data Visualization Engineer — Data visualization — chart design, visualization libraries, exploratory analysis",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/plot",
       "tags": ["agent", "data-science-team", "plot", "ml"]
     },
     {
       "name": "plot-chart",
       "description": "Design or critique a data visualization",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/plot/skills/plot-chart",
       "tags": ["skill", "data-science-team", "plot", "ml"]
     },
     {
       "name": "plot-eda",
       "description": "Design an exploratory data analysis workflow",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/plot/skills/plot-eda",
       "tags": ["skill", "data-science-team", "plot", "ml"]
     },
     {
       "name": "plot-recon",
       "description": "Audit existing visualizations in a codebase or notebook",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/plot/skills/plot-recon",
       "tags": ["skill", "data-science-team", "plot", "ml"]
     },
     {
       "name": "clean",
       "description": "Data Quality Engineer — Data quality — deduplication, validation, outlier detection, ETL pipeline design",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/clean",
       "tags": ["agent", "data-science-team", "clean", "ml"]
     },
     {
       "name": "clean-validate",
       "description": "Design a data validation pipeline",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/clean/skills/clean-validate",
       "tags": ["skill", "data-science-team", "clean", "ml"]
     },
     {
       "name": "clean-transform",
       "description": "Design a data cleaning and transformation pipeline",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/clean/skills/clean-transform",
       "tags": ["skill", "data-science-team", "clean", "ml"]
     },
     {
       "name": "clean-recon",
       "description": "Audit existing data cleaning code",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/clean/skills/clean-recon",
       "tags": ["skill", "data-science-team", "clean", "ml"]
     },
     {
       "name": "eval",
       "description": "Experiment Design Engineer — Experiment design — A/B testing, statistical power, experiment tracking, causal inference",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/eval",
       "tags": ["agent", "data-science-team", "eval", "ml"]
     },
     {
       "name": "eval-design",
       "description": "Design an A/B test",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/eval/skills/eval-design",
       "tags": ["skill", "data-science-team", "eval", "ml"]
     },
     {
       "name": "eval-analyze",
       "description": "Analyze A/B test results",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/eval/skills/eval-analyze",
       "tags": ["skill", "data-science-team", "eval", "ml"]
     },
     {
       "name": "eval-recon",
       "description": "Audit existing experimentation infrastructure",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/eval/skills/eval-recon",
       "tags": ["skill", "data-science-team", "eval", "ml"]
     },
     {
       "name": "secops-team",
       "description": "Security Operations Team bundle — 10 agents: Red, Blue, Hunt, Patch, Chain, Sast, Siem, Resp, Zero, Phish",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./bundle/secops-team",
       "tags": ["bundle", "secops-team", "security"]
     },
     {
       "name": "red",
       "description": "Offensive Security Engineer — Red team operations — penetration testing, attack simulation, vulnerability exploitation",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/red",
       "tags": ["agent", "secops-team", "red", "security"]
     },
     {
       "name": "red-pentest",
       "description": "Design a penetration testing plan — scope, methodology, and rules of engagement",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/red/skills/red-pentest",
       "tags": ["skill", "secops-team", "red", "security"]
     },
     {
       "name": "red-report",
       "description": "Write a penetration test finding report with CVSS scores and remediation",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/red/skills/red-report",
       "tags": ["skill", "secops-team", "red", "security"]
     },
     {
       "name": "red-recon",
       "description": "Design a reconnaissance plan — OSINT and attack surface mapping",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/red/skills/red-recon",
       "tags": ["skill", "secops-team", "red", "security"]
     },
     {
       "name": "blue",
       "description": "Defensive Security Engineer — Blue team operations — SOC design, detection engineering, hardening playbooks",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/blue",
       "tags": ["agent", "secops-team", "blue", "security"]
     },
     {
       "name": "blue-detect",
       "description": "Design detection rules for a threat — SIEM queries and MITRE ATT&CK mapping",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/blue/skills/blue-detect",
       "tags": ["skill", "secops-team", "blue", "security"]
     },
     {
       "name": "blue-harden",
       "description": "Write a hardening playbook — CIS benchmark mapping and implementation steps",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/blue/skills/blue-harden",
       "tags": ["skill", "secops-team", "blue", "security"]
     },
     {
       "name": "blue-recon",
       "description": "Audit existing security controls and detection coverage",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/blue/skills/blue-recon",
       "tags": ["skill", "secops-team", "blue", "security"]
     },
     {
       "name": "hunt",
       "description": "Threat Hunter — Threat hunting — hypothesis-driven hunting, compromise assessment, IOC analysis",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/hunt",
       "tags": ["agent", "secops-team", "hunt", "security"]
     },
     {
       "name": "hunt-assess",
       "description": "Design a compromise assessment — hunting scope and evidence collection",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/hunt/skills/hunt-assess",
       "tags": ["skill", "secops-team", "hunt", "security"]
     },
     {
       "name": "hunt-ioc",
       "description": "Analyze indicators of compromise — enrichment and attribution",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/hunt/skills/hunt-ioc",
       "tags": ["skill", "secops-team", "hunt", "security"]
     },
     {
       "name": "hunt-recon",
       "description": "Design a threat hunting program — maturity assessment and playbook library",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/hunt/skills/hunt-recon",
       "tags": ["skill", "secops-team", "hunt", "security"]
     },
     {
       "name": "patch",
       "description": "Vulnerability Management Engineer — Vulnerability management — CVE triage, CVSS prioritization, patching cadence, SLA design",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/patch",
       "tags": ["agent", "secops-team", "patch", "security"]
     },
     {
       "name": "patch-triage",
       "description": "Triage CVEs — CVSS + EPSS + KEV scoring and prioritization",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/patch/skills/patch-triage",
       "tags": ["skill", "secops-team", "patch", "security"]
     },
     {
       "name": "patch-plan",
       "description": "Design a vulnerability management program — SLAs and asset tiers",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/patch/skills/patch-plan",
       "tags": ["skill", "secops-team", "patch", "security"]
     },
     {
       "name": "patch-recon",
       "description": "Audit existing vulnerability management for SLA gaps",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/patch/skills/patch-recon",
       "tags": ["skill", "secops-team", "patch", "security"]
     },
     {
       "name": "chain",
       "description": "Supply Chain Security Engineer — Supply chain security — SBOM generation, dependency scanning, third-party risk, license compliance",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/chain",
       "tags": ["agent", "secops-team", "chain", "security"]
     },
     {
       "name": "chain-sbom",
       "description": "Design an SBOM generation pipeline for CI/CD",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/chain/skills/chain-sbom",
       "tags": ["skill", "secops-team", "chain", "security"]
     },
     {
       "name": "chain-scan",
       "description": "Design a dependency scanning program — CVE detection and license checks",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/chain/skills/chain-scan",
       "tags": ["skill", "secops-team", "chain", "security"]
     },
     {
       "name": "chain-recon",
       "description": "Audit existing dependency security and supply chain gaps",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/chain/skills/chain-recon",
       "tags": ["skill", "secops-team", "chain", "security"]
     },
     {
       "name": "sast",
       "description": "Application Security Engineer — Application security — SAST/DAST scanning, code security review, secure SDLC design",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/sast",
       "tags": ["agent", "secops-team", "sast", "security"]
     },
     {
       "name": "sast-scan",
       "description": "Design a SAST/DAST scanning pipeline — tooling and CI integration",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/sast/skills/sast-scan",
       "tags": ["skill", "secops-team", "sast", "security"]
     },
     {
       "name": "sast-fix",
       "description": "Analyze and fix a SAST finding with secure code alternative",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/sast/skills/sast-fix",
       "tags": ["skill", "secops-team", "sast", "security"]
     },
     {
       "name": "sast-recon",
       "description": "Audit application security tooling for OWASP Top 10 coverage",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/sast/skills/sast-recon",
       "tags": ["skill", "secops-team", "sast", "security"]
     },
     {
       "name": "siem",
       "description": "Detection & SIEM Engineer — SIEM engineering — log pipeline design, detection rule development, alert tuning",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/siem",
       "tags": ["agent", "secops-team", "siem", "security"]
     },
     {
       "name": "siem-rule",
       "description": "Write SIEM detection rules in SIGMA format with MITRE mapping",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/siem/skills/siem-rule",
       "tags": ["skill", "secops-team", "siem", "security"]
     },
     {
       "name": "siem-alert",
       "description": "Tune a SIEM alert to reduce false positives",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/siem/skills/siem-alert",
       "tags": ["skill", "secops-team", "siem", "security"]
     },
     {
       "name": "siem-recon",
       "description": "Audit existing SIEM deployment — log coverage and rule quality",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/siem/skills/siem-recon",
       "tags": ["skill", "secops-team", "siem", "security"]
     },
     {
       "name": "resp",
       "description": "Incident Response Engineer — Incident response — playbook design, containment procedures, DFIR, post-incident review",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/resp",
       "tags": ["agent", "secops-team", "resp", "security"]
     },
     {
       "name": "resp-playbook",
       "description": "Write an incident response playbook for a threat scenario",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/resp/skills/resp-playbook",
       "tags": ["skill", "secops-team", "resp", "security"]
     },
     {
       "name": "resp-contain",
       "description": "Design containment procedures for an active incident",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/resp/skills/resp-contain",
       "tags": ["skill", "secops-team", "resp", "security"]
     },
     {
       "name": "resp-recon",
       "description": "Audit existing incident response capability and playbook coverage",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/resp/skills/resp-recon",
       "tags": ["skill", "secops-team", "resp", "security"]
     },
     {
       "name": "zero",
       "description": "Zero Trust Architect — Zero trust architecture — network segmentation, identity-based access, microsegmentation design",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/zero",
       "tags": ["agent", "secops-team", "zero", "security"]
     },
     {
       "name": "zero-design",
       "description": "Design a zero trust architecture — phased roadmap and segmentation",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/zero/skills/zero-design",
       "tags": ["skill", "secops-team", "zero", "security"]
     },
     {
       "name": "zero-audit",
       "description": "Audit an environment against zero trust principles",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/zero/skills/zero-audit",
       "tags": ["skill", "secops-team", "zero", "security"]
     },
     {
       "name": "zero-recon",
       "description": "Survey network and identity controls for zero trust readiness",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/zero/skills/zero-recon",
       "tags": ["skill", "secops-team", "zero", "security"]
     },
     {
       "name": "phish",
       "description": "Security Awareness Engineer — Security awareness — phishing simulation design, security training programs, social engineering assessment",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/phish",
       "tags": ["agent", "secops-team", "phish", "security"]
     },
     {
       "name": "phish-assess",
       "description": "Design a phishing simulation program — scenarios and measurement",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/phish/skills/phish-assess",
       "tags": ["skill", "secops-team", "phish", "security"]
     },
     {
       "name": "phish-train",
       "description": "Design a security awareness training curriculum",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/phish/skills/phish-train",
       "tags": ["skill", "secops-team", "phish", "security"]
     },
     {
       "name": "phish-recon",
       "description": "Audit existing security awareness program — coverage and effectiveness",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/phish/skills/phish-recon",
       "tags": ["skill", "secops-team", "phish", "security"]
     },
     {
       "name": "devx-team",
       "description": "Developer Experience Team bundle — 10 agents: Guide, Sample, Mock, Schema, Port, Change, Onboard, Bench, Compat, Gate",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./bundle/devx-team",
       "tags": ["bundle", "devx-team", "developer-experience"]
     },
     {
       "name": "guide",
       "description": "API Documentation Engineer — API and SDK documentation — reference docs, guides, and documentation architecture",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/guide",
       "tags": ["agent", "devx-team", "guide", "developer-experience"]
     },
     {
       "name": "guide-write",
       "description": "Write API reference documentation for an endpoint or SDK method",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/guide/skills/guide-write",
       "tags": ["skill", "devx-team", "guide", "developer-experience"]
     },
     {
       "name": "guide-audit",
       "description": "Audit existing API documentation for completeness and accuracy",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/guide/skills/guide-audit",
       "tags": ["skill", "devx-team", "guide", "developer-experience"]
     },
     {
       "name": "guide-recon",
       "description": "Survey documentation coverage across an API or SDK",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/guide/skills/guide-recon",
       "tags": ["skill", "devx-team", "guide", "developer-experience"]
     },
     {
       "name": "sample",
       "description": "Code Sample Engineer — Code samples and tutorials — working examples, quickstarts, and language-specific guides",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/sample",
       "tags": ["agent", "devx-team", "sample", "developer-experience"]
     },
     {
       "name": "sample-write",
       "description": "Write a working code sample or tutorial for an API feature",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/sample/skills/sample-write",
       "tags": ["skill", "devx-team", "sample", "developer-experience"]
     },
     {
       "name": "sample-review",
       "description": "Review existing code samples for correctness and developer experience",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/sample/skills/sample-review",
       "tags": ["skill", "devx-team", "sample", "developer-experience"]
     },
     {
       "name": "sample-recon",
       "description": "Survey existing code samples — coverage, language parity, and freshness",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/sample/skills/sample-recon",
       "tags": ["skill", "devx-team", "sample", "developer-experience"]
     },
     {
       "name": "mock",
       "description": "API Mocking & Contract Engineer — API mocking — mock server design, contract testing, API simulation",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/mock",
       "tags": ["agent", "devx-team", "mock", "developer-experience"]
     },
     {
       "name": "mock-design",
       "description": "Design a mock server for an API",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/mock/skills/mock-design",
       "tags": ["skill", "devx-team", "mock", "developer-experience"]
     },
     {
       "name": "mock-contract",
       "description": "Design a consumer-driven contract testing setup",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/mock/skills/mock-contract",
       "tags": ["skill", "devx-team", "mock", "developer-experience"]
     },
     {
       "name": "mock-recon",
       "description": "Audit existing mocks for contract drift and missing error cases",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/mock/skills/mock-recon",
       "tags": ["skill", "devx-team", "mock", "developer-experience"]
     },
     {
       "name": "schema",
       "description": "API Schema Engineer — API schema design — OpenAPI, GraphQL, gRPC schema quality and design standards",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/schema",
       "tags": ["agent", "devx-team", "schema", "developer-experience"]
     },
     {
       "name": "schema-design",
       "description": "Design an API schema — OpenAPI, GraphQL, or gRPC proto",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/schema/skills/schema-design",
       "tags": ["skill", "devx-team", "schema", "developer-experience"]
     },
     {
       "name": "schema-review",
       "description": "Review an API schema for consistency and completeness",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/schema/skills/schema-review",
       "tags": ["skill", "devx-team", "schema", "developer-experience"]
     },
     {
       "name": "schema-recon",
       "description": "Audit existing API schemas for inconsistencies and coverage gaps",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/schema/skills/schema-recon",
       "tags": ["skill", "devx-team", "schema", "developer-experience"]
     },
     {
       "name": "port",
       "description": "SDK Design Engineer — SDK design — multi-language SDK architecture, idiomatic patterns, cross-language consistency",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/port",
       "tags": ["agent", "devx-team", "port", "developer-experience"]
     },
     {
       "name": "port-design",
       "description": "Design an SDK architecture for an API",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/port/skills/port-design",
       "tags": ["skill", "devx-team", "port", "developer-experience"]
     },
     {
       "name": "port-review",
       "description": "Review an existing SDK for idiomatic quality and consistency",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/port/skills/port-review",
       "tags": ["skill", "devx-team", "port", "developer-experience"]
     },
     {
       "name": "port-recon",
       "description": "Audit multi-language SDK coverage and consistency",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/port/skills/port-recon",
       "tags": ["skill", "devx-team", "port", "developer-experience"]
     },
     {
       "name": "change",
       "description": "Changelog & Release Communication Engineer — Changelog and release communication — breaking change docs, deprecation notices, migration guides",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/change",
       "tags": ["agent", "devx-team", "change", "developer-experience"]
     },
     {
       "name": "change-write",
       "description": "Write a changelog entry or release notes for an API version",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/change/skills/change-write",
       "tags": ["skill", "devx-team", "change", "developer-experience"]
     },
     {
       "name": "change-policy",
       "description": "Design an API versioning and deprecation policy",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/change/skills/change-policy",
       "tags": ["skill", "devx-team", "change", "developer-experience"]
     },
     {
       "name": "change-recon",
       "description": "Audit existing changelog and deprecation practices",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/change/skills/change-recon",
       "tags": ["skill", "devx-team", "change", "developer-experience"]
     },
     {
       "name": "onboard",
       "description": "Developer Onboarding Engineer — Developer onboarding — quickstart design, time-to-first-call optimization, onboarding funnel audit",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/onboard",
       "tags": ["agent", "devx-team", "onboard", "developer-experience"]
     },
     {
       "name": "onboard-quickstart",
       "description": "Write a developer quickstart — minimal steps to first successful API call",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/onboard/skills/onboard-quickstart",
       "tags": ["skill", "devx-team", "onboard", "developer-experience"]
     },
     {
       "name": "onboard-audit",
       "description": "Audit the developer onboarding experience and measure TTFC",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/onboard/skills/onboard-audit",
       "tags": ["skill", "devx-team", "onboard", "developer-experience"]
     },
     {
       "name": "onboard-recon",
       "description": "Survey existing onboarding docs and developer portal",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/onboard/skills/onboard-recon",
       "tags": ["skill", "devx-team", "onboard", "developer-experience"]
     },
     {
       "name": "bench",
       "description": "API Performance Engineer — API performance benchmarking — latency profiling, throughput testing, regression detection",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/bench",
       "tags": ["agent", "devx-team", "bench", "developer-experience"]
     },
     {
       "name": "bench-profile",
       "description": "Design a performance benchmark for an API",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/bench/skills/bench-profile",
       "tags": ["skill", "devx-team", "bench", "developer-experience"]
     },
     {
       "name": "bench-compare",
       "description": "Compare API performance across versions for regression detection",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/bench/skills/bench-compare",
       "tags": ["skill", "devx-team", "bench", "developer-experience"]
     },
     {
       "name": "bench-recon",
       "description": "Audit existing performance testing for gaps and stale baselines",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/bench/skills/bench-recon",
       "tags": ["skill", "devx-team", "bench", "developer-experience"]
     },
     {
       "name": "compat",
       "description": "Backwards Compatibility Engineer — Backwards compatibility — breaking change detection, deprecation management, semver discipline",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/compat",
       "tags": ["agent", "devx-team", "compat", "developer-experience"]
     },
     {
       "name": "compat-audit",
       "description": "Audit a proposed API change for breaking changes",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/compat/skills/compat-audit",
       "tags": ["skill", "devx-team", "compat", "developer-experience"]
     },
     {
       "name": "compat-policy",
       "description": "Design an API compatibility and deprecation policy",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/compat/skills/compat-policy",
       "tags": ["skill", "devx-team", "compat", "developer-experience"]
     },
     {
       "name": "compat-recon",
       "description": "Audit existing API for breaking change risks and missing controls",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/compat/skills/compat-recon",
       "tags": ["skill", "devx-team", "compat", "developer-experience"]
     },
     {
       "name": "gate",
       "description": "API Quality Gate Engineer — API quality gates — linting, style enforcement, breaking change CI, and API governance",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/gate",
       "tags": ["agent", "devx-team", "gate", "developer-experience"]
     },
     {
       "name": "gate-lint",
       "description": "Design an API linting ruleset with style rules and severity levels",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/gate/skills/gate-lint",
       "tags": ["skill", "devx-team", "gate", "developer-experience"]
     },
     {
       "name": "gate-ci",
       "description": "Integrate API quality gates into CI",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/gate/skills/gate-ci",
       "tags": ["skill", "devx-team", "gate", "developer-experience"]
     },
     {
       "name": "gate-recon",
       "description": "Audit existing API quality controls and CI gates",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./team/gate/skills/gate-recon",
       "tags": ["skill", "devx-team", "gate", "developer-experience"]
     },
     {
       "name": "infra-specialist-team",
       "description": "Infrastructure Specialist Team — 10 agents: Kube, Terra, Finop, Serv, Edge, Cache, Queue, Mesh, Multi, Chaos",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["bundle", "infrastructure", "cloud", "team"],
       "source": "./bundle/infra-specialist-team"
     },
     {
       "name": "kube",
       "description": "Infrastructure Specialist Team — Kube: Kubernetes cluster design — RBAC, networking, operators, workload configuration",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["agent", "infrastructure", "cloud"],
       "source": "./team/kube"
     },
     {
       "name": "kube-design",
       "description": "Kube skill: kube-design",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "kube"],
       "source": "./team/kube/skills/kube-design"
     },
     {
       "name": "kube-rbac",
       "description": "Kube skill: kube-rbac",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "kube"],
       "source": "./team/kube/skills/kube-rbac"
     },
     {
       "name": "kube-recon",
       "description": "Kube skill: kube-recon",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "kube"],
       "source": "./team/kube/skills/kube-recon"
     },
     {
       "name": "terra",
       "description": "Infrastructure Specialist Team — Terra: Terraform and IaC — module design, state management, drift detection, and IaC best practices",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["agent", "infrastructure", "cloud"],
       "source": "./team/terra"
     },
     {
       "name": "terra-drift",
       "description": "Terra skill: terra-drift",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "terra"],
       "source": "./team/terra/skills/terra-drift"
     },
     {
       "name": "terra-module",
       "description": "Terra skill: terra-module",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "terra"],
       "source": "./team/terra/skills/terra-module"
     },
     {
       "name": "terra-recon",
       "description": "Terra skill: terra-recon",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "terra"],
       "source": "./team/terra/skills/terra-recon"
     },
     {
       "name": "finop",
       "description": "Infrastructure Specialist Team — Finop: Cloud cost optimization — FinOps practices, rightsizing, reservation strategy, cost attribution",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["agent", "infrastructure", "cloud"],
       "source": "./team/finop"
     },
     {
       "name": "finop-audit",
       "description": "Finop skill: finop-audit",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "finop"],
       "source": "./team/finop/skills/finop-audit"
     },
     {
       "name": "finop-recon",
       "description": "Finop skill: finop-recon",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "finop"],
       "source": "./team/finop/skills/finop-recon"
     },
     {
       "name": "finop-reserve",
       "description": "Finop skill: finop-reserve",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "finop"],
       "source": "./team/finop/skills/finop-reserve"
     },
     {
       "name": "serv",
       "description": "Infrastructure Specialist Team — Serv: Serverless architecture — Lambda/Cloud Functions/Cloud Run design, cold start optimization, event patterns",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["agent", "infrastructure", "cloud"],
       "source": "./team/serv"
     },
     {
       "name": "serv-cold",
       "description": "Serv skill: serv-cold",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "serv"],
       "source": "./team/serv/skills/serv-cold"
     },
     {
       "name": "serv-design",
       "description": "Serv skill: serv-design",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "serv"],
       "source": "./team/serv/skills/serv-design"
     },
     {
       "name": "serv-recon",
       "description": "Serv skill: serv-recon",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "serv"],
       "source": "./team/serv/skills/serv-recon"
     },
     {
       "name": "edge",
       "description": "Infrastructure Specialist Team — Edge: Edge computing and CDN — global distribution, cache strategy, edge functions, latency optimization",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["agent", "infrastructure", "cloud"],
       "source": "./team/edge"
     },
     {
       "name": "edge-cdn",
       "description": "Edge skill: edge-cdn",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "edge"],
       "source": "./team/edge/skills/edge-cdn"
     },
     {
       "name": "edge-recon",
       "description": "Edge skill: edge-recon",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "edge"],
       "source": "./team/edge/skills/edge-recon"
     },
     {
       "name": "edge-route",
       "description": "Edge skill: edge-route",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "edge"],
       "source": "./team/edge/skills/edge-route"
     },
     {
       "name": "cache",
       "description": "Infrastructure Specialist Team — Cache: Caching strategy — Redis/Memcached design, cache invalidation, eviction policies, application caching patterns",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["agent", "infrastructure", "cloud"],
       "source": "./team/cache"
     },
     {
       "name": "cache-design",
       "description": "Cache skill: cache-design",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "cache"],
       "source": "./team/cache/skills/cache-design"
     },
     {
       "name": "cache-evict",
       "description": "Cache skill: cache-evict",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "cache"],
       "source": "./team/cache/skills/cache-evict"
     },
     {
       "name": "cache-recon",
       "description": "Cache skill: cache-recon",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "cache"],
       "source": "./team/cache/skills/cache-recon"
     },
     {
       "name": "queue",
       "description": "Infrastructure Specialist Team — Queue: Message queuing and streaming — Kafka, SQS, RabbitMQ design, consumer group strategy, dead letter queues",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["agent", "infrastructure", "cloud"],
       "source": "./team/queue"
     },
     {
       "name": "queue-design",
       "description": "Queue skill: queue-design",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "queue"],
       "source": "./team/queue/skills/queue-design"
     },
     {
       "name": "queue-recon",
       "description": "Queue skill: queue-recon",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "queue"],
       "source": "./team/queue/skills/queue-recon"
     },
     {
       "name": "queue-scale",
       "description": "Queue skill: queue-scale",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "queue"],
       "source": "./team/queue/skills/queue-scale"
     },
     {
       "name": "mesh",
       "description": "Infrastructure Specialist Team — Mesh: Service mesh design — Istio/Linkerd/Envoy, mTLS, traffic management, observability integration",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["agent", "infrastructure", "cloud"],
       "source": "./team/mesh"
     },
     {
       "name": "mesh-design",
       "description": "Mesh skill: mesh-design",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "mesh"],
       "source": "./team/mesh/skills/mesh-design"
     },
     {
       "name": "mesh-observe",
       "description": "Mesh skill: mesh-observe",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "mesh"],
       "source": "./team/mesh/skills/mesh-observe"
     },
     {
       "name": "mesh-recon",
       "description": "Mesh skill: mesh-recon",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "mesh"],
       "source": "./team/mesh/skills/mesh-recon"
     },
     {
       "name": "multi",
       "description": "Infrastructure Specialist Team — Multi: Multi-cloud architecture — provider selection, portability strategy, lock-in avoidance, workload placement",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["agent", "infrastructure", "cloud"],
       "source": "./team/multi"
     },
     {
       "name": "multi-design",
       "description": "Multi skill: multi-design",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "multi"],
       "source": "./team/multi/skills/multi-design"
     },
     {
       "name": "multi-port",
       "description": "Multi skill: multi-port",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "multi"],
       "source": "./team/multi/skills/multi-port"
     },
     {
       "name": "multi-recon",
       "description": "Multi skill: multi-recon",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "multi"],
       "source": "./team/multi/skills/multi-recon"
     },
     {
       "name": "chaos",
       "description": "Infrastructure Specialist Team — Chaos: Chaos engineering — failure injection design, game days, resilience testing, blast radius control",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["agent", "infrastructure", "cloud"],
       "source": "./team/chaos"
     },
     {
       "name": "chaos-design",
       "description": "Chaos skill: chaos-design",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "chaos"],
       "source": "./team/chaos/skills/chaos-design"
     },
     {
       "name": "chaos-game",
       "description": "Chaos skill: chaos-game",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "chaos"],
       "source": "./team/chaos/skills/chaos-game"
     },
     {
       "name": "chaos-recon",
       "description": "Chaos skill: chaos-recon",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "infrastructure", "chaos"],
       "source": "./team/chaos/skills/chaos-recon"
     },
     {
       "name": "ai-ops-team",
       "description": "AI Operations Team — 9 agents: Deploy, Eval, Trace, Guard, Budget, Token, Prompt, Embed, Rank",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["bundle", "ai-ops", "llm", "team"],
       "source": "./bundle/ai-ops-team"
     },
     {
       "name": "deploy",
       "description": "AI Operations Team — Deploy: Model serving, inference APIs, blue/green deploys, rollback, and canary releases for production ML.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["agent", "ai-ops", "llm"],
       "source": "./team/deploy"
     },
     {
       "name": "deploy-serve",
       "description": "Design and configure model serving infrastructure — endpoint scaling, batching, GPU allocation.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "deploy"],
       "source": "./team/deploy/skills/deploy-serve"
     },
     {
       "name": "deploy-canary",
       "description": "Plan and execute canary releases for model updates — traffic splitting, rollback triggers, success metrics.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "deploy"],
       "source": "./team/deploy/skills/deploy-canary"
     },
     {
       "name": "deploy-recon",
       "description": "Audit current model deployment topology — serving config, latency profile, version inventory.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "deploy"],
       "source": "./team/deploy/skills/deploy-recon"
     },
     {
       "name": "trace",
       "description": "AI Operations Team — Trace: LLM tracing, span capture, prompt/completion logging, cost attribution, and AI system debugging.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["agent", "ai-ops", "llm"],
       "source": "./team/trace"
     },
     {
       "name": "trace-instrument",
       "description": "Instrument LLM calls with tracing — span structure, token counts, latency, model metadata.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "trace"],
       "source": "./team/trace/skills/trace-instrument"
     },
     {
       "name": "trace-debug",
       "description": "Debug AI system behavior using traces — prompt reconstruction, output comparison, failure attribution.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "trace"],
       "source": "./team/trace/skills/trace-debug"
     },
     {
       "name": "trace-recon",
       "description": "Audit LLM observability coverage — trace gaps, logging completeness, cost attribution accuracy.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "trace"],
       "source": "./team/trace/skills/trace-recon"
     },
     {
       "name": "guard",
       "description": "AI Operations Team — Guard: Input/output safety filters, PII detection, content moderation, and AI policy enforcement at runtime.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["agent", "ai-ops", "llm"],
       "source": "./team/guard"
     },
     {
       "name": "guard-design",
       "description": "Design guardrail layers — input classifiers, output validators, PII scrubbers, policy rule engines.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "guard"],
       "source": "./team/guard/skills/guard-design"
     },
     {
       "name": "guard-audit",
       "description": "Audit guardrail coverage — bypass vectors, false positive rates, policy gap analysis, red-team scenarios.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "guard"],
       "source": "./team/guard/skills/guard-audit"
     },
     {
       "name": "guard-recon",
       "description": "Map current AI safety controls — filter inventory, coverage gaps, latency impact, incident history.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "guard"],
       "source": "./team/guard/skills/guard-recon"
     },
     {
       "name": "budget",
       "description": "AI Operations Team — Budget: LLM spend tracking, model cost optimization, budget alerts, and token efficiency audits across AI workloads.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["agent", "ai-ops", "llm"],
       "source": "./team/budget"
     },
     {
       "name": "budget-audit",
       "description": "Audit AI spend — per-model cost breakdown, top consumers, waste identification, optimization levers.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "budget"],
       "source": "./team/budget/skills/budget-audit"
     },
     {
       "name": "budget-optimize",
       "description": "Design cost reduction strategies — model tiering, prompt compression, caching, batch inference.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "budget"],
       "source": "./team/budget/skills/budget-optimize"
     },
     {
       "name": "budget-recon",
       "description": "Map AI cost topology — billing attribution, team-level spend, forecast vs actuals, alert gaps.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "budget"],
       "source": "./team/budget/skills/budget-recon"
     },
     {
       "name": "token",
       "description": "AI Operations Team — Token: Context window optimization, token counting, truncation strategies, and chunking patterns for LLM efficiency.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["agent", "ai-ops", "llm"],
       "source": "./team/token"
     },
     {
       "name": "token-budget",
       "description": "Design token budgets — system/user/assistant allocation, overflow handling, context compression.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "token"],
       "source": "./team/token/skills/token-budget"
     },
     {
       "name": "token-chunk",
       "description": "Design chunking strategies — semantic splitting, overlap tuning, retrieval-aware chunk sizing.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "token"],
       "source": "./team/token/skills/token-chunk"
     },
     {
       "name": "token-recon",
       "description": "Audit token usage patterns — avg context size, waste, truncation frequency, budget adherence.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "token"],
       "source": "./team/token/skills/token-recon"
     },
     {
       "name": "prompt",
       "description": "AI Operations Team — Prompt: System prompt design, few-shot libraries, chain-of-thought patterns, and prompt versioning for production LLM applications.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["agent", "ai-ops", "llm"],
       "source": "./team/prompt"
     },
     {
       "name": "prompt-design",
       "description": "Design production prompts — system prompt architecture, instruction clarity, few-shot selection.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "prompt"],
       "source": "./team/prompt/skills/prompt-design"
     },
     {
       "name": "prompt-version",
       "description": "Build prompt versioning systems — storage, A/B testing, regression tracking, rollback.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "prompt"],
       "source": "./team/prompt/skills/prompt-version"
     },
     {
       "name": "prompt-recon",
       "description": "Audit prompt library — duplication, quality, coverage gaps, version drift, eval alignment.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "prompt"],
       "source": "./team/prompt/skills/prompt-recon"
     },
     {
       "name": "embed",
       "description": "AI Operations Team — Embed: Embedding model selection, vector pipeline design, similarity search, and production index management.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["agent", "ai-ops", "llm"],
       "source": "./team/embed"
     },
     {
       "name": "embed-design",
       "description": "Design embedding pipelines — model selection, batching, normalization, index refresh strategy.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "embed"],
       "source": "./team/embed/skills/embed-design"
     },
     {
       "name": "embed-search",
       "description": "Optimize similarity search — ANN index tuning, hybrid search, reranking, query expansion.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "embed"],
       "source": "./team/embed/skills/embed-search"
     },
     {
       "name": "embed-recon",
       "description": "Audit embedding infrastructure — model drift, index freshness, query latency, coverage gaps.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "embed"],
       "source": "./team/embed/skills/embed-recon"
     },
     {
       "name": "rank",
       "description": "AI Operations Team — Rank: Retrieval reranking, relevance scoring, learning-to-rank pipelines, and result quality evaluation for search and RAG.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["agent", "ai-ops", "llm"],
       "source": "./team/rank"
     },
     {
       "name": "rank-design",
       "description": "Design ranking pipelines — reranker selection, score fusion, cross-encoder patterns, latency trade-offs.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "rank"],
       "source": "./team/rank/skills/rank-design"
     },
     {
       "name": "rank-eval",
       "description": "Build ranking evaluation — NDCG/MRR measurement, human relevance labeling, offline eval harness.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "rank"],
       "source": "./team/rank/skills/rank-eval"
     },
     {
       "name": "rank-recon",
       "description": "Audit ranking quality — metric trends, failure modes, dataset coverage, reranker performance.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "rank"],
       "source": "./team/rank/skills/rank-recon"
     },
     {
       "name": "eval-harness",
       "description": "Design eval harnesses — task schemas, metrics, dataset versioning, eval-as-code patterns.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "eval"],
       "source": "./team/evals/skills/eval-harness"
     },
     {
       "name": "eval-regress",
       "description": "Build automated regression suites — golden sets, threshold alerting, CI integration for model changes.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["skill", "ai-ops", "eval"],
       "source": "./team/evals/skills/eval-regress"
     },
     {
       "name": "evals",
       "description": "AI Operations Team — Evals: Eval harness design, benchmark suites, automated regression, human eval orchestration.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "tags": ["agent", "ai-ops", "llm"],
       "source": "./team/evals"
     },
     {
       "name": "buzz-community",
       "description": "Build and manage open source community \u2014 Discord/Slack structure, contributor onboarding, ambassador program, community flywheel design, and GitHub community health. Use when asked to \"build a community\", \"grow our Discord\", \"improve contributor experience\", or \"design a developer ambassador program\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/buzz-community",
       "author": {
         "name": "tonone-ai",
@@ -4489,7 +4489,7 @@
     {
       "name": "buzz-launch",
       "description": "Design and execute a launch plan \u2014 Product Hunt, HN Show HN, newsletter coordination, social posts, and community launch moment. Use when asked to \"launch [feature/product]\", \"plan a launch\", \"help us do a Product Hunt launch\", or \"coordinate the announcement\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/buzz-launch",
       "author": {
         "name": "tonone-ai",
@@ -4502,7 +4502,7 @@
     {
       "name": "buzz-pitch",
       "description": "Write media pitches and press releases \u2014 journalist outreach emails, podcast pitch scripts, newsletter sponsor pitches, and press release copy. Use when asked to \"pitch journalists\", \"write a press release\", \"reach out to podcasts\", or \"get media coverage\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/buzz-pitch",
       "author": {
         "name": "tonone-ai",
@@ -4515,7 +4515,7 @@
     {
       "name": "buzz-recon",
       "description": "PR and community reconnaissance \u2014 audit current press coverage, social presence, community health, and competitor PR. Use when asked to \"audit our PR\", \"what's our community state\", \"how do we compare in press\", or before planning a launch or community initiative.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/buzz-recon",
       "author": {
         "name": "tonone-ai",
@@ -4528,7 +4528,7 @@
     {
       "name": "buzz-social",
       "description": "Social media strategy and post drafting \u2014 HN posts, Twitter/X threads, LinkedIn posts, Reddit comments, and developer community content. Use when asked to \"write a HN post\", \"draft social posts\", \"help us post on Twitter\", or \"create a social launch plan\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/buzz-social",
       "author": {
         "name": "tonone-ai",
@@ -4541,7 +4541,7 @@
     {
       "name": "deal-close",
       "description": "Close a specific deal \u2014 diagnose why a deal is stalling, write a tailored proposal, design the closing sequence, or navigate procurement. Use when a specific deal is stuck, \"how do I close this\", \"write a proposal for this customer\", or \"help me get to yes\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/deal-close",
       "author": {
         "name": "tonone-ai",
@@ -4554,7 +4554,7 @@
     {
       "name": "deal-pipeline",
       "description": "Design or audit B2B sales pipeline \u2014 define stage names, entry/exit criteria, qualification standards, and CRM field requirements. Use when asked to \"design our pipeline\", \"audit our CRM stages\", \"define what qualified means\", or \"build a sales process\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/deal-pipeline",
       "author": {
         "name": "tonone-ai",
@@ -4567,7 +4567,7 @@
     {
       "name": "deal-playbook",
       "description": "Write sales playbooks \u2014 outbound sequences, discovery call guides, objection handling scripts, and demo frameworks. Use when asked to \"write a sales playbook\", \"build an outbound sequence\", \"help me handle objections\", or \"design a discovery call\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/deal-playbook",
       "author": {
         "name": "tonone-ai",
@@ -4580,7 +4580,7 @@
     {
       "name": "deal-pricing",
       "description": "Design pricing strategy and packaging \u2014 tiers, value metrics, enterprise pricing, freemium design, and pricing page copy. Use when asked to \"design our pricing\", \"should we change our price\", \"how do we package the product\", or \"what should we charge enterprise\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/deal-pricing",
       "author": {
         "name": "tonone-ai",
@@ -4593,7 +4593,7 @@
     {
       "name": "deal-recon",
       "description": "Revenue reconnaissance \u2014 audit current sales pipeline, deal patterns, ICP definition, and revenue motion to understand what's working and where the constraint is. Use when asked to \"audit our sales\", \"where is revenue stuck\", \"what's our pipeline state\", \"before designing a playbook\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/deal-recon",
       "author": {
         "name": "tonone-ai",
@@ -4606,7 +4606,7 @@
     {
       "name": "ink-calendar",
       "description": "Build a content calendar \u2014 editorial plan, publishing cadence, topic assignment, and distribution workflow. Use when asked to \"build a content calendar\", \"plan our content for the quarter\", \"how often should we publish\", or \"create an editorial schedule\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/ink-calendar",
       "author": {
         "name": "tonone-ai",
@@ -4619,7 +4619,7 @@
     {
       "name": "ink-case",
       "description": "Write customer case studies and success stories \u2014 interview guide, story structure, and publish-ready case study with metrics. Use when asked to \"write a case study\", \"document a customer success story\", \"create social proof content\", or \"write about how [customer] uses the product\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/ink-case",
       "author": {
         "name": "tonone-ai",
@@ -4632,7 +4632,7 @@
     {
       "name": "ink-post",
       "description": "Write a blog post or article \u2014 research the keyword, draft the post, and produce publish-ready content with SEO optimization. Use when asked to \"write a blog post\", \"write about [topic]\", \"draft an article\", or \"write a tutorial\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/ink-post",
       "author": {
         "name": "tonone-ai",
@@ -4645,7 +4645,7 @@
     {
       "name": "ink-recon",
       "description": "Content marketing reconnaissance \u2014 audit current content, SEO health, competitor content gaps, and content distribution. Use when asked to \"audit our content\", \"what's our SEO state\", \"where are the content gaps\", or before designing a content strategy.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/ink-recon",
       "author": {
         "name": "tonone-ai",
@@ -4658,7 +4658,7 @@
     {
       "name": "ink-seo",
       "description": "SEO strategy and keyword research \u2014 build topic clusters, keyword gap analysis, on-page audit, and prioritized SEO roadmap. Use when asked to \"improve our SEO\", \"do keyword research\", \"build a topic cluster\", or \"why aren't we ranking\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/ink-seo",
       "author": {
         "name": "tonone-ai",
@@ -4671,7 +4671,7 @@
     {
       "name": "keep-expand",
       "description": "Design expansion revenue playbooks \u2014 upsell triggers, seat expansion sequences, tier upgrade paths, and cross-sell motions. Use when asked to \"grow existing customers\", \"increase NRR\", \"design upsell\", or \"how do we get customers to expand\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/keep-expand",
       "author": {
         "name": "tonone-ai",
@@ -4684,7 +4684,7 @@
     {
       "name": "keep-health",
       "description": "Design a customer health scoring model \u2014 define signals, weights, thresholds, and action triggers. Use when asked to \"build health scoring\", \"how do we predict churn\", \"what signals indicate a customer is at risk\", or \"design our health model\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/keep-health",
       "author": {
         "name": "tonone-ai",
@@ -4697,7 +4697,7 @@
     {
       "name": "keep-onboard",
       "description": "Optimize customer onboarding \u2014 map the activation sequence, identify drop-off points, design the aha moment, and produce the onboarding email sequence. Use when asked to \"fix onboarding\", \"improve activation\", \"time-to-value is too slow\", or \"customers aren't getting started\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/keep-onboard",
       "author": {
         "name": "tonone-ai",
@@ -4710,7 +4710,7 @@
     {
       "name": "keep-playbook",
       "description": "Write churn prevention and win-back playbooks \u2014 risk intervention sequences, save conversation guides, and win-back email campaigns. Use when asked to \"prevent churn\", \"save at-risk customers\", \"win back churned customers\", or \"build a save play\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/keep-playbook",
       "author": {
         "name": "tonone-ai",
@@ -4723,7 +4723,7 @@
     {
       "name": "keep-recon",
       "description": "Customer success reconnaissance \u2014 audit current onboarding completion, health signals, NRR, churn patterns, and CS motion. Use when asked to \"audit our customer success\", \"why are customers churning\", \"what's our NRR\", or before designing any CS playbook.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/keep-recon",
       "author": {
         "name": "tonone-ai",
@@ -4736,7 +4736,7 @@
     {
       "name": "pave-contribute",
       "description": "Contribute a session learning back to the upstream tonone repo. Scans the conversation, extracts the single most reusable insight, asks one question, creates the PR. Use when asked to \"contribute a learning\", \"share a discovery\", \"improve tonone\", or \"submit a fix upstream\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/pave-contribute",
       "author": {
         "name": "tonone-ai",
@@ -4749,7 +4749,7 @@
     {
       "name": "warden-scan",
       "description": "Automated SAST + dependency vulnerability scan. Runs Semgrep (code vulnerabilities) and pip-audit (CVE-matched dependencies) and writes a structured JSON report. Use when asked to \"scan for vulnerabilities\", \"run a security scan\", \"check for CVEs\", or \"audit dependencies\".",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/warden-scan",
       "author": {
         "name": "tonone-ai",
@@ -4762,7 +4762,7 @@
     {
       "name": "apex-profile",
       "description": "Scope the tonone agent roster for this project \u2014 install a curated subset of agents instead of the full 100-agent bundle. Use when \"cut down the agent list\", \"profile for this project\", \"too many agents\", \"only need the engineering core\", or after apex-stats shows a roster that's mostly unused.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/apex-profile",
       "author": {
         "name": "tonone-ai",
@@ -4775,7 +4775,7 @@
     {
       "name": "apex-route",
       "description": "Reach ANY tonone specialist on demand, even ones not installed in this session's roster \u2014 no restart needed. Use when asked \"which agent handles this\", \"reach a specialist we didn't install\", \"route this to the right agent\", or whenever a scoped apex-profile roster is missing the right hat for the job.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/apex-route",
       "author": {
         "name": "tonone-ai",
@@ -4788,7 +4788,7 @@
     {
       "name": "apex-stats",
       "description": "Spawn-count analytics for the tonone roster \u2014 which agents this project actually uses, from local session transcripts. Use when \"which agents do we actually use\", \"show tonone stats\", \"prune the roster\", or before running apex-profile.",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "source": "./skills/apex-stats",
       "author": {
         "name": "tonone-ai",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tonone",
   "description": "Engineering + Product + Operations + Legal + Design + Data Science + Security Operations + Developer Experience + Infrastructure Specialist + AI Operations team \u2014 100 agents as Claude Code specialists. Infrastructure, DevOps, backend, security, ML/AI, mobile, UX, analytics, growth, revenue, content, PR, customer success, finance, people, operations, support, contracts, compliance, IP, governance, regulatory, color systems, typography, motion, accessibility, design tokens, forecasting, feature engineering, model training, drift monitoring, vector search, LLM fine-tuning, pen testing, detection engineering, incident response, zero trust, API docs, SDK design, developer onboarding, Kubernetes, Terraform, FinOps, service mesh, edge computing, caching, queuing, multi-cloud, chaos engineering, model deployment, LLM evaluation, AI observability, guardrails, prompt engineering, embeddings, ranking, and more.",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "author": {
     "name": "tonone-ai",
     "url": "https://tonone.ai"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-07-29
+
+### Added
+
+- **XS/XL/XXL depth tiers for `apex-plan`** — the S/M/L scoping menu is now six tiers (XS through XXL), from a single-specialist no-review spike up to full-team parallel dispatch with an adversarial review pass for major builds/migrations.
+- **Depth-tier selection for `helm-plan`** — new Step 0 mirrors the same XS-XXL tiers on the product side (Helm alone at XS/S, up to the full Product team in parallel at XXL), so product scoping asks "how deep" the same way engineering scoping does.
+
+### Changed
+
+- Reviewed the other 8 teams (Operations, Legal, Design, Data Science, Security Operations, Developer Experience, Infrastructure Specialist, AI Operations) for an equivalent lead/orchestrator role — none exists today (flat peer rosters, no designated lead), so depth-tier scoping stays Apex + Helm only for now.
+
 ## [1.10.3] - 2026-07-27
 
 ### Changed

--- a/ELEPHANT.md
+++ b/ELEPHANT.md
@@ -259,3 +259,4 @@
 2026-07-29 15:27 : apex-plan XS-XXL depth tiers added (was S/M/L only), same tiers ported to helm-plan as new Step 0 — @fatih
 2026-07-29 15:27 : decided: other 8 teams (Ops/Legal/Design/DS/SecOps/DevEx/Infra/AIOps) have no lead agent — depth-scoping stays Apex+Helm only, user picked "skip for now" — @fatih
 2026-07-29 15:27 : confirmed: bundle/\*/skills/apex-plan and helm-plan are symlinks to root skills/ — only 2 real files per skill (team/ canonical + skills/ mirror), no separate bundle copy to sync — @fatih
+[!!] 2026-07-29 15:31 : release 1.11.0 — 2 features, 0 fixes, 1 changed (apex-plan+helm-plan XS-XXL depth tiers) — @fatih

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Codex reads `AGENTS.md` automatically. Invoke agents and skills by describing wh
 
 ```text
 > Read agents/forge.md and act as Forge — audit this infrastructure
-> Read agents/apex.md — plan this project with S/M/L options
+> Read agents/apex.md — plan this project with XS-XXL depth options
 > Follow the workflow in skills/warden-audit/SKILL.md
 ```
 

--- a/agents/apex.md
+++ b/agents/apex.md
@@ -78,9 +78,12 @@ Before dispatching specialists, make the architectural decisions:
 - **What are the constraints?** "Use the existing database," "no new services," "must work on the current infra."
 - **What decisions are you making now?** Name them. Reversible ones made without ceremony. Irreversible ones flagged before locking in.
 
-When users ask for options on a genuinely ambiguous product/engineering question, use the S/M/L format:
+When users ask for options on a genuinely ambiguous product/engineering question, use the XS-XXL depth format — six tiers from a fast, dirty spike to a full-team high-assurance build:
 
 ```
+XS — [summary] (sonnet × 1, no review)
+     Est. tokens: ~[X]K | Est. cost: ~$[X] | Time: ~[X]min
+
 S — [summary]
     Specialists: [who] (sonnet × N)
     Est. tokens: ~[X]K | Est. cost: ~$[X] | Time: ~[X]min
@@ -93,12 +96,20 @@ L — [summary]
     Specialists: [who] (sonnet × N)
     Est. tokens: ~[X]K | Est. cost: ~$[X] | Time: ~[X]min
 
+XL — [summary] (+ dedicated QA/perf review pass)
+     Specialists: [who] (sonnet × N)
+     Est. tokens: ~[X]K | Est. cost: ~$[X] | Time: ~[X]min
+
+XXL — [summary] (all relevant specialists in parallel + adversarial review pass)
+      Specialists: [who] (sonnet × N)
+      Est. tokens: ~[X]K | Est. cost: ~$[X] | Time: ~[X]min
+
 + Apex overhead (opus): ~[X]K tokens
 
-My recommendation: [S/M/L] because [reason].
+My recommendation: [tier] because [reason].
 ```
 
-Reserve S/M/L for work with genuinely different depth trade-offs. Don't use it as a ritual for every task — most work has an obvious depth. Pick it and move.
+Only show tiers that make sense for the request — don't pad the menu. Reserve the full XS-XXL spread for work with genuinely different depth trade-offs. Don't use it as a ritual for every task — most work has an obvious depth. Pick it and move.
 
 **Estimation guidelines:**
 
@@ -149,7 +160,7 @@ Usage:
   [Specialist]: [X]K tokens
   Apex: [X]K tokens
   Total: [X]K tokens | $[X] | [X]min
-  ([Over/Under] [S/M/L] estimate by [X]%)
+  ([Over/Under] [tier] estimate by [X]%)
 ```
 
 ## Helm Handoff

--- a/bundle/ai-ops-team/.claude-plugin/plugin.json
+++ b/bundle/ai-ops-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-ops-team",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "AI Operations Team \u2014 9 agents: Deploy, Eval, Trace, Guard, Budget, Token, Prompt, Embed, Rank",
   "author": {
     "name": "tonone-ai",

--- a/bundle/data-science-team/.claude-plugin/plugin.json
+++ b/bundle/data-science-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "data-science-team",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Data Science Team \u2014 10 agents: Cast, Feat, Fit, Score, Drift, Vect, Tune, Plot, Clean, Eval",
   "author": {
     "name": "tonone-ai",

--- a/bundle/design-team/.claude-plugin/plugin.json
+++ b/bundle/design-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "design-team",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Design Team \u2014 10 agents: Hue, Grid, Glyph, Move, Wire, Mark, Cut, Axe, Tone, Copy",
   "author": {
     "name": "tonone-ai",

--- a/bundle/devx-team/.claude-plugin/plugin.json
+++ b/bundle/devx-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devx-team",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Developer Experience Team \u2014 10 agents: Guide, Sample, Mock, Schema, Port, Change, Onboard, Bench, Compat, Gate",
   "author": {
     "name": "tonone-ai",

--- a/bundle/engineering-team/.claude-plugin/plugin.json
+++ b/bundle/engineering-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "engineering-team",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Engineering team \u2014 15 agents: Apex, Forge, Relay, Spine, Flux, Warden, Vigil, Prism, Cortex, Touch, Volt, Atlas, Lens, Proof, Pave",
   "author": {
     "name": "tonone-ai",

--- a/bundle/full-team/.claude-plugin/plugin.json
+++ b/bundle/full-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "full-team",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Full tonone team \u2014 all 31 agents (Engineering + Product + Operations) with all 177 skills",
   "author": {
     "name": "tonone-ai",

--- a/bundle/infra-specialist-team/.claude-plugin/plugin.json
+++ b/bundle/infra-specialist-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "infra-specialist-team",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Infrastructure Specialist Team \u2014 10 agents: Kube, Terra, Finop, Serv, Edge, Cache, Queue, Mesh, Multi, Chaos",
   "author": {
     "name": "tonone-ai",

--- a/bundle/legal-team/.claude-plugin/plugin.json
+++ b/bundle/legal-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legal-team",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Legal team \u2014 10 agents: Brief, Clause, Bind, Frame, Shield, Scope, Audit, Cite, Lodge, Terms",
   "author": {
     "name": "tonone-ai",

--- a/bundle/marketing-team/.claude-plugin/plugin.json
+++ b/bundle/marketing-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "marketing-team",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Marketing team \u2014 3 agents: Ink, Buzz, Pitch",
   "author": {
     "name": "tonone-ai",

--- a/bundle/operations-team/.claude-plugin/plugin.json
+++ b/bundle/operations-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "operations-team",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Operations team \u2014 4 agents: Mint, Folk, Keel, Brace",
   "author": {
     "name": "tonone-ai",

--- a/bundle/product-team/.claude-plugin/plugin.json
+++ b/bundle/product-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-team",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Product team \u2014 8 agents: Helm, Echo, Lumen, Draft, Form, Crest, Pitch, Surge",
   "author": {
     "name": "tonone-ai",

--- a/bundle/revenue-team/.claude-plugin/plugin.json
+++ b/bundle/revenue-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "revenue-team",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Revenue team \u2014 3 agents: Deal, Keep, Surge",
   "author": {
     "name": "tonone-ai",

--- a/bundle/secops-team/.claude-plugin/plugin.json
+++ b/bundle/secops-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "secops-team",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Security Operations Team \u2014 10 agents: Red, Blue, Hunt, Patch, Chain, Sast, Siem, Resp, Zero, Phish",
   "author": {
     "name": "tonone-ai",

--- a/lib/uiux/pyproject.toml
+++ b/lib/uiux/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uiux"
-version = "1.10.3"
+version = "1.11.0"
 description = "Shared UI/UX design intelligence library — BM25 search engine + design system generator"
 license = "MIT"
 requires-python = ">=3.10"

--- a/skills/apex-plan/.claude-plugin/plugin.json
+++ b/skills/apex-plan/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-plan",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Plan and scope a project \u2014 discovery, challenge assumptions, present S/M/L options with token and cost estimates. Use when asked to \"plan this\", \"scope this\", \"how should we build X\", or when a new project/feature request comes in.",
   "author": {
     "name": "tonone-ai",

--- a/skills/apex-plan/SKILL.md
+++ b/skills/apex-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: apex-plan
-description: Plan and scope a project — discovery, challenge assumptions, present S/M/L options with token and cost estimates. Use when asked to "plan this", "scope this", "how should we build X", or when a new project/feature request comes in.
+description: Plan and scope a project — discovery, challenge assumptions, present XS-XXL depth options with token and cost estimates. Use when asked to "plan this", "scope this", "how should we build X", or when a new project/feature request comes in.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
 version: 0.6.4
 author: tonone-ai <hello@tonone.ai>
@@ -21,29 +21,35 @@ Follow the output format defined in docs/output-kit.md — 40-line CLI max, box-
 
 2. **Assess which specialists are needed and at what depth.** Map the problem to the team roster: Forge (infra), Relay (CI/CD), Spine (backend), Flux (data), Warden (security), Vigil (observability), Prism (frontend), Cortex (ML/AI), Touch (mobile), Volt (embedded), Atlas (architecture docs), Lens (analytics). Only include specialists who are actually needed — 6 specialists when 2 would do is waste, not thoroughness.
 
-3. **Present 3 options (S/M/L)** using this format:
+3. **Present options across six depth tiers (XS/S/M/L/XL/XXL)** — only show tiers that make sense for the request (a typo fix doesn't need an XXL row, a system migration doesn't need XS). Use this format:
 
 ```
-S — [summary]
-    Specialists: [who] (sonnet x N)
-    Est. tokens: ~[X]K | Est. cost: ~$[X] | Time: ~[X]min
+XS — Fast & dirty (Spine, ~10K tokens, ~$0.02)
+     One specialist, single pass, no review. Prototype or throwaway spike.
 
-M — [summary]
-    Specialists: [who] (sonnet x N)
-    Est. tokens: ~[X]K | Est. cost: ~$[X] | Time: ~[X]min
+S — Quick & focused (Spine + Warden, ~30K tokens, ~$0.05)
+    Basic implementation with a security pass.
 
-L — [summary]
-    Specialists: [who] (sonnet x N)
-    Est. tokens: ~[X]K | Est. cost: ~$[X] | Time: ~[X]min
+M — Solid implementation (Spine + Warden + Flux + Relay, ~120K tokens, ~$0.20)
+    Feature + data layer + CI, reviewed.
+
+L — Full build-out (+ Vigil + Atlas, ~250K tokens, ~$0.45)
+    Everything in M + monitoring + documentation.
+
+XL — Production-hardened (+ Proof + Forge, ~450K tokens, ~$0.80)
+     Everything in L + dedicated QA pass + infra/perf review.
+
+XXL — Full team, high assurance (all relevant specialists in parallel + adversarial review pass, ~800K-1M tokens, ~$1.50+)
+      Major system build or migration. Multiple independent review rounds before delivery. Consider dispatching via the Workflow tool at this scale.
 
 + Apex overhead (opus): ~[X]K tokens
 
-My recommendation: [S/M/L] because [reason].
+My recommendation: [tier] because [reason].
 ```
 
-Lead with your recommendation and why.
+Lead with your recommendation and why. Fill in real specialists and numbers for the actual request — the block above is the template, not literal output.
 
-4. **Wait for the user to pick a level.** Do not proceed until they choose S, M, or L.
+4. **Wait for the user to pick a level.** Do not proceed until they choose a tier (XS, S, M, L, XL, or XXL).
 
 5. **Dispatch specialists at the chosen depth.** Run independent specialists in parallel. Run dependent specialists sequentially. Give each specialist clear scope, constraints, context about what others are doing, and budget guidance.
 
@@ -57,5 +63,5 @@ Usage:
   [Specialist]: [X]K tokens
   Apex: [X]K tokens
   Total: [X]K tokens | $[X] | [X]min
-  ([Over/Under] [S/M/L] estimate by [X]%)
+  ([Over/Under] [tier] estimate by [X]%)
 ```

--- a/skills/apex-profile/.claude-plugin/plugin.json
+++ b/skills/apex-profile/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-profile",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Scope the tonone agent roster for this project \u2014 install a curated subset of agents instead of the full 100-agent bundle. Use when \"cut down the agent list\", \"profile for this project\", \"too many agents\", \"only need the engineering core\", or after apex-stats shows a roster that's mostly unused.",
   "author": {
     "name": "tonone-ai",

--- a/skills/apex-recon/.claude-plugin/plugin.json
+++ b/skills/apex-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Engineering lead reconnaissance \u2014 inventory the project before planning. Use when asked to \"understand this project\", \"orient me on this codebase\", \"what's the state of the repo\", \"what's in progress\", or before starting work on an unfamiliar codebase.",
   "author": {
     "name": "tonone-ai",

--- a/skills/apex-review/.claude-plugin/plugin.json
+++ b/skills/apex-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-review",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Cross-cutting review of recent work \u2014 catches gaps between specialists. Use when asked to \"review what we built\", \"check the work\", \"pre-launch review\", or after completing a significant chunk of work.",
   "author": {
     "name": "tonone-ai",

--- a/skills/apex-route/.claude-plugin/plugin.json
+++ b/skills/apex-route/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-route",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Reach ANY tonone specialist on demand, even ones not installed in this session's roster \u2014 no restart needed. Use when asked \"which agent handles this\", \"reach a specialist we didn't install\", \"route this to the right agent\", or whenever a scoped apex-profile roster is missing the right hat for the job.",
   "author": {
     "name": "tonone-ai",

--- a/skills/apex-stats/.claude-plugin/plugin.json
+++ b/skills/apex-stats/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-stats",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Spawn-count analytics for the tonone roster \u2014 which agents this project actually uses, from local session transcripts. Use when \"which agents do we actually use\", \"show tonone stats\", \"prune the roster\", or before running apex-profile.",
   "author": {
     "name": "tonone-ai",

--- a/skills/apex-status/.claude-plugin/plugin.json
+++ b/skills/apex-status/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-status",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "CTO-level project status from git and codebase state. Use when asked \"where are we\", \"project status\", \"what's done\", or at the start of a work session.",
   "author": {
     "name": "tonone-ai",

--- a/skills/apex-takeover/.claude-plugin/plugin.json
+++ b/skills/apex-takeover/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-takeover",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "System takeover \u2014 take ownership of an existing codebase or inherited system. Use when \"we acquired this\", \"previous team left\", \"take over this system\", \"inherited this codebase\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/apex/.claude-plugin/plugin.json
+++ b/skills/apex/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apex",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Engineering lead \u2014 hand Apex any task and it routes internally. New features, planning, reviews, status, orientation, or system takeovers.",
   "author": {
     "name": "tonone-ai",

--- a/skills/atlas-adr/.claude-plugin/plugin.json
+++ b/skills/atlas-adr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atlas-adr",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Write an Architecture Decision Record \u2014 document what was decided, why, what alternatives were considered, and what trade-offs were accepted. Use when asked to \"write an ADR\", \"document this decision\", or \"why did we choose X\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/atlas-changelog/.claude-plugin/plugin.json
+++ b/skills/atlas-changelog/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atlas-changelog",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Maintain per-repo and cross-repo changelogs \u2014 append structured entries after agent work. Use when asked to \"log this change\", \"update changelog\", \"what changed\", \"change history\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/atlas-map/.claude-plugin/plugin.json
+++ b/skills/atlas-map/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atlas-map",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Map the system architecture \u2014 read the codebase, identify services and connections, output a C4-level architecture map as Mermaid diagrams with component descriptions. Use when asked to \"map the architecture\", \"system diagram\", \"how does this work\", or \"architecture overview\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/atlas-onboard/.claude-plugin/plugin.json
+++ b/skills/atlas-onboard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atlas-onboard",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Generate onboarding documentation \u2014 what this project does, how to set up locally, where things live, key decisions, how to deploy. Written for day-one engineers who know nothing. Use when asked for \"onboarding docs\", \"new engineer guide\", \"how to get started\", or \"developer setup\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/atlas-present/.claude-plugin/plugin.json
+++ b/skills/atlas-present/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atlas-present",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Generate a polished HTML presentation page and Obsidian Canvas for big releases \u2014 new products, takeovers, major migrations. Non-technical audience. Use when asked to \"present this\", \"release announcement\", \"show what we built\", or \"stakeholder update\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/atlas-recon/.claude-plugin/plugin.json
+++ b/skills/atlas-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atlas-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Documentation reconnaissance for takeover \u2014 find all docs, assess accuracy, freshness, coverage, and discoverability, and identify critical knowledge gaps. Use when asked \"what docs exist\", \"documentation assessment\", or \"knowledge gaps\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/atlas-report/.claude-plugin/plugin.json
+++ b/skills/atlas-report/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atlas-report",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Render agent findings as a styled HTML report in the browser. Use when asked for \"full report\", \"detailed report\", \"show in browser\", or when CLI output exceeds the 40-line budget.",
   "author": {
     "name": "tonone-ai",

--- a/skills/atlas/.claude-plugin/plugin.json
+++ b/skills/atlas/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atlas",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Knowledge engineer \u2014 architecture docs, ADRs, diagrams, changelogs, onboarding, and reports.",
   "author": {
     "name": "tonone-ai",

--- a/skills/buzz-community/.claude-plugin/plugin.json
+++ b/skills/buzz-community/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "buzz-community",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Build and manage open source community \u2014 Discord/Slack structure, contributor onboarding, ambassador program, community flywheel design, and GitHub community health. Use when asked to \"build a community\", \"grow our Discord\", \"improve contributor experience\", or \"design a developer ambassador program\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/buzz-launch/.claude-plugin/plugin.json
+++ b/skills/buzz-launch/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "buzz-launch",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Design and execute a launch plan \u2014 Product Hunt, HN Show HN, newsletter coordination, social posts, and community launch moment. Use when asked to \"launch [feature/product]\", \"plan a launch\", \"help us do a Product Hunt launch\", or \"coordinate the announcement\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/buzz-pitch/.claude-plugin/plugin.json
+++ b/skills/buzz-pitch/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "buzz-pitch",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Write media pitches and press releases \u2014 journalist outreach emails, podcast pitch scripts, newsletter sponsor pitches, and press release copy. Use when asked to \"pitch journalists\", \"write a press release\", \"reach out to podcasts\", or \"get media coverage\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/buzz-recon/.claude-plugin/plugin.json
+++ b/skills/buzz-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "buzz-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "PR and community reconnaissance \u2014 audit current press coverage, social presence, community health, and competitor PR. Use when asked to \"audit our PR\", \"what's our community state\", \"how do we compare in press\", or before planning a launch or community initiative.",
   "author": {
     "name": "tonone-ai",

--- a/skills/buzz-social/.claude-plugin/plugin.json
+++ b/skills/buzz-social/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "buzz-social",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Social media strategy and post drafting \u2014 HN posts, Twitter/X threads, LinkedIn posts, Reddit comments, and developer community content. Use when asked to \"write a HN post\", \"draft social posts\", \"help us post on Twitter\", or \"create a social launch plan\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/buzz/.claude-plugin/plugin.json
+++ b/skills/buzz/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "buzz",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "PR & Community engineer \u2014 press pitches, social media, open source community, DevRel, and coordinated launch moments.",
   "author": {
     "name": "tonone-ai",

--- a/skills/cortex-eval/.claude-plugin/plugin.json
+++ b/skills/cortex-eval/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex-eval",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Evaluate model performance \u2014 check for accuracy drops, data drift, and error patterns. Use when asked about \"model accuracy dropped\", \"evaluate the model\", \"check for drift\", or \"model performance\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/cortex-integrate/.claude-plugin/plugin.json
+++ b/skills/cortex-integrate/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex-integrate",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Design and implement an AI feature integration \u2014 model selection, architecture pattern, system prompt, data flow, error handling, cost estimate. Use when asked to \"add AI to this\", \"LLM integration\", \"add Claude/GPT\", or \"AI-powered feature\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/cortex-model/.claude-plugin/plugin.json
+++ b/skills/cortex-model/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex-model",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Build an ML pipeline \u2014 from data to trained model to serving endpoint. Use when asked to \"build ML model\", \"train a model\", \"prediction pipeline\", \"classification\", or \"regression\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/cortex-prompt/.claude-plugin/plugin.json
+++ b/skills/cortex-prompt/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex-prompt",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Build a production-ready prompt package \u2014 system prompt, few-shot examples, output format, edge case handling, eval criteria. Use when asked to \"prompt engineering\", \"build a prompt\", \"write a system prompt\", or \"improve this prompt\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/cortex-recon/.claude-plugin/plugin.json
+++ b/skills/cortex-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "ML reconnaissance \u2014 inventory all models, pipelines, data sources, and monitoring. Use when asked \"what ML do we have\", \"model inventory\", or \"ML assessment\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/cortex/.claude-plugin/plugin.json
+++ b/skills/cortex/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "ML/AI engineer \u2014 LLM integrations, prompt engineering, model pipelines, evals, RAG.",
   "author": {
     "name": "tonone-ai",

--- a/skills/crest-compete/.claude-plugin/plugin.json
+++ b/skills/crest-compete/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "crest-compete",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Competitive analysis ending in a clear positioning call \u2014 where to play, how to win. Use when asked to \"analyze competitors\", \"competitive landscape\", \"how do we compare to X\", \"competitive positioning\", \"where should we play\", \"find our white space\", or \"who else does this\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/crest-narrative/.claude-plugin/plugin.json
+++ b/skills/crest-narrative/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "crest-narrative",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Strategic narrative \u2014 write a standalone strategy memo that frames product direction, bets, and rationale for a planning horizon. Use when asked to \"write a strategy doc\", \"product vision\", \"strategic narrative\", \"company strategy memo\", \"planning memo\", or \"explain our product direction\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/crest-okr/.claude-plugin/plugin.json
+++ b/skills/crest-okr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "crest-okr",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "OKR design \u2014 create objectives and key results with a North Star metric, input metrics tree, and cadence. Use when asked to \"set OKRs\", \"define our objectives\", \"what should we measure this quarter\", \"design our OKR framework\", \"build a metrics tree\", or \"what's our North Star\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/crest-recon/.claude-plugin/plugin.json
+++ b/skills/crest-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "crest-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Strategic context reconnaissance \u2014 read existing roadmaps, OKRs, competitive docs, and briefs to establish context before planning. Use when asked to \"understand our strategy\", \"what's the current roadmap\", \"what OKRs do we have\", \"strategic context\", or before starting any prioritization or roadmap work.",
   "author": {
     "name": "tonone-ai",

--- a/skills/crest-roadmap/.claude-plugin/plugin.json
+++ b/skills/crest-roadmap/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "crest-roadmap",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Build a product roadmap with sequenced bets and explicit tradeoffs. Use when asked to \"build a roadmap\", \"prioritize the backlog strategically\", \"what do we build next quarter\", \"sequence our bets\", \"what should we focus on\", or \"product strategy for the next N months\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/crest/.claude-plugin/plugin.json
+++ b/skills/crest/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "crest",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Product strategist \u2014 roadmaps, competitive analysis, OKRs, strategic narratives.",
   "author": {
     "name": "tonone-ai",

--- a/skills/deal-close/.claude-plugin/plugin.json
+++ b/skills/deal-close/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deal-close",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Close a specific deal \u2014 diagnose why a deal is stalling, write a tailored proposal, design the closing sequence, or navigate procurement. Use when a specific deal is stuck, \"how do I close this\", \"write a proposal for this customer\", or \"help me get to yes\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/deal-pipeline/.claude-plugin/plugin.json
+++ b/skills/deal-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deal-pipeline",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Design or audit B2B sales pipeline \u2014 define stage names, entry/exit criteria, qualification standards, and CRM field requirements. Use when asked to \"design our pipeline\", \"audit our CRM stages\", \"define what qualified means\", or \"build a sales process\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/deal-playbook/.claude-plugin/plugin.json
+++ b/skills/deal-playbook/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deal-playbook",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Write sales playbooks \u2014 outbound sequences, discovery call guides, objection handling scripts, and demo frameworks. Use when asked to \"write a sales playbook\", \"build an outbound sequence\", \"help me handle objections\", or \"design a discovery call\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/deal-pricing/.claude-plugin/plugin.json
+++ b/skills/deal-pricing/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deal-pricing",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Design pricing strategy and packaging \u2014 tiers, value metrics, enterprise pricing, freemium design, and pricing page copy. Use when asked to \"design our pricing\", \"should we change our price\", \"how do we package the product\", or \"what should we charge enterprise\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/deal-recon/.claude-plugin/plugin.json
+++ b/skills/deal-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deal-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Revenue reconnaissance \u2014 audit current sales pipeline, deal patterns, ICP definition, and revenue motion to understand what's working and where the constraint is. Use when asked to \"audit our sales\", \"where is revenue stuck\", \"what's our pipeline state\", \"before designing a playbook\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/deal/.claude-plugin/plugin.json
+++ b/skills/deal/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deal",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Revenue & Sales engineer \u2014 B2B pipeline, deal strategy, pricing proposals, sales playbooks, and enterprise closing.",
   "author": {
     "name": "tonone-ai",

--- a/skills/draft-flow/.claude-plugin/plugin.json
+++ b/skills/draft-flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-flow",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/draft-ia/.claude-plugin/plugin.json
+++ b/skills/draft-ia/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-ia",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Information architecture \u2014 design navigation structure, content hierarchy, sitemap, and taxonomy for a product or feature set. Use when asked to \"organize the navigation\", \"information architecture\", \"how should content be structured\", \"sitemap\", \"nav redesign\", \"where should X live\", or \"content hierarchy\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/draft-landing/.claude-plugin/plugin.json
+++ b/skills/draft-landing/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-landing",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/draft-patterns/.claude-plugin/plugin.json
+++ b/skills/draft-patterns/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-patterns",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/draft-recon/.claude-plugin/plugin.json
+++ b/skills/draft-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "UI and UX reconnaissance \u2014 scan existing frontend routes, components, navigation, and flows to understand the current UX state before designing. Use when asked to \"understand the current UI\", \"what UX patterns exist\", \"map the navigation\", \"what screens exist\", or before starting any flow or wireframe work.",
   "author": {
     "name": "tonone-ai",

--- a/skills/draft-review/.claude-plugin/plugin.json
+++ b/skills/draft-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-review",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Usability review \u2014 evaluate an existing flow or UI against usability heuristics, flag friction points, and recommend fixes. Use when asked to \"review the UX\", \"usability audit\", \"what's wrong with this flow\", \"UX feedback\", \"critique this design\", or \"why are users dropping off here\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/draft-wireframe/.claude-plugin/plugin.json
+++ b/skills/draft-wireframe/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-wireframe",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Wireframe a screen \u2014 ASCII/text by default, or hand-drawn HTML when the user says sketch/whiteboard/graph-paper. Text mode: buildable spec for Form and Prism. HTML mode: self-contained file with graph-paper background, marker headlines, sticky notes, hatched chart placeholders.",
   "author": {
     "name": "tonone-ai",

--- a/skills/draft/.claude-plugin/plugin.json
+++ b/skills/draft/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "draft",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "UX designer \u2014 user flows, information architecture, wireframes, and interaction design.",
   "author": {
     "name": "tonone-ai",

--- a/skills/echo-feedback/.claude-plugin/plugin.json
+++ b/skills/echo-feedback/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "echo-feedback",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Feedback synthesis \u2014 cluster support tickets, NPS verbatims, app store reviews, and churn surveys by theme, separate signal from noise, and produce an actionable insight report. Use when asked to \"synthesize this feedback\", \"analyze support tickets\", \"what are users complaining about\", \"NPS analysis\", \"churn feedback synthesis\", or \"what's the feedback telling us\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/echo-interview/.claude-plugin/plugin.json
+++ b/skills/echo-interview/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "echo-interview",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Run a user interview \u2014 produce an interview guide and synthesize the output into an actionable insight report. Use when asked to \"run a user interview\", \"synthesize these interview notes\", \"what do users actually want\", \"build a persona from this feedback\", \"find the JTBD in these transcripts\", or \"analyze this interview data\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/echo-jobs/.claude-plugin/plugin.json
+++ b/skills/echo-jobs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "echo-jobs",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Jobs-to-Be-Done analysis \u2014 given a product, user descriptions, transcripts, or tickets, produce a JTBD job map with switching forces analysis and opportunity ranking. Use when asked to \"find the JTBD\", \"what jobs are users hiring us for\", \"job mapping\", \"what are users really trying to do\", \"JTBD framework\", or \"why are users switching\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/echo-recon/.claude-plugin/plugin.json
+++ b/skills/echo-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "echo-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "User research reconnaissance \u2014 survey existing personas, research docs, interview notes, and feedback artifacts to establish what is already known about users. Use when asked to \"what research exists\", \"review existing personas\", \"what do we know about our users\", or before starting new research or synthesis work.",
   "author": {
     "name": "tonone-ai",

--- a/skills/echo-segment/.claude-plugin/plugin.json
+++ b/skills/echo-segment/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "echo-segment",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "User segmentation and persona creation from mixed data sources \u2014 analytics, CRM, support tickets, reviews, or any combination. Use when asked to \"build personas\", \"who are our users\", \"segment our users\", \"create user profiles\", \"define user archetypes\", or \"who is the target user\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/echo/.claude-plugin/plugin.json
+++ b/skills/echo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "echo",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "User researcher \u2014 interviews, personas, Jobs-to-Be-Done, and customer feedback synthesis.",
   "author": {
     "name": "tonone-ai",

--- a/skills/flux-health/.claude-plugin/plugin.json
+++ b/skills/flux-health/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flux-health",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Data quality and pipeline health check \u2014 freshness, schema drift, null rates, orphaned records, pipeline status. Use when asked about \"data quality check\", \"pipeline health\", \"is our data fresh\", or \"schema drift\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/flux-migrate/.claude-plugin/plugin.json
+++ b/skills/flux-migrate/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flux-migrate",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Build zero-downtime database migrations \u2014 forward SQL, rollback SQL, deployment sequence. Use when asked to \"write migration\", \"schema change\", \"add column\", \"rename table\", \"drop column\", or \"migrate safely\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/flux-pipeline/.claude-plugin/plugin.json
+++ b/skills/flux-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flux-pipeline",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Build a data pipeline \u2014 ETL/ELT with extraction, transformation, loading, error handling, and scheduling. Use when asked to \"build ETL\", \"data pipeline\", \"move data from X to Y\", or \"sync data\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/flux-query/.claude-plugin/plugin.json
+++ b/skills/flux-query/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flux-query",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Optimize slow database queries \u2014 analyze execution plans, add indexes, rewrite queries. Use when asked about \"slow query\", \"optimize SQL\", \"query performance\", or \"explain this query\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/flux-recon/.claude-plugin/plugin.json
+++ b/skills/flux-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flux-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Database reconnaissance \u2014 full inventory of schema, migrations, data volume, backups, connection pooling, and query patterns. Use when asked to \"assess this database\", \"understand the schema\", or \"database health check\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/flux-schema/.claude-plugin/plugin.json
+++ b/skills/flux-schema/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flux-schema",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Design and build database schema \u2014 tables, columns, types, indexes, constraints, relationships. Given a domain description, output the schema and write the files. Use when asked to \"design schema\", \"database design\", \"create tables\", or \"data model\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/flux/.claude-plugin/plugin.json
+++ b/skills/flux/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Data engineer \u2014 databases, migrations, pipelines, schema design, and query optimization.",
   "author": {
     "name": "tonone-ai",

--- a/skills/forge-audit/.claude-plugin/plugin.json
+++ b/skills/forge-audit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-audit",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Audit existing infrastructure for security issues, waste, and misconfigurations. Use when asked to \"audit my infra\", \"check cloud setup\", \"infra review\", \"are we wasting money\", \"security check on infra\", or \"review my terraform\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/forge-cost/.claude-plugin/plugin.json
+++ b/skills/forge-cost/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-cost",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Audit cloud infrastructure costs and produce a concrete optimization plan with specific changes and estimated savings. Use when asked to \"how much is this costing\", \"reduce cloud spend\", \"cost optimization\", \"are we overpaying\", \"cloud bill\", or \"budget for this infra\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/forge-diagnose/.claude-plugin/plugin.json
+++ b/skills/forge-diagnose/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-diagnose",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Diagnose runtime infrastructure issues \u2014 cold starts, timeouts, scaling problems, network failures. Use when asked about \"infra is slow\", \"cold starts\", \"network issues\", \"why is this timing out\", \"scaling problem\", \"latency spikes\", or \"service is down\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/forge-infra/.claude-plugin/plugin.json
+++ b/skills/forge-infra/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-infra",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Build production-grade infrastructure as code for a service or project. Use when asked to \"set up infra\", \"provision infrastructure\", \"create cloud resources\", \"IaC for this project\", \"terraform for this\", or \"deploy this service\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/forge-network/.claude-plugin/plugin.json
+++ b/skills/forge-network/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-network",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Design and build networking infrastructure \u2014 VPCs, subnets, DNS, load balancers, firewall rules. Use when asked to \"set up networking\", \"VPC design\", \"configure DNS\", \"load balancer setup\", \"network architecture\", or \"firewall rules\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/forge-recon/.claude-plugin/plugin.json
+++ b/skills/forge-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Infrastructure reconnaissance \u2014 inventory all cloud resources, map connections, flag risks. Use when asked to \"inventory our infra\", \"what infrastructure do we have\", \"map our cloud resources\", \"infra discovery\", or \"what's running in our cloud\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/forge/.claude-plugin/plugin.json
+++ b/skills/forge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forge",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Infrastructure engineer \u2014 cloud services, IaC, networking, cost optimization.",
   "author": {
     "name": "tonone-ai",

--- a/skills/form-audit/.claude-plugin/plugin.json
+++ b/skills/form-audit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-audit",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/form-brand/.claude-plugin/plugin.json
+++ b/skills/form-brand/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-brand",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/form-brief/.claude-plugin/plugin.json
+++ b/skills/form-brief/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-brief",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Translate a design brief (I-Lang or natural language) into a concrete DESIGN.md and HTML token preview \u2014 resolves palette, typography, mood, density, and constraints to specific CSS tokens.",
   "author": {
     "name": "tonone-ai",

--- a/skills/form-component/.claude-plugin/plugin.json
+++ b/skills/form-component/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-component",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/form-deck/.claude-plugin/plugin.json
+++ b/skills/form-deck/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-deck",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/form-email/.claude-plugin/plugin.json
+++ b/skills/form-email/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-email",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/form-exam/.claude-plugin/plugin.json
+++ b/skills/form-exam/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-exam",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/form-logo/.claude-plugin/plugin.json
+++ b/skills/form-logo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-logo",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/form-mobile/.claude-plugin/plugin.json
+++ b/skills/form-mobile/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-mobile",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/form-palette/.claude-plugin/plugin.json
+++ b/skills/form-palette/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-palette",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/form-social/.claude-plugin/plugin.json
+++ b/skills/form-social/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-social",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/form-style/.claude-plugin/plugin.json
+++ b/skills/form-style/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-style",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/form-tokens/.claude-plugin/plugin.json
+++ b/skills/form-tokens/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-tokens",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/form-web/.claude-plugin/plugin.json
+++ b/skills/form-web/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form-web",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/form/.claude-plugin/plugin.json
+++ b/skills/form/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Visual designer \u2014 brand identity, color systems, typography, design tokens, and UI design.",
   "author": {
     "name": "tonone-ai",

--- a/skills/helm-arbiter/.claude-plugin/plugin.json
+++ b/skills/helm-arbiter/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-arbiter",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Scope arbitration \u2014 resolve disagreements between product and engineering on what is in or out of scope, with a decision log and escalation path. Use when asked to \"resolve this scope disagreement\", \"arbitrate between product and eng\", \"scope is creeping\", \"we can't agree on what's in scope\", or \"help us decide what to cut\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/helm-brief/.claude-plugin/plugin.json
+++ b/skills/helm-brief/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-brief",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/helm-handoff/.claude-plugin/plugin.json
+++ b/skills/helm-handoff/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-handoff",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/helm-plan/.claude-plugin/plugin.json
+++ b/skills/helm-plan/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-plan",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/helm-plan/SKILL.md
+++ b/skills/helm-plan/SKILL.md
@@ -16,6 +16,36 @@ You are Helm — the Head of Product on the Product Team.
 
 ## Steps
 
+### Step 0: Choose Depth
+
+Before gathering input, present depth tiers so the user picks how much product-team involvement this needs — fast gut-check vs. full cross-functional rigor. Only show tiers that make sense for the request. Use this format:
+
+```
+XS — Gut check (Helm, ~10K tokens, ~$0.02)
+     Ballpark call, no scoring, no research. "Just tell me what to do."
+
+S — Fast RICE pass (Helm, ~25K tokens, ~$0.04)
+    Score given items with stated/default inputs. No other specialists.
+
+M — Researched roadmap (Helm + Lumen + Crest, ~100K tokens, ~$0.18)
+    RICE scoring grounded in real metrics + strategic filter pass.
+
+L — Full roadmap (+ Echo + Draft, ~220K tokens, ~$0.40)
+    Everything in M + user research validation + flow sanity check.
+
+XL — Strategic roadmap (+ Crest-compete + Pitch, ~400K tokens, ~$0.70)
+     Everything in L + competitive positioning + messaging alignment. Cross-functional handoff ready.
+
+XXL — Full product strategy overhaul (entire Product team in parallel + adversarial review, ~700K-900K tokens, ~$1.30+)
+      Major roadmap reset or new market bet. Multiple independent review rounds before delivery. Consider dispatching via the Workflow tool at this scale.
+
+My recommendation: [tier] because [reason].
+```
+
+Lead with your recommendation and why. Fill in real specialists and numbers for the actual request — the block above is the template, not literal output.
+
+**Wait for the user to pick a tier** (XS, S, M, L, XL, or XXL) before proceeding. The chosen tier determines which specialists get consulted in Steps 1-4 below — at XS/S, Helm works alone; at M and above, dispatch the named specialists in parallel and fold their input into the RICE scoring and judgment filters.
+
 ### Step 1: Gather the Input
 
 Collect the list of features, ideas, or initiatives to prioritize. For each item, you need (or will estimate):
@@ -66,7 +96,15 @@ NOT NOW:
 
 ### Step 5: Deliver
 
-Present the RICE table followed by the roadmap view. Note any items where the RICE score and your judgment diverge, and explain why.
+Present the RICE table followed by the roadmap view. Note any items where the RICE score and your judgment diverge, and explain why. If specialists were dispatched (M tier and above), close with a usage receipt:
+
+```
+Usage:
+  [Specialist]: [X]K tokens
+  Helm: [X]K tokens
+  Total: [X]K tokens | $[X] | [X]min
+  ([Over/Under] [tier] estimate by [X]%)
+```
 
 Follow the output format defined in docs/output-kit.md — 40-line CLI max, box-drawing skeleton, unified severity indicators, compressed prose.
 

--- a/skills/helm-recon/.claude-plugin/plugin.json
+++ b/skills/helm-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Product landscape reconnaissance \u2014 survey existing briefs, research, strategy, and team output before writing new briefs or dispatching specialists. Use when asked to \"understand the product state\", \"what briefs exist\", \"what has the team produced\", \"orient me on this product\", or before starting a new product initiative.",
   "author": {
     "name": "tonone-ai",

--- a/skills/helm/.claude-plugin/plugin.json
+++ b/skills/helm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "helm",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Head of product \u2014 orchestrate the product team, write briefs, plan initiatives, hand off to Apex.",
   "author": {
     "name": "tonone-ai",

--- a/skills/ink-calendar/.claude-plugin/plugin.json
+++ b/skills/ink-calendar/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ink-calendar",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Build a content calendar \u2014 editorial plan, publishing cadence, topic assignment, and distribution workflow. Use when asked to \"build a content calendar\", \"plan our content for the quarter\", \"how often should we publish\", or \"create an editorial schedule\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/ink-case/.claude-plugin/plugin.json
+++ b/skills/ink-case/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ink-case",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Write customer case studies and success stories \u2014 interview guide, story structure, and publish-ready case study with metrics. Use when asked to \"write a case study\", \"document a customer success story\", \"create social proof content\", or \"write about how [customer] uses the product\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/ink-post/.claude-plugin/plugin.json
+++ b/skills/ink-post/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ink-post",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Write a blog post or article \u2014 research the keyword, draft the post, and produce publish-ready content with SEO optimization. Use when asked to \"write a blog post\", \"write about [topic]\", \"draft an article\", or \"write a tutorial\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/ink-recon/.claude-plugin/plugin.json
+++ b/skills/ink-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ink-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Content marketing reconnaissance \u2014 audit current content, SEO health, competitor content gaps, and content distribution. Use when asked to \"audit our content\", \"what's our SEO state\", \"where are the content gaps\", or before designing a content strategy.",
   "author": {
     "name": "tonone-ai",

--- a/skills/ink-seo/.claude-plugin/plugin.json
+++ b/skills/ink-seo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ink-seo",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "SEO strategy and keyword research \u2014 build topic clusters, keyword gap analysis, on-page audit, and prioritized SEO roadmap. Use when asked to \"improve our SEO\", \"do keyword research\", \"build a topic cluster\", or \"why aren't we ranking\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/ink/.claude-plugin/plugin.json
+++ b/skills/ink/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ink",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Content Marketing engineer \u2014 blog strategy, SEO, thought leadership, developer content, case studies, and content calendar.",
   "author": {
     "name": "tonone-ai",

--- a/skills/keep-expand/.claude-plugin/plugin.json
+++ b/skills/keep-expand/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-expand",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Design expansion revenue playbooks \u2014 upsell triggers, seat expansion sequences, tier upgrade paths, and cross-sell motions. Use when asked to \"grow existing customers\", \"increase NRR\", \"design upsell\", or \"how do we get customers to expand\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/keep-health/.claude-plugin/plugin.json
+++ b/skills/keep-health/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-health",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Design a customer health scoring model \u2014 define signals, weights, thresholds, and action triggers. Use when asked to \"build health scoring\", \"how do we predict churn\", \"what signals indicate a customer is at risk\", or \"design our health model\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/keep-onboard/.claude-plugin/plugin.json
+++ b/skills/keep-onboard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-onboard",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Optimize customer onboarding \u2014 map the activation sequence, identify drop-off points, design the aha moment, and produce the onboarding email sequence. Use when asked to \"fix onboarding\", \"improve activation\", \"time-to-value is too slow\", or \"customers aren't getting started\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/keep-playbook/.claude-plugin/plugin.json
+++ b/skills/keep-playbook/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-playbook",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Write churn prevention and win-back playbooks \u2014 risk intervention sequences, save conversation guides, and win-back email campaigns. Use when asked to \"prevent churn\", \"save at-risk customers\", \"win back churned customers\", or \"build a save play\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/keep-recon/.claude-plugin/plugin.json
+++ b/skills/keep-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Customer success reconnaissance \u2014 audit current onboarding completion, health signals, NRR, churn patterns, and CS motion. Use when asked to \"audit our customer success\", \"why are customers churning\", \"what's our NRR\", or before designing any CS playbook.",
   "author": {
     "name": "tonone-ai",

--- a/skills/keep/.claude-plugin/plugin.json
+++ b/skills/keep/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Customer Success engineer \u2014 onboarding optimization, health scoring, expansion revenue, churn prevention, and NRR growth.",
   "author": {
     "name": "tonone-ai",

--- a/skills/lens-audit/.claude-plugin/plugin.json
+++ b/skills/lens-audit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lens-audit",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Review existing analytics \u2014 find all dashboards and reports, check who uses them, whether metrics are defined, and whether they drive decisions. Recommend what to keep, kill, or add. Use when asked \"are our dashboards useful\", \"analytics review\", or \"metrics audit\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/lens-chart/.claude-plugin/plugin.json
+++ b/skills/lens-chart/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lens-chart",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/lens-dashboard/.claude-plugin/plugin.json
+++ b/skills/lens-dashboard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lens-dashboard",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Design and spec an analytical dashboard \u2014 define the question each chart answers, write the SQL queries, spec the layout and refresh cadence. Produces a complete dashboard spec ready to implement. Use when asked to \"build a dashboard\", \"analytics dashboard\", \"BI dashboard\", \"weekly product health\", or \"visualize this data\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/lens-metrics/.claude-plugin/plugin.json
+++ b/skills/lens-metrics/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lens-metrics",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Produce a complete metrics definition doc \u2014 metric name, formula, data source, segmentation, SQL or event tracking spec, and what good/bad looks like. Given a product area, outputs the full metrics spec. Use when asked to \"define KPIs\", \"metrics framework\", \"what should we measure\", \"north star metric\", or \"instrument this feature\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/lens-recon/.claude-plugin/plugin.json
+++ b/skills/lens-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lens-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Analytics reconnaissance for takeover \u2014 find all analytics tools, inventory what's tracked and dashboarded, assess data freshness and metric definitions, and present a coverage map. Use when asked \"what analytics exist\", \"BI assessment\", or \"what do we track\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/lens-report/.claude-plugin/plugin.json
+++ b/skills/lens-report/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lens-report",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Build a reporting pipeline \u2014 scheduled reports with SQL queries, delivery via Slack or email, threshold alerts, and historical comparison. Use when asked for \"automated reports\", \"scheduled report\", \"email digest\", or \"Slack alerts for metrics\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/lens/.claude-plugin/plugin.json
+++ b/skills/lens/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lens",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Analytics and BI engineer \u2014 dashboards, metrics design, reporting pipelines, and data storytelling.",
   "author": {
     "name": "tonone-ai",

--- a/skills/lumen-abtest/.claude-plugin/plugin.json
+++ b/skills/lumen-abtest/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lumen-abtest",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "A/B test design \u2014 produce an experiment spec with hypothesis, primary metric, MDE, sample size, run time, and decision rule. Also determines when NOT to A/B test and what to do instead. Use when asked to \"design an A/B test\", \"should we test this\", \"experiment design\", \"how do we know if this works\", \"what's the sample size\", or \"set up an experiment\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/lumen-funnel/.claude-plugin/plugin.json
+++ b/skills/lumen-funnel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lumen-funnel",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/lumen-instrument/.claude-plugin/plugin.json
+++ b/skills/lumen-instrument/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lumen-instrument",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Instrumentation plan \u2014 design event taxonomy, property schema, and tracking plan for analytics tools. Use when asked to \"what should we track\", \"instrumentation plan\", \"set up analytics events\", \"analytics event schema\", \"tracking plan\", or \"instrument this feature\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/lumen-metrics/.claude-plugin/plugin.json
+++ b/skills/lumen-metrics/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lumen-metrics",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Metrics architecture \u2014 produce a complete metrics plan given a product description. North Star, input metrics tree, instrumentation spec, action triggers, and counter-metrics. Use when asked to \"design a metrics framework\", \"what should we measure\", \"build a metrics system\", \"define our KPIs\", \"what are our success metrics\", \"metrics strategy\", or \"what do we track\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/lumen-recon/.claude-plugin/plugin.json
+++ b/skills/lumen-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lumen-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Analytics reconnaissance \u2014 scan existing event tracking, metric definitions, dashboards, and analytics configuration to understand what is currently being measured. Use when asked to \"what are we tracking\", \"audit our analytics\", \"what metrics exist\", \"analytics inventory\", or before designing new metrics or instrumentation.",
   "author": {
     "name": "tonone-ai",

--- a/skills/lumen/.claude-plugin/plugin.json
+++ b/skills/lumen/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lumen",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Product analyst \u2014 metrics architecture, funnel analysis, A/B test design, retention, and growth measurement.",
   "author": {
     "name": "tonone-ai",

--- a/skills/pave-audit/.claude-plugin/plugin.json
+++ b/skills/pave-audit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pave-audit",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Audit developer experience \u2014 measure onboarding time, build speed, deployment friction, and developer satisfaction. Use when asked to \"DX audit\", \"developer experience review\", \"why is development slow\", \"onboarding assessment\", or \"DORA metrics\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/pave-catalog/.claude-plugin/plugin.json
+++ b/skills/pave-catalog/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pave-catalog",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Build a service catalog \u2014 schema, starter entries, and governance model. Produces what information to capture per service, how it's maintained, and where it lives. Use when asked to \"service catalog\", \"what services do we have\", \"catalog our services\", \"service inventory\", or \"who owns what\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/pave-contribute/.claude-plugin/plugin.json
+++ b/skills/pave-contribute/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pave-contribute",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Contribute a session learning back to the upstream tonone repo. Scans the conversation, extracts the single most reusable insight, asks one question, creates the PR. Use when asked to \"contribute a learning\", \"share a discovery\", \"improve tonone\", or \"submit a fix upstream\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/pave-env/.claude-plugin/plugin.json
+++ b/skills/pave-env/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pave-env",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Set up local development environments \u2014 devcontainers, Docker Compose, one-command setup, dev/prod parity. Use when asked to \"set up dev environment\", \"devcontainer\", \"docker compose for dev\", \"local development setup\", or \"one command to run\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/pave-golden/.claude-plugin/plugin.json
+++ b/skills/pave-golden/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pave-golden",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Define a golden path \u2014 the opinionated, supported way to do a common developer task (create a new service, set up an environment, deploy a feature). Produces concrete steps, templates, and tooling. Use when asked to \"golden path\", \"create project template\", \"scaffold a new service\", \"how should we create services\", or \"standardize our setup\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/pave-recon/.claude-plugin/plugin.json
+++ b/skills/pave-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pave-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Platform reconnaissance \u2014 inventory all developer tooling, environments, build systems, and developer workflows for project takeover. Use when asked to \"understand the dev setup\", \"developer tooling assessment\", \"platform assessment\", or \"how do developers work here\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/pave/.claude-plugin/plugin.json
+++ b/skills/pave/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pave",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Platform engineer \u2014 developer experience, golden paths, service catalogs, and local dev environments.",
   "author": {
     "name": "tonone-ai",

--- a/skills/pitch-copy/.claude-plugin/plugin.json
+++ b/skills/pitch-copy/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pitch-copy",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Landing page and marketing copy \u2014 write hero section, problem/solution blocks, proof points, and CTAs. Use when asked to \"write landing page copy\", \"write the homepage\", \"marketing copy for this feature\", \"product page copy\", \"write the hero section\", or \"write copy for [surface]\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/pitch-landing/.claude-plugin/plugin.json
+++ b/skills/pitch-landing/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pitch-landing",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/pitch-launch/.claude-plugin/plugin.json
+++ b/skills/pitch-launch/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pitch-launch",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Produce an actual launch plan with announcement copy, channel sequence, and day-1 checklist. Use when asked to \"plan a launch\", \"GTM strategy\", \"how do we announce this\", \"launch plan for [feature]\", \"go-to-market\", \"write our Product Hunt post\", or \"how do we get people to notice this\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/pitch-message/.claude-plugin/plugin.json
+++ b/skills/pitch-message/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pitch-message",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Messaging framework \u2014 produce a full headline, subheadline, proof points, and CTA hierarchy for use across all surfaces. Use when asked to \"write our messaging\", \"messaging framework\", \"what should our headline say\", \"copy hierarchy\", \"tagline and messaging\", or \"how do we talk about the product\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/pitch-position/.claude-plugin/plugin.json
+++ b/skills/pitch-position/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pitch-position",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Produce a complete positioning document using the Dunford framework \u2014 competitive alternatives, unique attributes, value, best-fit customer, market category, positioning statement, and tagline. Use when asked to \"write our positioning\", \"define our value prop\", \"positioning statement\", \"what market are we in\", \"how do we position against X\", \"what's our tagline\", or \"write our messaging foundation\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/pitch-recon/.claude-plugin/plugin.json
+++ b/skills/pitch-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pitch-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Marketing and messaging reconnaissance \u2014 read existing landing pages, copy, positioning docs, and marketing materials to understand the current messaging state. Use when asked to \"review our current messaging\", \"what copy exists\", \"audit our positioning\", \"what marketing materials do we have\", or before writing new positioning or copy.",
   "author": {
     "name": "tonone-ai",

--- a/skills/pitch/.claude-plugin/plugin.json
+++ b/skills/pitch/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pitch",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Product marketer \u2014 positioning, messaging, value prop, GTM strategy, and launch copy.",
   "author": {
     "name": "tonone-ai",

--- a/skills/prism-audit/.claude-plugin/plugin.json
+++ b/skills/prism-audit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-audit",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Frontend audit \u2014 bundle size, dependencies, accessibility, performance, component quality. Use when asked for \"frontend review\", \"performance audit\", \"accessibility check\", or \"bundle size\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/prism-chart/.claude-plugin/plugin.json
+++ b/skills/prism-chart/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-chart",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/prism-component/.claude-plugin/plugin.json
+++ b/skills/prism-component/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-component",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Implement a reusable, accessible, typed component from a design spec. Use when asked to \"create a component\", \"build a widget\", \"implement this design\", or \"reusable UI element\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/prism-dashboard/.claude-plugin/plugin.json
+++ b/skills/prism-dashboard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-dashboard",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Build an internal dashboard with data tables, filters, detail views, and CRUD. Use when asked to build an \"admin panel\", \"internal dashboard\", \"back office\", or \"data dashboard UI\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/prism-recon/.claude-plugin/plugin.json
+++ b/skills/prism-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Frontend reconnaissance \u2014 map the component tree, routing, state management, build config, and assess quality. Use when asked to \"understand this frontend\", \"frontend assessment\", or \"what's the UI built with\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/prism-stack/.claude-plugin/plugin.json
+++ b/skills/prism-stack/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-stack",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/prism-ui/.claude-plugin/plugin.json
+++ b/skills/prism-ui/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-ui",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Implement a complete UI screen or feature from a Form visual spec. Use when asked to \"build a page\", \"implement this screen\", \"build the frontend for this feature\", or \"create this UI\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/prism/.claude-plugin/plugin.json
+++ b/skills/prism/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Frontend engineer \u2014 UI components, dashboards, design system implementation, and frontend audits.",
   "author": {
     "name": "tonone-ai",

--- a/skills/proof-api/.claude-plugin/plugin.json
+++ b/skills/proof-api/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "proof-api",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Build API test suites \u2014 endpoint testing, contract testing, load testing for REST/GraphQL/gRPC APIs. Use when asked to \"test this API\", \"API tests\", \"endpoint testing\", \"contract tests\", or \"load test\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/proof-audit/.claude-plugin/plugin.json
+++ b/skills/proof-audit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "proof-audit",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Audit test suite health \u2014 find flaky tests, slow tests, coverage gaps, and testing anti-patterns. Use when asked to \"audit tests\", \"fix flaky tests\", \"why are tests slow\", \"test health\", or \"improve test suite\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/proof-design/.claude-plugin/plugin.json
+++ b/skills/proof-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "proof-design",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/proof-e2e/.claude-plugin/plugin.json
+++ b/skills/proof-e2e/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "proof-e2e",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Build E2E test specs for critical user journeys \u2014 Playwright or Cypress, page objects, setup/teardown, CI config. Use when asked to \"write E2E tests\", \"end-to-end testing\", \"browser tests\", \"UI tests\", or \"Playwright tests\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/proof-recon/.claude-plugin/plugin.json
+++ b/skills/proof-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "proof-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Testing reconnaissance \u2014 inventory all tests, frameworks, coverage, CI integration, and assess testing maturity for project takeover. Use when asked to \"understand the tests\", \"testing assessment\", \"what's tested\", or \"test inventory\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/proof-strategy/.claude-plugin/plugin.json
+++ b/skills/proof-strategy/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "proof-strategy",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Produce a test strategy for a project or feature \u2014 risk map, test type decisions, coverage targets, CI config. Use when asked to \"create test strategy\", \"what should we test\", \"testing plan\", or \"improve test coverage\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/proof/.claude-plugin/plugin.json
+++ b/skills/proof/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "proof",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "QA and testing engineer \u2014 test strategy, E2E suites, API tests, flaky test triage, coverage.",
   "author": {
     "name": "tonone-ai",

--- a/skills/relay-audit/.claude-plugin/plugin.json
+++ b/skills/relay-audit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "relay-audit",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Audit an existing CI/CD pipeline for slowness, security issues, and reliability gaps. Use when asked to \"audit pipeline\", \"why is CI slow\", \"pipeline review\", or \"deployment review\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/relay-deploy/.claude-plugin/plugin.json
+++ b/skills/relay-deploy/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "relay-deploy",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Set up a complete deployment configuration \u2014 Dockerfile, deployment manifest, environment config, and rollback procedure. Use when asked about \"deployment setup\", \"how do I deploy this\", \"deployment strategy\", or \"rollback plan\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/relay-docker/.claude-plugin/plugin.json
+++ b/skills/relay-docker/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "relay-docker",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Build production-ready Dockerfiles with multi-stage builds, security hardening, and docker-compose for local dev. Use when asked to \"create Dockerfile\", \"optimize container\", or \"dockerize this\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/relay-pipeline/.claude-plugin/plugin.json
+++ b/skills/relay-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "relay-pipeline",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Build a full CI/CD pipeline from scratch. Use when asked to \"set up CI/CD\", \"create pipeline\", or \"automate deploys\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/relay-recon/.claude-plugin/plugin.json
+++ b/skills/relay-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "relay-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Map the full CI/CD pipeline \u2014 triggers, build, test, deploy flow \u2014 with risk assessment. Use when asked \"how does this deploy\", \"map the pipeline\", or \"understand CI/CD\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/relay-ship/.claude-plugin/plugin.json
+++ b/skills/relay-ship/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "relay-ship",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "End-to-end ship workflow \u2014 merge base, run tests, review diff, bump version, commit, push, create PR. Use when asked to \"ship\", \"push to main\", \"create a PR\", \"get this merged\", or \"deploy this branch\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/relay/.claude-plugin/plugin.json
+++ b/skills/relay/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "relay",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "DevOps engineer \u2014 CI/CD pipelines, deployments, GitOps, Docker, and developer experience.",
   "author": {
     "name": "tonone-ai",

--- a/skills/spine-api/.claude-plugin/plugin.json
+++ b/skills/spine-api/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-api",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Design and spec an API \u2014 endpoints, request/response shapes, error codes, auth pattern, pagination. Applies Stripe's consistency principles. Use when asked to \"design an API\", \"build API endpoints\", \"create REST API\", or \"API for this feature\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/spine-design/.claude-plugin/plugin.json
+++ b/skills/spine-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-design",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Produce a system design doc \u2014 components, data flow, decisions made, tradeoffs, failure modes. Not a list of options. An actual design with calls made. Use when asked for \"system design for\", \"architect this\", \"how should we build\", or \"design the backend\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/spine-perf/.claude-plugin/plugin.json
+++ b/skills/spine-perf/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-perf",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Find and fix performance bottlenecks \u2014 N+1 queries, missing indexes, sync bottlenecks, caching gaps. Use when asked \"why is this slow\", \"performance issue\", \"optimize this endpoint\", or \"N+1 queries\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/spine-recon/.claude-plugin/plugin.json
+++ b/skills/spine-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Backend reconnaissance \u2014 map all routes, middleware, models, dependencies, auth, and assess code quality for project takeover. Use when asked to \"understand this backend\", \"map the API\", or \"assess code quality\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/spine-review/.claude-plugin/plugin.json
+++ b/skills/spine-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-review",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "API and backend code review \u2014 REST conventions, auth, validation, error handling, pagination, rate limiting, test coverage. Use when asked to \"review this API\", \"code review\", \"review backend\", or \"pre-launch backend check\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/spine-service/.claude-plugin/plugin.json
+++ b/skills/spine-service/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-service",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Build a new production-ready service from scratch \u2014 config management, health checks, graceful shutdown, structured logging. Use when asked to \"new service\", \"scaffold a backend\", \"bootstrap service\", or \"create microservice\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/spine/.claude-plugin/plugin.json
+++ b/skills/spine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spine",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Backend engineer \u2014 APIs, system design, performance, distributed systems, and service scaffolding.",
   "author": {
     "name": "tonone-ai",

--- a/skills/surge-activation/.claude-plugin/plugin.json
+++ b/skills/surge-activation/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surge-activation",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/surge-experiment/.claude-plugin/plugin.json
+++ b/skills/surge-experiment/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surge-experiment",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Growth experiment design \u2014 structure a growth hypothesis, define metric, baseline, expected lift, and kill condition for a single experiment. Use when asked to \"design a growth experiment\", \"test this growth idea\", \"experiment framework\", \"how do we test if this works\", or \"growth hypothesis\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/surge-landing/.claude-plugin/plugin.json
+++ b/skills/surge-landing/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surge-landing",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/surge-plg/.claude-plugin/plugin.json
+++ b/skills/surge-plg/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surge-plg",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "PLG motion design \u2014 free tier definition, activation sequence, expansion trigger points, viral mechanic assessment. Given a product, output the PLG architecture and make the calls. Use when asked to \"PLG strategy\", \"freemium model\", \"product-led growth plan\", \"self-serve motion\", \"how do we add a free tier\", \"upgrade triggers\", or \"viral loop design\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/surge-recon/.claude-plugin/plugin.json
+++ b/skills/surge-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surge-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Growth state reconnaissance \u2014 scan existing onboarding flows, acquisition channels, conversion funnels, and growth experiment logs to understand current growth state. Use when asked to \"what's our growth state\", \"audit the funnel\", \"what growth experiments have we run\", \"acquisition channel inventory\", or before designing new growth experiments.",
   "author": {
     "name": "tonone-ai",

--- a/skills/surge-retention/.claude-plugin/plugin.json
+++ b/skills/surge-retention/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surge-retention",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Retention diagnosis + intervention plan \u2014 analyze the retention curve, identify the primary drop-off point, and produce a specific intervention plan with expected impact. Use when asked to \"improve retention\", \"why are users churning\", \"build a retention playbook\", \"reduce churn\", \"win-back campaign\", or \"users aren't coming back\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/surge/.claude-plugin/plugin.json
+++ b/skills/surge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surge",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Growth engineer \u2014 acquisition channels, activation funnels, retention playbooks, and PLG strategy.",
   "author": {
     "name": "tonone-ai",

--- a/skills/tonone-onboard/.claude-plugin/plugin.json
+++ b/skills/tonone-onboard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tonone-onboard",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "First-run onboarding tour \u2014 guided walkthrough of tonone's 23 agents, key skills, and worktree sessions. Two paths: expert (~90 sec) and newcomer (~8 min). Use when asked \"how do I use tonone\", \"what can tonone do\", \"show me around\", or \"first steps\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/touch-app/.claude-plugin/plugin.json
+++ b/skills/touch-app/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "touch-app",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Produce a complete mobile app architecture design \u2014 platform choice, navigation structure, state management, data layer, key screens. Use when asked to \"build a mobile app\", \"new app\", \"create iOS/Android app\", \"app architecture\", or \"cross-platform app\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/touch-audit/.claude-plugin/plugin.json
+++ b/skills/touch-audit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "touch-audit",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Mobile audit \u2014 app size, startup time, crash reporting, store compliance, accessibility, offline behavior. Use when asked for \"mobile review\", \"app store readiness\", \"mobile performance\", or \"crash analysis\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/touch-feature/.claude-plugin/plugin.json
+++ b/skills/touch-feature/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "touch-feature",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Produce a mobile feature spec \u2014 user story, technical approach, component breakdown, platform-specific considerations, edge cases. Use when asked to \"add a screen\", \"spec this feature\", \"mobile feature\", \"new tab\", \"push notifications\", or \"deep link\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/touch-recon/.claude-plugin/plugin.json
+++ b/skills/touch-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "touch-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Mobile reconnaissance \u2014 understand the app's tech stack, architecture, dependencies, and health for takeover. Use when asked to \"understand this app\", \"mobile assessment\", or \"app health\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/touch-release/.claude-plugin/plugin.json
+++ b/skills/touch-release/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "touch-release",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Set up mobile release pipeline \u2014 Fastlane, code signing, CI, beta distribution, versioning. Use when asked about \"app store setup\", \"release pipeline\", \"fastlane\", \"beta distribution\", or \"signing\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/touch-ui/.claude-plugin/plugin.json
+++ b/skills/touch-ui/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "touch-ui",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "|",
   "author": {
     "name": "tonone-ai",

--- a/skills/touch/.claude-plugin/plugin.json
+++ b/skills/touch/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "touch",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Mobile engineer \u2014 native iOS/Android, cross-platform, app stores, mobile performance.",
   "author": {
     "name": "tonone-ai",

--- a/skills/vigil-alert/.claude-plugin/plugin.json
+++ b/skills/vigil-alert/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vigil-alert",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Write SLO-based alert rules with burn rate thresholds and paired runbooks. Outputs actual alert configs, not a strategy doc. Use when asked to \"set up alerts\", \"create runbooks\", \"define SLOs\", or \"alerting strategy\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/vigil-check/.claude-plugin/plugin.json
+++ b/skills/vigil-check/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vigil-check",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Verify observability posture \u2014 audit monitoring coverage, find blind spots, prioritize gaps. Use when asked \"is monitoring sufficient\", \"observability review\", \"are we covered\", or \"pre-launch monitoring check\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/vigil-incident/.claude-plugin/plugin.json
+++ b/skills/vigil-incident/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vigil-incident",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Incident response \u2014 diagnose production issues, find root cause, propose fix with rollback. Use when asked about \"something is broken\", \"production issue\", \"why is this down\", \"incident\", or \"debug production\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/vigil-instrument/.claude-plugin/plugin.json
+++ b/skills/vigil-instrument/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vigil-instrument",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Instrument a service with OpenTelemetry \u2014 RED metrics, structured logs, distributed tracing, and health checks. Outputs actual code and config, not a plan. Use when asked to \"add monitoring\", \"instrument this\", \"add logging\", \"set up tracing\", or \"observability\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/vigil-recon/.claude-plugin/plugin.json
+++ b/skills/vigil-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vigil-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Observability reconnaissance \u2014 inventory what monitoring exists, map coverage, highlight blind spots. Use when asked \"what monitoring exists\", \"observability assessment\", or \"what can we see\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/vigil/.claude-plugin/plugin.json
+++ b/skills/vigil/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vigil",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Observability and reliability engineer \u2014 SLOs, alerting, instrumentation, and incident response.",
   "author": {
     "name": "tonone-ai",

--- a/skills/volt-driver/.claude-plugin/plugin.json
+++ b/skills/volt-driver/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "volt-driver",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Build a device driver or protocol handler \u2014 I2C sensors, BLE services, MQTT clients, SPI peripherals with interrupt-driven I/O and clean HAL abstraction. Use when asked to \"write a driver\", \"I2C device\", \"BLE service\", \"MQTT client\", or \"sensor integration\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/volt-firmware/.claude-plugin/plugin.json
+++ b/skills/volt-firmware/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "volt-firmware",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Produce a complete firmware architecture spec for a described device \u2014 layer diagram, module responsibilities, HAL interface definitions, key state machines, RTOS decision. Use when asked to \"design firmware architecture\", \"plan embedded firmware\", \"architect an IoT device\", \"how should I structure this firmware\", or given a device description and asked what the firmware should look like.",
   "author": {
     "name": "tonone-ai",

--- a/skills/volt-ota/.claude-plugin/plugin.json
+++ b/skills/volt-ota/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "volt-ota",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Produce a complete OTA update system design \u2014 partition layout, update flow, rollback conditions, validation checks, fleet management approach, failure modes and recovery. Use when asked about \"OTA updates\", \"firmware updates over the air\", \"how do I update devices in the field\", \"OTA strategy\", or \"remote firmware update design\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/volt-power/.claude-plugin/plugin.json
+++ b/skills/volt-power/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "volt-power",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Power management audit \u2014 analyze sleep modes, wake sources, power state machines, radio duty cycles, and battery life estimates. Use when asked to \"audit power usage\", \"optimize battery life\", \"review power management\", \"why is my battery draining\", \"power budget analysis\", or \"sleep mode review\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/volt-recon/.claude-plugin/plugin.json
+++ b/skills/volt-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "volt-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Firmware reconnaissance for takeover \u2014 inventory the MCU, peripherals, RTOS, protocols, OTA, power management, and assess code quality with risk flags. Use when asked to \"understand this firmware\", \"device inventory\", or \"embedded assessment\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/volt/.claude-plugin/plugin.json
+++ b/skills/volt/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "volt",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Embedded and IoT engineer \u2014 firmware, microcontrollers, OTA updates, device protocols.",
   "author": {
     "name": "tonone-ai",

--- a/skills/warden-audit/.claude-plugin/plugin.json
+++ b/skills/warden-audit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warden-audit",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Full security audit \u2014 secrets, dependencies, IAM, auth, injection, XSS, HTTPS, rate limiting, public storage. Use when asked for \"security audit\", \"check for vulnerabilities\", \"security review\", or \"are we secure\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/warden-harden/.claude-plugin/plugin.json
+++ b/skills/warden-harden/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warden-harden",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Produce a hardening spec and implement it \u2014 auth patterns, security headers, rate limiting, input validation, secrets management, dependency hygiene. Use when asked to \"harden this\", \"add security to this service\", \"what security do I need\", or \"secure this before launch\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/warden-iam/.claude-plugin/plugin.json
+++ b/skills/warden-iam/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warden-iam",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Build IAM from scratch \u2014 roles, policies, service accounts with least privilege. Use when asked to \"set up IAM\", \"create roles\", \"service accounts\", or \"access control\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/warden-recon/.claude-plugin/plugin.json
+++ b/skills/warden-recon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warden-recon",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Security reconnaissance \u2014 full inventory of secrets management, IAM, dependencies, auth, encryption, audit logging, and compliance gaps. Use when asked about \"security posture\", \"how secure is this\", or \"security assessment\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/warden-scan/.claude-plugin/plugin.json
+++ b/skills/warden-scan/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warden-scan",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Automated SAST + dependency vulnerability scan. Runs Semgrep (code vulnerabilities) and pip-audit (CVE-matched dependencies) and writes a structured JSON report. Use when asked to \"scan for vulnerabilities\", \"run a security scan\", \"check for CVEs\", or \"audit dependencies\".",
   "author": {
     "name": "tonone-ai",

--- a/skills/warden-threat/.claude-plugin/plugin.json
+++ b/skills/warden-threat/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warden-threat",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Produce a threat model \u2014 assets, ranked threats, mitigations, accepted risks. Use when asked to \"threat model this\", \"what could go wrong security-wise\", \"map our attack surface\", or before designing any security-sensitive feature.",
   "author": {
     "name": "tonone-ai",

--- a/skills/warden/.claude-plugin/plugin.json
+++ b/skills/warden/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warden",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Security engineer \u2014 IAM, secrets, threat modeling, hardening, auth, and supply chain security.",
   "author": {
     "name": "tonone-ai",

--- a/team/apex/.claude-plugin/plugin.json
+++ b/team/apex/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apex",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Engineering lead \u2014 orchestrates the team, scopes work, controls depth and budget",
   "author": {
     "name": "tonone-ai",

--- a/team/apex/agents/apex.md
+++ b/team/apex/agents/apex.md
@@ -78,9 +78,12 @@ Before dispatching specialists, make the architectural decisions:
 - **What are the constraints?** "Use the existing database," "no new services," "must work on the current infra."
 - **What decisions are you making now?** Name them. Reversible ones made without ceremony. Irreversible ones flagged before locking in.
 
-When users ask for options on a genuinely ambiguous product/engineering question, use the S/M/L format:
+When users ask for options on a genuinely ambiguous product/engineering question, use the XS-XXL depth format — six tiers from a fast, dirty spike to a full-team high-assurance build:
 
 ```
+XS — [summary] (sonnet × 1, no review)
+     Est. tokens: ~[X]K | Est. cost: ~$[X] | Time: ~[X]min
+
 S — [summary]
     Specialists: [who] (sonnet × N)
     Est. tokens: ~[X]K | Est. cost: ~$[X] | Time: ~[X]min
@@ -93,12 +96,20 @@ L — [summary]
     Specialists: [who] (sonnet × N)
     Est. tokens: ~[X]K | Est. cost: ~$[X] | Time: ~[X]min
 
+XL — [summary] (+ dedicated QA/perf review pass)
+     Specialists: [who] (sonnet × N)
+     Est. tokens: ~[X]K | Est. cost: ~$[X] | Time: ~[X]min
+
+XXL — [summary] (all relevant specialists in parallel + adversarial review pass)
+      Specialists: [who] (sonnet × N)
+      Est. tokens: ~[X]K | Est. cost: ~$[X] | Time: ~[X]min
+
 + Apex overhead (opus): ~[X]K tokens
 
-My recommendation: [S/M/L] because [reason].
+My recommendation: [tier] because [reason].
 ```
 
-Reserve S/M/L for work with genuinely different depth trade-offs. Don't use it as a ritual for every task — most work has an obvious depth. Pick it and move.
+Only show tiers that make sense for the request — don't pad the menu. Reserve the full XS-XXL spread for work with genuinely different depth trade-offs. Don't use it as a ritual for every task — most work has an obvious depth. Pick it and move.
 
 **Estimation guidelines:**
 
@@ -149,7 +160,7 @@ Usage:
   [Specialist]: [X]K tokens
   Apex: [X]K tokens
   Total: [X]K tokens | $[X] | [X]min
-  ([Over/Under] [S/M/L] estimate by [X]%)
+  ([Over/Under] [tier] estimate by [X]%)
 ```
 
 ## Helm Handoff

--- a/team/apex/scripts/pyproject.toml
+++ b/team/apex/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apex"
-version = "1.10.3"
+version = "1.11.0"
 description = "Engineering lead — orchestrates the team, scopes work, controls depth and budget"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/apex/skills/apex-plan/SKILL.md
+++ b/team/apex/skills/apex-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: apex-plan
-description: Plan and scope a project — discovery, challenge assumptions, present S/M/L options with token and cost estimates. Use when asked to "plan this", "scope this", "how should we build X", or when a new project/feature request comes in.
+description: Plan and scope a project — discovery, challenge assumptions, present XS-XXL depth options with token and cost estimates. Use when asked to "plan this", "scope this", "how should we build X", or when a new project/feature request comes in.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task, TodoWrite, AskUserQuestion
 version: 0.6.4
 author: tonone-ai <hello@tonone.ai>
@@ -21,29 +21,35 @@ Follow the output format defined in docs/output-kit.md — 40-line CLI max, box-
 
 2. **Assess which specialists are needed and at what depth.** Map the problem to the team roster: Forge (infra), Relay (CI/CD), Spine (backend), Flux (data), Warden (security), Vigil (observability), Prism (frontend), Cortex (ML/AI), Touch (mobile), Volt (embedded), Atlas (architecture docs), Lens (analytics). Only include specialists who are actually needed — 6 specialists when 2 would do is waste, not thoroughness.
 
-3. **Present 3 options (S/M/L)** using this format:
+3. **Present options across six depth tiers (XS/S/M/L/XL/XXL)** — only show tiers that make sense for the request (a typo fix doesn't need an XXL row, a system migration doesn't need XS). Use this format:
 
 ```
-S — [summary]
-    Specialists: [who] (sonnet x N)
-    Est. tokens: ~[X]K | Est. cost: ~$[X] | Time: ~[X]min
+XS — Fast & dirty (Spine, ~10K tokens, ~$0.02)
+     One specialist, single pass, no review. Prototype or throwaway spike.
 
-M — [summary]
-    Specialists: [who] (sonnet x N)
-    Est. tokens: ~[X]K | Est. cost: ~$[X] | Time: ~[X]min
+S — Quick & focused (Spine + Warden, ~30K tokens, ~$0.05)
+    Basic implementation with a security pass.
 
-L — [summary]
-    Specialists: [who] (sonnet x N)
-    Est. tokens: ~[X]K | Est. cost: ~$[X] | Time: ~[X]min
+M — Solid implementation (Spine + Warden + Flux + Relay, ~120K tokens, ~$0.20)
+    Feature + data layer + CI, reviewed.
+
+L — Full build-out (+ Vigil + Atlas, ~250K tokens, ~$0.45)
+    Everything in M + monitoring + documentation.
+
+XL — Production-hardened (+ Proof + Forge, ~450K tokens, ~$0.80)
+     Everything in L + dedicated QA pass + infra/perf review.
+
+XXL — Full team, high assurance (all relevant specialists in parallel + adversarial review pass, ~800K-1M tokens, ~$1.50+)
+      Major system build or migration. Multiple independent review rounds before delivery. Consider dispatching via the Workflow tool at this scale.
 
 + Apex overhead (opus): ~[X]K tokens
 
-My recommendation: [S/M/L] because [reason].
+My recommendation: [tier] because [reason].
 ```
 
-Lead with your recommendation and why.
+Lead with your recommendation and why. Fill in real specialists and numbers for the actual request — the block above is the template, not literal output.
 
-4. **Wait for the user to pick a level.** Do not proceed until they choose S, M, or L.
+4. **Wait for the user to pick a level.** Do not proceed until they choose a tier (XS, S, M, L, XL, or XXL).
 
 5. **Dispatch specialists at the chosen depth.** Run independent specialists in parallel. Run dependent specialists sequentially. Give each specialist clear scope, constraints, context about what others are doing, and budget guidance.
 
@@ -57,5 +63,5 @@ Usage:
   [Specialist]: [X]K tokens
   Apex: [X]K tokens
   Total: [X]K tokens | $[X] | [X]min
-  ([Over/Under] [S/M/L] estimate by [X]%)
+  ([Over/Under] [tier] estimate by [X]%)
 ```

--- a/team/atlas/.claude-plugin/plugin.json
+++ b/team/atlas/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atlas",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Knowledge engineer \u2014 architecture docs, ADRs, API specs, system diagrams, onboarding, output formatting, browser reports, changelogs, release presentations",
   "author": {
     "name": "tonone-ai",

--- a/team/atlas/scripts/pyproject.toml
+++ b/team/atlas/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "atlas"
-version = "1.10.3"
+version = "1.11.0"
 description = "Knowledge engineer — architecture docs, ADRs, API specs, system diagrams, onboarding"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/audit/.claude-plugin/plugin.json
+++ b/team/audit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "audit",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Legal compliance audit \u2014 internal controls review, legal risk register, audit trail documentation",
   "author": {
     "name": "tonone-ai",

--- a/team/axe/.claude-plugin/plugin.json
+++ b/team/axe/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "axe",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Design Team \u2014 Axe: Accessibility engineering \u2014 WCAG audits, keyboard nav, screen reader testing, ARIA",
   "author": {
     "name": "tonone-ai",

--- a/team/bench/.claude-plugin/plugin.json
+++ b/team/bench/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bench",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Developer Experience Team \u2014 Bench: API performance benchmarking \u2014 latency profiling, throughput testing, performance regression detection",
   "author": {
     "name": "tonone-ai",

--- a/team/bind/.claude-plugin/plugin.json
+++ b/team/bind/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bind",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Compliance framework implementation \u2014 SOC2, GDPR, HIPAA, ISO 27001 gap analysis and remediation plans",
   "author": {
     "name": "tonone-ai",

--- a/team/blue/.claude-plugin/plugin.json
+++ b/team/blue/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "blue",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Security Operations Team \u2014 Blue: Blue team operations \u2014 SOC design, detection engineering, hardening playbooks",
   "author": {
     "name": "tonone-ai",

--- a/team/brace/.claude-plugin/plugin.json
+++ b/team/brace/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brace",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Support engineer -- ticket workflow design, SLA architecture, knowledge base, escalation paths, and support operations at scale",
   "author": {
     "name": "tonone-ai",

--- a/team/brace/scripts/pyproject.toml
+++ b/team/brace/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brace"
-version = "1.10.3"
+version = "1.11.0"
 description = "Support agent -- ticket workflow, SLA design, knowledge base, escalation paths, support operations"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/brief/.claude-plugin/plugin.json
+++ b/team/brief/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brief",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Contract & policy drafting \u2014 NDAs, MSAs, employment agreements, SLAs, vendor contracts",
   "author": {
     "name": "tonone-ai",

--- a/team/budget/.claude-plugin/plugin.json
+++ b/team/budget/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "budget",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "AI Operations Team \u2014 Budget: LLM spend tracking, model cost optimization, budget alerts, and token efficiency audits across AI workloads.",
   "author": {
     "name": "tonone-ai",

--- a/team/buzz/.claude-plugin/plugin.json
+++ b/team/buzz/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "buzz",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "PR & Community engineer \u2014 press pitches, social media, open source community, DevRel, and launch moments",
   "author": {
     "name": "tonone-ai",

--- a/team/buzz/scripts/pyproject.toml
+++ b/team/buzz/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "buzz"
-version = "1.10.3"
+version = "1.11.0"
 description = "PR and community agent -- press pitches, social media, open source community, DevRel, launch moments"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/cache/.claude-plugin/plugin.json
+++ b/team/cache/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cache",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Infrastructure Specialist Team \u2014 Cache: Caching strategy \u2014 Redis/Memcached design, cache invalidation, eviction policies, application caching patterns",
   "author": {
     "name": "tonone-ai",

--- a/team/cast/.claude-plugin/plugin.json
+++ b/team/cast/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cast",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Data Science Team \u2014 Cast: Time series forecasting \u2014 demand prediction, trend analysis, seasonal decomposition",
   "author": {
     "name": "tonone-ai",

--- a/team/chain/.claude-plugin/plugin.json
+++ b/team/chain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "chain",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Security Operations Team \u2014 Chain: Supply chain security \u2014 SBOM generation, dependency scanning, third-party risk, license compliance",
   "author": {
     "name": "tonone-ai",

--- a/team/change/.claude-plugin/plugin.json
+++ b/team/change/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "change",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Developer Experience Team \u2014 Change: Changelog and release communication \u2014 breaking change documentation, deprecation notices, migration guides",
   "author": {
     "name": "tonone-ai",

--- a/team/chaos/.claude-plugin/plugin.json
+++ b/team/chaos/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "chaos",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Infrastructure Specialist Team \u2014 Chaos: Chaos engineering \u2014 failure injection design, game days, resilience testing, blast radius control",
   "author": {
     "name": "tonone-ai",

--- a/team/cite/.claude-plugin/plugin.json
+++ b/team/cite/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cite",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Legal research \u2014 case law synthesis, statute analysis, regulatory guidance, jurisdiction comparison",
   "author": {
     "name": "tonone-ai",

--- a/team/clause/.claude-plugin/plugin.json
+++ b/team/clause/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "clause",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Contract clause analysis \u2014 redlining, risk scoring, negotiation playbooks",
   "author": {
     "name": "tonone-ai",

--- a/team/clean/.claude-plugin/plugin.json
+++ b/team/clean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "clean",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Data Science Team \u2014 Clean: Data quality \u2014 deduplication, validation, outlier detection, ETL pipeline design",
   "author": {
     "name": "tonone-ai",

--- a/team/compat/.claude-plugin/plugin.json
+++ b/team/compat/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "compat",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Developer Experience Team \u2014 Compat: Backwards compatibility \u2014 breaking change detection, deprecation management, semver discipline",
   "author": {
     "name": "tonone-ai",

--- a/team/copy/.claude-plugin/plugin.json
+++ b/team/copy/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "copy",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Design Team \u2014 Copy: UX writing and content design \u2014 microcopy, error messages, onboarding flows, UI content strategy",
   "author": {
     "name": "tonone-ai",

--- a/team/cortex/.claude-plugin/plugin.json
+++ b/team/cortex/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "ML/AI engineer \u2014 model training, MLOps, feature engineering, LLM integration",
   "author": {
     "name": "tonone-ai",

--- a/team/cortex/scripts/pyproject.toml
+++ b/team/cortex/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cortex"
-version = "1.10.3"
+version = "1.11.0"
 description = "ML/AI engineer — model training, MLOps, feature engineering, LLM integration"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/crest/.claude-plugin/plugin.json
+++ b/team/crest/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "crest",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Product strategist \u2014 roadmap planning, prioritization frameworks, competitive analysis, and market positioning",
   "author": {
     "name": "tonone-ai",

--- a/team/crest/scripts/pyproject.toml
+++ b/team/crest/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "crest"
-version = "1.10.3"
+version = "1.11.0"
 description = "Product strategist — roadmap planning, prioritization frameworks, competitive analysis, and market positioning"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/cut/.claude-plugin/plugin.json
+++ b/team/cut/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cut",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Design Team \u2014 Cut: Illustration and icon design \u2014 custom assets, icon systems, SVG optimization",
   "author": {
     "name": "tonone-ai",

--- a/team/deal/.claude-plugin/plugin.json
+++ b/team/deal/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deal",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Revenue & Sales engineer \u2014 B2B pipeline, deal strategy, pricing, sales playbooks, and enterprise closing",
   "author": {
     "name": "tonone-ai",

--- a/team/deal/scripts/pyproject.toml
+++ b/team/deal/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deal"
-version = "1.10.3"
+version = "1.11.0"
 description = "Revenue and sales agent -- pipeline tracking, deal playbooks, pricing, enterprise closing"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/deploy/.claude-plugin/plugin.json
+++ b/team/deploy/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deploy",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "AI Operations Team \u2014 Deploy: Model serving, inference APIs, blue/green deploys, rollback, and canary releases for production ML.",
   "author": {
     "name": "tonone-ai",

--- a/team/draft/.claude-plugin/plugin.json
+++ b/team/draft/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "draft",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "UX designer \u2014 user flows, information architecture, wireframes, and interaction design",
   "author": {
     "name": "tonone-ai",

--- a/team/draft/scripts/pyproject.toml
+++ b/team/draft/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "draft"
-version = "1.10.3"
+version = "1.11.0"
 description = "UX designer — user flows, information architecture, wireframes, and interaction design"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/drift/.claude-plugin/plugin.json
+++ b/team/drift/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "drift",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Data Science Team \u2014 Drift: ML monitoring \u2014 data drift, concept drift, model degradation, production ML health",
   "author": {
     "name": "tonone-ai",

--- a/team/echo/.claude-plugin/plugin.json
+++ b/team/echo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "echo",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "User researcher \u2014 interviews, personas, Jobs-to-Be-Done, and customer feedback synthesis",
   "author": {
     "name": "tonone-ai",

--- a/team/echo/scripts/pyproject.toml
+++ b/team/echo/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "echo"
-version = "1.10.3"
+version = "1.11.0"
 description = "User researcher — interviews, personas, Jobs-to-Be-Done, and customer feedback synthesis"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/edge/.claude-plugin/plugin.json
+++ b/team/edge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "edge",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Infrastructure Specialist Team \u2014 Edge: Edge computing and CDN \u2014 global distribution, cache strategy, edge functions, latency optimization",
   "author": {
     "name": "tonone-ai",

--- a/team/embed/.claude-plugin/plugin.json
+++ b/team/embed/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "embed",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "AI Operations Team \u2014 Embed: Embedding model selection, vector pipeline design, similarity search, and production index management.",
   "author": {
     "name": "tonone-ai",

--- a/team/eval/.claude-plugin/plugin.json
+++ b/team/eval/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "eval",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Data Science Team \u2014 Eval: Experiment design \u2014 A/B testing, statistical power, experiment tracking, causal inference",
   "author": {
     "name": "tonone-ai",

--- a/team/evals/.claude-plugin/plugin.json
+++ b/team/evals/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "evals",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "AI Operations Team \u2014 Evals: Eval harness design, benchmark suites, automated regression, and human eval pipeline orchestration.",
   "author": {
     "name": "tonone-ai",

--- a/team/feat/.claude-plugin/plugin.json
+++ b/team/feat/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "feat",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Data Science Team \u2014 Feat: Feature engineering \u2014 transformations, encodings, feature stores, pipeline design",
   "author": {
     "name": "tonone-ai",

--- a/team/finop/.claude-plugin/plugin.json
+++ b/team/finop/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "finop",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Infrastructure Specialist Team \u2014 Finop: Cloud cost optimization \u2014 FinOps practices, rightsizing, reservation strategy, cost attribution",
   "author": {
     "name": "tonone-ai",

--- a/team/fit/.claude-plugin/plugin.json
+++ b/team/fit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fit",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Data Science Team \u2014 Fit: Model training \u2014 algorithm selection, hyperparameter tuning, training infrastructure",
   "author": {
     "name": "tonone-ai",

--- a/team/flux/.claude-plugin/plugin.json
+++ b/team/flux/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Data engineer \u2014 databases, migrations, pipelines, data modeling",
   "author": {
     "name": "tonone-ai",

--- a/team/flux/scripts/pyproject.toml
+++ b/team/flux/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flux"
-version = "1.10.3"
+version = "1.11.0"
 description = "Data engineer — databases, migrations, pipelines, data modeling"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/folk/.claude-plugin/plugin.json
+++ b/team/folk/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "folk",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "People engineer - org design, hiring pipelines, compensation frameworks, onboarding playbooks, performance management, and human-to-agent migration",
   "author": {
     "name": "tonone-ai",

--- a/team/folk/scripts/pyproject.toml
+++ b/team/folk/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "folk"
-version = "1.10.3"
+version = "1.11.0"
 description = "People agent -- org design, hiring, compensation, onboarding, performance, migration"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/forge/.claude-plugin/plugin.json
+++ b/team/forge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forge",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Infrastructure engineer \u2014 cloud services, networking, IaC, cost optimization",
   "author": {
     "name": "tonone-ai",

--- a/team/forge/scripts/pyproject.toml
+++ b/team/forge/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "forge"
-version = "1.10.3"
+version = "1.11.0"
 description = "Infrastructure engineer — cloud services, networking, IaC, cost optimization"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/form/.claude-plugin/plugin.json
+++ b/team/form/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "form",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Visual designer \u2014 brand identity, color systems, typography, UI design, and design systems",
   "author": {
     "name": "tonone-ai",

--- a/team/form/scripts/pyproject.toml
+++ b/team/form/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "form"
-version = "1.10.3"
+version = "1.11.0"
 description = "Visual designer — brand identity, color systems, typography, UI design, and design systems"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/frame/.claude-plugin/plugin.json
+++ b/team/frame/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "frame",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Corporate governance \u2014 board resolutions, cap table hygiene, shareholder agreements, equity plan docs",
   "author": {
     "name": "tonone-ai",

--- a/team/gate/.claude-plugin/plugin.json
+++ b/team/gate/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gate",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Developer Experience Team \u2014 Gate: API quality gates \u2014 linting, style enforcement, breaking change CI, and API governance",
   "author": {
     "name": "tonone-ai",

--- a/team/glyph/.claude-plugin/plugin.json
+++ b/team/glyph/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glyph",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Design Team \u2014 Glyph: Typography system design \u2014 font pairing, type scale, hierarchy, readability tokens",
   "author": {
     "name": "tonone-ai",

--- a/team/grid/.claude-plugin/plugin.json
+++ b/team/grid/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "grid",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Design Team \u2014 Grid: Layout system design \u2014 spacing scales, responsive grids, breakpoints, layout primitives",
   "author": {
     "name": "tonone-ai",

--- a/team/guard/.claude-plugin/plugin.json
+++ b/team/guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "guard",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "AI Operations Team \u2014 Guard: Input/output safety filters, PII detection, content moderation, and AI policy enforcement at runtime.",
   "author": {
     "name": "tonone-ai",

--- a/team/guide/.claude-plugin/plugin.json
+++ b/team/guide/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "guide",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Developer Experience Team \u2014 Guide: API and SDK documentation \u2014 reference docs, guides, and documentation architecture",
   "author": {
     "name": "tonone-ai",

--- a/team/helm/.claude-plugin/plugin.json
+++ b/team/helm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "helm",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Head of Product \u2014 product strategy, requirements, and engineering handoff via the Helm\u2194Apex interface",
   "author": {
     "name": "tonone-ai",

--- a/team/helm/scripts/pyproject.toml
+++ b/team/helm/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "helm"
-version = "1.10.3"
+version = "1.11.0"
 description = "Head of Product — product strategy, requirements, and engineering handoff"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/helm/skills/helm-plan/SKILL.md
+++ b/team/helm/skills/helm-plan/SKILL.md
@@ -16,6 +16,36 @@ You are Helm — the Head of Product on the Product Team.
 
 ## Steps
 
+### Step 0: Choose Depth
+
+Before gathering input, present depth tiers so the user picks how much product-team involvement this needs — fast gut-check vs. full cross-functional rigor. Only show tiers that make sense for the request. Use this format:
+
+```
+XS — Gut check (Helm, ~10K tokens, ~$0.02)
+     Ballpark call, no scoring, no research. "Just tell me what to do."
+
+S — Fast RICE pass (Helm, ~25K tokens, ~$0.04)
+    Score given items with stated/default inputs. No other specialists.
+
+M — Researched roadmap (Helm + Lumen + Crest, ~100K tokens, ~$0.18)
+    RICE scoring grounded in real metrics + strategic filter pass.
+
+L — Full roadmap (+ Echo + Draft, ~220K tokens, ~$0.40)
+    Everything in M + user research validation + flow sanity check.
+
+XL — Strategic roadmap (+ Crest-compete + Pitch, ~400K tokens, ~$0.70)
+     Everything in L + competitive positioning + messaging alignment. Cross-functional handoff ready.
+
+XXL — Full product strategy overhaul (entire Product team in parallel + adversarial review, ~700K-900K tokens, ~$1.30+)
+      Major roadmap reset or new market bet. Multiple independent review rounds before delivery. Consider dispatching via the Workflow tool at this scale.
+
+My recommendation: [tier] because [reason].
+```
+
+Lead with your recommendation and why. Fill in real specialists and numbers for the actual request — the block above is the template, not literal output.
+
+**Wait for the user to pick a tier** (XS, S, M, L, XL, or XXL) before proceeding. The chosen tier determines which specialists get consulted in Steps 1-4 below — at XS/S, Helm works alone; at M and above, dispatch the named specialists in parallel and fold their input into the RICE scoring and judgment filters.
+
 ### Step 1: Gather the Input
 
 Collect the list of features, ideas, or initiatives to prioritize. For each item, you need (or will estimate):
@@ -66,7 +96,15 @@ NOT NOW:
 
 ### Step 5: Deliver
 
-Present the RICE table followed by the roadmap view. Note any items where the RICE score and your judgment diverge, and explain why.
+Present the RICE table followed by the roadmap view. Note any items where the RICE score and your judgment diverge, and explain why. If specialists were dispatched (M tier and above), close with a usage receipt:
+
+```
+Usage:
+  [Specialist]: [X]K tokens
+  Helm: [X]K tokens
+  Total: [X]K tokens | $[X] | [X]min
+  ([Over/Under] [tier] estimate by [X]%)
+```
 
 Follow the output format defined in docs/output-kit.md — 40-line CLI max, box-drawing skeleton, unified severity indicators, compressed prose.
 

--- a/team/hue/.claude-plugin/plugin.json
+++ b/team/hue/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hue",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Design Team \u2014 Hue: Color palette design \u2014 semantic tokens, dark/light mode, WCAG contrast compliance",
   "author": {
     "name": "tonone-ai",

--- a/team/hunt/.claude-plugin/plugin.json
+++ b/team/hunt/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hunt",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Security Operations Team \u2014 Hunt: Threat hunting \u2014 hypothesis-driven hunting, compromise assessment, IOC analysis",
   "author": {
     "name": "tonone-ai",

--- a/team/ink/.claude-plugin/plugin.json
+++ b/team/ink/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ink",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Content Marketing engineer \u2014 blog strategy, SEO, thought leadership, developer content, and content calendar",
   "author": {
     "name": "tonone-ai",

--- a/team/ink/scripts/pyproject.toml
+++ b/team/ink/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ink"
-version = "1.10.3"
+version = "1.11.0"
 description = "Content marketing agent -- blog strategy, SEO, thought leadership, developer content, content calendar"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/keel/.claude-plugin/plugin.json
+++ b/team/keel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keel",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Operations engineer -- process design, vendor management, legal ops, compliance, OKR execution, and cross-functional coordination",
   "author": {
     "name": "tonone-ai",

--- a/team/keel/scripts/pyproject.toml
+++ b/team/keel/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keel"
-version = "1.10.3"
+version = "1.11.0"
 description = "Operations agent -- process design, vendor management, legal ops, compliance, OKR execution"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/keep/.claude-plugin/plugin.json
+++ b/team/keep/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Customer Success engineer \u2014 onboarding optimization, health scoring, expansion revenue, and churn prevention",
   "author": {
     "name": "tonone-ai",

--- a/team/keep/scripts/pyproject.toml
+++ b/team/keep/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keep"
-version = "1.10.3"
+version = "1.11.0"
 description = "Customer success agent -- onboarding optimization, health scoring, expansion revenue, churn prevention"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/kube/.claude-plugin/plugin.json
+++ b/team/kube/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kube",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Infrastructure Specialist Team \u2014 Kube: Kubernetes cluster design \u2014 RBAC, networking, operators, workload configuration",
   "author": {
     "name": "tonone-ai",

--- a/team/lens/.claude-plugin/plugin.json
+++ b/team/lens/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lens",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Data analytics & BI engineer \u2014 dashboards, metrics design, reporting, data storytelling",
   "author": {
     "name": "tonone-ai",

--- a/team/lens/scripts/pyproject.toml
+++ b/team/lens/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lens"
-version = "1.10.3"
+version = "1.11.0"
 description = "Data analytics & BI engineer — dashboards, metrics design, reporting, data storytelling"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/lodge/.claude-plugin/plugin.json
+++ b/team/lodge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lodge",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Regulatory filings \u2014 DMCA responses, FTC disclosures, GDPR DPA agreements, government filings, state registrations",
   "author": {
     "name": "tonone-ai",

--- a/team/lumen/.claude-plugin/plugin.json
+++ b/team/lumen/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lumen",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Product analyst \u2014 metrics frameworks, funnel analysis, OKRs, A/B test design, and retention analysis",
   "author": {
     "name": "tonone-ai",

--- a/team/lumen/scripts/pyproject.toml
+++ b/team/lumen/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lumen"
-version = "1.10.3"
+version = "1.11.0"
 description = "Product analyst — metrics frameworks, funnel analysis, OKRs, A/B test design, and retention analysis"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/mark/.claude-plugin/plugin.json
+++ b/team/mark/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mark",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Design Team \u2014 Mark: Brand identity design \u2014 logo usage rules, brand guidelines, visual identity systems",
   "author": {
     "name": "tonone-ai",

--- a/team/mesh/.claude-plugin/plugin.json
+++ b/team/mesh/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mesh",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Infrastructure Specialist Team \u2014 Mesh: Service mesh design \u2014 Istio/Linkerd/Envoy, mTLS, traffic management, observability integration",
   "author": {
     "name": "tonone-ai",

--- a/team/mint/.claude-plugin/plugin.json
+++ b/team/mint/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mint",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Finance engineer \u2014 P&L, runway, unit economics, fundraising, board reporting, and cap table management",
   "author": {
     "name": "tonone-ai",

--- a/team/mint/scripts/pyproject.toml
+++ b/team/mint/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mint"
-version = "1.10.3"
+version = "1.11.0"
 description = "Finance agent -- P&L, runway, unit economics, budget, fundraising, board reporting"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/mock/.claude-plugin/plugin.json
+++ b/team/mock/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mock",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Developer Experience Team \u2014 Mock: API mocking \u2014 mock server design, contract testing, API simulation for development",
   "author": {
     "name": "tonone-ai",

--- a/team/move/.claude-plugin/plugin.json
+++ b/team/move/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "move",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Design Team \u2014 Move: Motion design \u2014 animation principles, transition systems, micro-interaction specs",
   "author": {
     "name": "tonone-ai",

--- a/team/multi/.claude-plugin/plugin.json
+++ b/team/multi/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "multi",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Infrastructure Specialist Team \u2014 Multi: Multi-cloud architecture \u2014 provider selection, portability strategy, lock-in avoidance, workload placement",
   "author": {
     "name": "tonone-ai",

--- a/team/onboard/.claude-plugin/plugin.json
+++ b/team/onboard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onboard",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Developer Experience Team \u2014 Onboard: Developer onboarding \u2014 quickstart design, time-to-first-call optimization, onboarding funnel audit",
   "author": {
     "name": "tonone-ai",

--- a/team/patch/.claude-plugin/plugin.json
+++ b/team/patch/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "patch",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Security Operations Team \u2014 Patch: Vulnerability management \u2014 CVE triage, CVSS prioritization, patching cadence, SLA design",
   "author": {
     "name": "tonone-ai",

--- a/team/pave/.claude-plugin/plugin.json
+++ b/team/pave/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pave",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Platform engineer \u2014 developer experience, service catalogs, internal CLIs, golden paths, environment management",
   "author": {
     "name": "tonone-ai",

--- a/team/pave/scripts/pyproject.toml
+++ b/team/pave/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pave"
-version = "1.10.3"
+version = "1.11.0"
 description = "Platform engineer — developer experience, service catalogs, golden paths, environment management"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/pave/skills/pave-contribute/.claude-plugin/plugin.json
+++ b/team/pave/skills/pave-contribute/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tonone-pave-contribute",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Contribute a session learning back to the tonone repo",
   "skills": [
     {

--- a/team/phish/.claude-plugin/plugin.json
+++ b/team/phish/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "phish",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Security Operations Team \u2014 Phish: Security awareness \u2014 phishing simulation design, security training programs, social engineering assessment",
   "author": {
     "name": "tonone-ai",

--- a/team/pitch/.claude-plugin/plugin.json
+++ b/team/pitch/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pitch",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Product marketer \u2014 positioning, messaging, value proposition, GTM strategy, and launch copy",
   "author": {
     "name": "tonone-ai",

--- a/team/pitch/scripts/pyproject.toml
+++ b/team/pitch/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pitch"
-version = "1.10.3"
+version = "1.11.0"
 description = "Product marketer — positioning, messaging, value proposition, GTM strategy, and launch copy"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/plot/.claude-plugin/plugin.json
+++ b/team/plot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plot",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Data Science Team \u2014 Plot: Data visualization \u2014 chart design, visualization libraries, exploratory analysis, dashboard specs",
   "author": {
     "name": "tonone-ai",

--- a/team/port/.claude-plugin/plugin.json
+++ b/team/port/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "port",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Developer Experience Team \u2014 Port: SDK design \u2014 multi-language SDK architecture, idiomatic patterns, and cross-language consistency",
   "author": {
     "name": "tonone-ai",

--- a/team/prism/.claude-plugin/plugin.json
+++ b/team/prism/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Frontend & DX engineer \u2014 UI, internal tools, developer portals",
   "author": {
     "name": "tonone-ai",

--- a/team/prism/scripts/pyproject.toml
+++ b/team/prism/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prism"
-version = "1.10.3"
+version = "1.11.0"
 description = "Frontend & DX engineer — UI, internal tools, developer portals"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/prompt/.claude-plugin/plugin.json
+++ b/team/prompt/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prompt",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "AI Operations Team \u2014 Prompt: System prompt design, few-shot libraries, chain-of-thought patterns, and prompt versioning for production LLM applications.",
   "author": {
     "name": "tonone-ai",

--- a/team/proof/.claude-plugin/plugin.json
+++ b/team/proof/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "proof",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "QA & testing engineer \u2014 test strategy, E2E suites, integration testing, test infrastructure, flaky test triage",
   "author": {
     "name": "tonone-ai",

--- a/team/proof/scripts/pyproject.toml
+++ b/team/proof/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "proof"
-version = "1.10.3"
+version = "1.11.0"
 description = "QA & testing engineer — test strategy, E2E suites, integration testing, test infrastructure"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/queue/.claude-plugin/plugin.json
+++ b/team/queue/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "queue",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Infrastructure Specialist Team \u2014 Queue: Message queuing and streaming \u2014 Kafka, SQS, RabbitMQ design, consumer group strategy, dead letter queues",
   "author": {
     "name": "tonone-ai",

--- a/team/rank/.claude-plugin/plugin.json
+++ b/team/rank/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rank",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "AI Operations Team \u2014 Rank: Retrieval reranking, relevance scoring, learning-to-rank pipelines, and result quality evaluation for search and RAG.",
   "author": {
     "name": "tonone-ai",

--- a/team/red/.claude-plugin/plugin.json
+++ b/team/red/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "red",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Security Operations Team \u2014 Red: Red team operations \u2014 penetration testing, attack simulation, vulnerability exploitation",
   "author": {
     "name": "tonone-ai",

--- a/team/relay/.claude-plugin/plugin.json
+++ b/team/relay/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "relay",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "DevOps engineer \u2014 CI/CD, deployments, GitOps, developer experience",
   "author": {
     "name": "tonone-ai",

--- a/team/relay/scripts/pyproject.toml
+++ b/team/relay/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "relay"
-version = "1.10.3"
+version = "1.11.0"
 description = "DevOps engineer — CI/CD, deployments, GitOps, developer experience"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/resp/.claude-plugin/plugin.json
+++ b/team/resp/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "resp",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Security Operations Team \u2014 Resp: Incident response \u2014 playbook design, containment procedures, DFIR, post-incident review",
   "author": {
     "name": "tonone-ai",

--- a/team/sample/.claude-plugin/plugin.json
+++ b/team/sample/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sample",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Developer Experience Team \u2014 Sample: Code samples and tutorials \u2014 working examples, quickstarts, and language-specific guides",
   "author": {
     "name": "tonone-ai",

--- a/team/sast/.claude-plugin/plugin.json
+++ b/team/sast/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sast",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Security Operations Team \u2014 Sast: Application security \u2014 SAST/DAST scanning, code security review, secure SDLC design",
   "author": {
     "name": "tonone-ai",

--- a/team/schema/.claude-plugin/plugin.json
+++ b/team/schema/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "schema",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Developer Experience Team \u2014 Schema: API schema design \u2014 OpenAPI, GraphQL, gRPC schema quality, and design standards",
   "author": {
     "name": "tonone-ai",

--- a/team/scope/.claude-plugin/plugin.json
+++ b/team/scope/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scope",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "IP strategy \u2014 trademark clearance, patent landscape, open source license compliance, IP assignment",
   "author": {
     "name": "tonone-ai",

--- a/team/score/.claude-plugin/plugin.json
+++ b/team/score/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "score",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Data Science Team \u2014 Score: Model evaluation \u2014 metrics design, statistical significance, model comparison, evaluation frameworks",
   "author": {
     "name": "tonone-ai",

--- a/team/serv/.claude-plugin/plugin.json
+++ b/team/serv/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "serv",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Infrastructure Specialist Team \u2014 Serv: Serverless architecture \u2014 Lambda/Cloud Functions/Cloud Run design, cold start optimization, event patterns",
   "author": {
     "name": "tonone-ai",

--- a/team/shield/.claude-plugin/plugin.json
+++ b/team/shield/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shield",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Regulatory risk assessment \u2014 GDPR exposure, CCPA, FTC rules, financial regulation, export controls",
   "author": {
     "name": "tonone-ai",

--- a/team/siem/.claude-plugin/plugin.json
+++ b/team/siem/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "siem",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Security Operations Team \u2014 Siem: SIEM engineering \u2014 log pipeline design, detection rule development, alert tuning",
   "author": {
     "name": "tonone-ai",

--- a/team/spine/.claude-plugin/plugin.json
+++ b/team/spine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spine",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Backend engineer \u2014 APIs, system design, performance, distributed systems",
   "author": {
     "name": "tonone-ai",

--- a/team/spine/scripts/pyproject.toml
+++ b/team/spine/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spine"
-version = "1.10.3"
+version = "1.11.0"
 description = "Backend engineer — APIs, system design, performance, distributed systems"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/surge/.claude-plugin/plugin.json
+++ b/team/surge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surge",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Growth engineer \u2014 acquisition channels, activation funnels, retention playbooks, and PLG strategy",
   "author": {
     "name": "tonone-ai",

--- a/team/surge/scripts/pyproject.toml
+++ b/team/surge/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surge"
-version = "1.10.3"
+version = "1.11.0"
 description = "Growth engineer — acquisition channels, activation funnels, retention playbooks, and PLG strategy"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/terms/.claude-plugin/plugin.json
+++ b/team/terms/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "terms",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Privacy policy and Terms of Service \u2014 GDPR-compliant privacy notices, ToS, cookie policies, data processing agreements",
   "author": {
     "name": "tonone-ai",

--- a/team/terra/.claude-plugin/plugin.json
+++ b/team/terra/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "terra",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Infrastructure Specialist Team \u2014 Terra: Terraform and IaC \u2014 module design, state management, drift detection, and IaC best practices",
   "author": {
     "name": "tonone-ai",

--- a/team/token/.claude-plugin/plugin.json
+++ b/team/token/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "token",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "AI Operations Team \u2014 Token: Context window optimization, token counting, truncation strategies, and chunking patterns for LLM efficiency.",
   "author": {
     "name": "tonone-ai",

--- a/team/tone/.claude-plugin/plugin.json
+++ b/team/tone/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tone",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Design Team \u2014 Tone: Design token engineering \u2014 token architecture, theming systems, style-dictionary pipelines",
   "author": {
     "name": "tonone-ai",

--- a/team/touch/.claude-plugin/plugin.json
+++ b/team/touch/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "touch",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Mobile engineer \u2014 native iOS/Android, cross-platform, app stores, mobile performance",
   "author": {
     "name": "tonone-ai",

--- a/team/touch/scripts/pyproject.toml
+++ b/team/touch/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "touch"
-version = "1.10.3"
+version = "1.11.0"
 description = "Mobile engineer — native iOS/Android, cross-platform, app stores, mobile performance"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/trace/.claude-plugin/plugin.json
+++ b/team/trace/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "trace",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "AI Operations Team \u2014 Trace: LLM tracing, span capture, prompt/completion logging, cost attribution, and AI system debugging.",
   "author": {
     "name": "tonone-ai",

--- a/team/tune/.claude-plugin/plugin.json
+++ b/team/tune/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tune",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Data Science Team \u2014 Tune: LLM fine-tuning \u2014 PEFT/LoRA, RLHF, instruction tuning, prompt optimization",
   "author": {
     "name": "tonone-ai",

--- a/team/vect/.claude-plugin/plugin.json
+++ b/team/vect/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vect",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Data Science Team \u2014 Vect: Embeddings and vector search \u2014 semantic search, RAG pipelines, vector database design",
   "author": {
     "name": "tonone-ai",

--- a/team/vigil/.claude-plugin/plugin.json
+++ b/team/vigil/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vigil",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Observability & reliability engineer \u2014 monitoring, alerting, SRE, incident response, SLOs",
   "author": {
     "name": "tonone-ai",

--- a/team/vigil/scripts/pyproject.toml
+++ b/team/vigil/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vigil"
-version = "1.10.3"
+version = "1.11.0"
 description = "Observability & reliability engineer — monitoring, alerting, SRE, incident response, SLOs"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/volt/.claude-plugin/plugin.json
+++ b/team/volt/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "volt",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Embedded & IoT engineer \u2014 firmware, microcontrollers, edge computing, device protocols",
   "author": {
     "name": "tonone-ai",

--- a/team/volt/scripts/pyproject.toml
+++ b/team/volt/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "volt"
-version = "1.10.3"
+version = "1.11.0"
 description = "Embedded & IoT engineer — firmware, microcontrollers, edge computing, device protocols"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/warden/.claude-plugin/plugin.json
+++ b/team/warden/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warden",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Security engineer \u2014 IAM, secrets, compliance, threat modeling",
   "author": {
     "name": "tonone-ai",

--- a/team/warden/scripts/pyproject.toml
+++ b/team/warden/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "warden"
-version = "1.10.3"
+version = "1.11.0"
 description = "Security engineer — IAM, secrets, compliance, threat modeling"
 license = "MIT"
 requires-python = ">=3.10"

--- a/team/wire/.claude-plugin/plugin.json
+++ b/team/wire/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wire",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Design Team \u2014 Wire: Prototyping and handoff \u2014 interactive flow docs, component specs, developer handoff",
   "author": {
     "name": "tonone-ai",

--- a/team/zero/.claude-plugin/plugin.json
+++ b/team/zero/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zero",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Security Operations Team \u2014 Zero: Zero trust architecture \u2014 network segmentation, identity-based access, microsegmentation design",
   "author": {
     "name": "tonone-ai",


### PR DESCRIPTION
## Summary
- Extended `apex-plan`'s S/M/L scoping menu to six tiers (XS through XXL) — XS is a single specialist, no review, for fast/dirty spikes; XXL is the full relevant roster in parallel with an adversarial review pass for major builds/migrations.
- Ported the same XS-XXL tiers to `helm-plan` as a new Step 0, so product scoping asks "how deep" the same way engineering scoping does (Helm alone at XS/S, full Product team in parallel at XXL).
- Same treatment applied to `agents/apex.md`'s persona-level S/M/L block for consistency, plus a small README example update.
- Checked the other 8 teams (Ops, Legal, Design, Data Science, SecOps, DevEx, Infra, AI Ops) for an equivalent lead/orchestrator role — none exists (flat peer rosters), so depth-tier scoping stays Apex + Helm only for now.
- Version bumped 1.10.3 → 1.11.0 across all `plugin.json`/`pyproject.toml` files and `marketplace.json` entries via `scripts/bump-version.py`. CHANGELOG.md and ELEPHANT.md updated via `/elephant changelog`.

## Test plan
- [x] `pytest tests/test_structure.py tests/test_agent_compliance.py tests/test_skill_compliance.py` — 38 passed
- [x] `python scripts/bump-version.py --check` — all files at 1.11.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
*— [tonone](https://second.tonone.ai)*