### PR TITLE
Fix 11 agents that fail claude plugin install (form, budget, deploy, embed, evals, guard, prompt, proof, rank, token, trace)

### DIFF
--- a/team/budget/.claude-plugin/plugin.json
+++ b/team/budget/.claude-plugin/plugin.json
@@ -1,32 +1,17 @@
 {
   "name": "budget",
   "version": "1.13.0",
-  "description": "AI Operations Team \u2014 Budget: LLM spend tracking, model cost optimization, budget alerts, and token efficiency audits across AI workloads.",
+  "description": "AI Operations Team — Budget: LLM spend tracking, model cost optimization, budget alerts, and token efficiency audits across AI workloads.",
   "author": {
     "name": "tonone-ai",
     "url": "https://tonone.ai"
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["agents", "ai-ops-team", "ai-ops", "llm"],
-  "agents": [
-    {
-      "name": "Budget",
-      "path": "agents/budget.md"
-    }
-  ],
-  "skills": [
-    {
-      "name": "budget-audit",
-      "path": "skills/budget-audit/SKILL.md"
-    },
-    {
-      "name": "budget-optimize",
-      "path": "skills/budget-optimize/SKILL.md"
-    },
-    {
-      "name": "budget-recon",
-      "path": "skills/budget-recon/SKILL.md"
-    }
+  "keywords": [
+    "agents",
+    "ai-ops-team",
+    "ai-ops",
+    "llm"
   ]
 }

--- a/team/deploy/.claude-plugin/plugin.json
+++ b/team/deploy/.claude-plugin/plugin.json
@@ -1,32 +1,17 @@
 {
   "name": "deploy",
   "version": "1.13.0",
-  "description": "AI Operations Team \u2014 Deploy: Model serving, inference APIs, blue/green deploys, rollback, and canary releases for production ML.",
+  "description": "AI Operations Team — Deploy: Model serving, inference APIs, blue/green deploys, rollback, and canary releases for production ML.",
   "author": {
     "name": "tonone-ai",
     "url": "https://tonone.ai"
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["agents", "ai-ops-team", "ai-ops", "llm"],
-  "agents": [
-    {
-      "name": "Deploy",
-      "path": "agents/deploy.md"
-    }
-  ],
-  "skills": [
-    {
-      "name": "deploy-serve",
-      "path": "skills/deploy-serve/SKILL.md"
-    },
-    {
-      "name": "deploy-canary",
-      "path": "skills/deploy-canary/SKILL.md"
-    },
-    {
-      "name": "deploy-recon",
-      "path": "skills/deploy-recon/SKILL.md"
-    }
+  "keywords": [
+    "agents",
+    "ai-ops-team",
+    "ai-ops",
+    "llm"
   ]
 }

--- a/team/embed/.claude-plugin/plugin.json
+++ b/team/embed/.claude-plugin/plugin.json
@@ -1,32 +1,17 @@
 {
   "name": "embed",
   "version": "1.13.0",
-  "description": "AI Operations Team \u2014 Embed: Embedding model selection, vector pipeline design, similarity search, and production index management.",
+  "description": "AI Operations Team — Embed: Embedding model selection, vector pipeline design, similarity search, and production index management.",
   "author": {
     "name": "tonone-ai",
     "url": "https://tonone.ai"
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["agents", "ai-ops-team", "ai-ops", "llm"],
-  "agents": [
-    {
-      "name": "Embed",
-      "path": "agents/embed.md"
-    }
-  ],
-  "skills": [
-    {
-      "name": "embed-design",
-      "path": "skills/embed-design/SKILL.md"
-    },
-    {
-      "name": "embed-search",
-      "path": "skills/embed-search/SKILL.md"
-    },
-    {
-      "name": "embed-recon",
-      "path": "skills/embed-recon/SKILL.md"
-    }
+  "keywords": [
+    "agents",
+    "ai-ops-team",
+    "ai-ops",
+    "llm"
   ]
 }

--- a/team/evals/.claude-plugin/plugin.json
+++ b/team/evals/.claude-plugin/plugin.json
@@ -1,32 +1,17 @@
 {
   "name": "evals",
   "version": "1.13.0",
-  "description": "AI Operations Team \u2014 Evals: Eval harness design, benchmark suites, automated regression, and human eval pipeline orchestration.",
+  "description": "AI Operations Team — Evals: Eval harness design, benchmark suites, automated regression, and human eval pipeline orchestration.",
   "author": {
     "name": "tonone-ai",
     "url": "https://tonone.ai"
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["agents", "ai-ops-team", "ai-ops", "llm"],
-  "agents": [
-    {
-      "name": "Evals",
-      "path": "agents/evals.md"
-    }
-  ],
-  "skills": [
-    {
-      "name": "eval-harness",
-      "path": "skills/eval-harness/SKILL.md"
-    },
-    {
-      "name": "eval-regress",
-      "path": "skills/eval-regress/SKILL.md"
-    },
-    {
-      "name": "eval-recon",
-      "path": "skills/eval-recon/SKILL.md"
-    }
+  "keywords": [
+    "agents",
+    "ai-ops-team",
+    "ai-ops",
+    "llm"
   ]
 }

--- a/team/form/.claude-plugin/plugin.json
+++ b/team/form/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "form",
   "version": "1.13.0",
-  "description": "Visual designer \u2014 brand identity, color systems, typography, UI design, and design systems",
+  "description": "Visual designer — brand identity, color systems, typography, UI design, and design systems",
   "author": {
     "name": "tonone-ai",
     "url": "https://tonone.ai"
@@ -16,75 +16,5 @@
     "logo",
     "design-system",
     "product-team"
-  ],
-  "skills": [
-    {
-      "name": "form-brand",
-      "path": "skills/form-brand/skill.md"
-    },
-    {
-      "name": "form-logo",
-      "path": "skills/form-logo/skill.md"
-    },
-    {
-      "name": "form-web",
-      "path": "skills/form-web/skill.md"
-    },
-    {
-      "name": "form-mobile",
-      "path": "skills/form-mobile/skill.md"
-    },
-    {
-      "name": "form-deck",
-      "path": "skills/form-deck/skill.md"
-    },
-    {
-      "name": "form-social",
-      "path": "skills/form-social/skill.md"
-    },
-    {
-      "name": "form-email",
-      "path": "skills/form-email/skill.md"
-    },
-    {
-      "name": "form-component",
-      "path": "skills/form-component/skill.md"
-    },
-    {
-      "name": "form-audit",
-      "path": "skills/form-audit/skill.md"
-    },
-    {
-      "name": "form-tokens",
-      "path": "skills/form-tokens/skill.md"
-    },
-    {
-      "name": "form-exam",
-      "path": "skills/form-exam/skill.md"
-    },
-    {
-      "name": "form-palette",
-      "path": "skills/form-palette/skill.md"
-    },
-    {
-      "name": "form-style",
-      "path": "skills/form-style/skill.md"
-    },
-    {
-      "name": "form-direction",
-      "path": "skills/form-direction/skill.md"
-    },
-    {
-      "name": "form-animate",
-      "path": "skills/form-animate/skill.md"
-    },
-    {
-      "name": "form-critique",
-      "path": "skills/form-critique/skill.md"
-    },
-    {
-      "name": "form-brief",
-      "path": "skills/form-brief/skill.md"
-    }
   ]
 }

--- a/team/guard/.claude-plugin/plugin.json
+++ b/team/guard/.claude-plugin/plugin.json
@@ -1,32 +1,17 @@
 {
   "name": "guard",
   "version": "1.13.0",
-  "description": "AI Operations Team \u2014 Guard: Input/output safety filters, PII detection, content moderation, and AI policy enforcement at runtime.",
+  "description": "AI Operations Team — Guard: Input/output safety filters, PII detection, content moderation, and AI policy enforcement at runtime.",
   "author": {
     "name": "tonone-ai",
     "url": "https://tonone.ai"
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["agents", "ai-ops-team", "ai-ops", "llm"],
-  "agents": [
-    {
-      "name": "Guard",
-      "path": "agents/guard.md"
-    }
-  ],
-  "skills": [
-    {
-      "name": "guard-design",
-      "path": "skills/guard-design/SKILL.md"
-    },
-    {
-      "name": "guard-audit",
-      "path": "skills/guard-audit/SKILL.md"
-    },
-    {
-      "name": "guard-recon",
-      "path": "skills/guard-recon/SKILL.md"
-    }
+  "keywords": [
+    "agents",
+    "ai-ops-team",
+    "ai-ops",
+    "llm"
   ]
 }

--- a/team/prompt/.claude-plugin/plugin.json
+++ b/team/prompt/.claude-plugin/plugin.json
@@ -1,32 +1,17 @@
 {
   "name": "prompt",
   "version": "1.13.0",
-  "description": "AI Operations Team \u2014 Prompt: System prompt design, few-shot libraries, chain-of-thought patterns, and prompt versioning for production LLM applications.",
+  "description": "AI Operations Team — Prompt: System prompt design, few-shot libraries, chain-of-thought patterns, and prompt versioning for production LLM applications.",
   "author": {
     "name": "tonone-ai",
     "url": "https://tonone.ai"
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["agents", "ai-ops-team", "ai-ops", "llm"],
-  "agents": [
-    {
-      "name": "Prompt",
-      "path": "agents/prompt.md"
-    }
-  ],
-  "skills": [
-    {
-      "name": "prompt-design",
-      "path": "skills/prompt-design/SKILL.md"
-    },
-    {
-      "name": "prompt-version",
-      "path": "skills/prompt-version/SKILL.md"
-    },
-    {
-      "name": "prompt-recon",
-      "path": "skills/prompt-recon/SKILL.md"
-    }
+  "keywords": [
+    "agents",
+    "ai-ops-team",
+    "ai-ops",
+    "llm"
   ]
 }

--- a/team/proof/.claude-plugin/plugin.json
+++ b/team/proof/.claude-plugin/plugin.json
@@ -1,38 +1,18 @@
 {
   "name": "proof",
   "version": "1.13.0",
-  "description": "QA & testing engineer \u2014 test strategy, E2E suites, integration testing, test infrastructure, flaky test triage",
+  "description": "QA & testing engineer — test strategy, E2E suites, integration testing, test infrastructure, flaky test triage",
   "author": {
     "name": "tonone-ai",
     "url": "https://tonone.ai"
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["testing", "qa", "e2e", "integration", "playwright"],
-  "skills": [
-    {
-      "name": "proof-strategy",
-      "path": "skills/proof-strategy/skill.md"
-    },
-    {
-      "name": "proof-e2e",
-      "path": "skills/proof-e2e/skill.md"
-    },
-    {
-      "name": "proof-api",
-      "path": "skills/proof-api/skill.md"
-    },
-    {
-      "name": "proof-audit",
-      "path": "skills/proof-audit/skill.md"
-    },
-    {
-      "name": "proof-recon",
-      "path": "skills/proof-recon/skill.md"
-    },
-    {
-      "name": "proof-design",
-      "path": "skills/proof-design/skill.md"
-    }
+  "keywords": [
+    "testing",
+    "qa",
+    "e2e",
+    "integration",
+    "playwright"
   ]
 }

--- a/team/rank/.claude-plugin/plugin.json
+++ b/team/rank/.claude-plugin/plugin.json
@@ -1,32 +1,17 @@
 {
   "name": "rank",
   "version": "1.13.0",
-  "description": "AI Operations Team \u2014 Rank: Retrieval reranking, relevance scoring, learning-to-rank pipelines, and result quality evaluation for search and RAG.",
+  "description": "AI Operations Team — Rank: Retrieval reranking, relevance scoring, learning-to-rank pipelines, and result quality evaluation for search and RAG.",
   "author": {
     "name": "tonone-ai",
     "url": "https://tonone.ai"
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["agents", "ai-ops-team", "ai-ops", "llm"],
-  "agents": [
-    {
-      "name": "Rank",
-      "path": "agents/rank.md"
-    }
-  ],
-  "skills": [
-    {
-      "name": "rank-design",
-      "path": "skills/rank-design/SKILL.md"
-    },
-    {
-      "name": "rank-eval",
-      "path": "skills/rank-eval/SKILL.md"
-    },
-    {
-      "name": "rank-recon",
-      "path": "skills/rank-recon/SKILL.md"
-    }
+  "keywords": [
+    "agents",
+    "ai-ops-team",
+    "ai-ops",
+    "llm"
   ]
 }

--- a/team/token/.claude-plugin/plugin.json
+++ b/team/token/.claude-plugin/plugin.json
@@ -1,32 +1,17 @@
 {
   "name": "token",
   "version": "1.13.0",
-  "description": "AI Operations Team \u2014 Token: Context window optimization, token counting, truncation strategies, and chunking patterns for LLM efficiency.",
+  "description": "AI Operations Team — Token: Context window optimization, token counting, truncation strategies, and chunking patterns for LLM efficiency.",
   "author": {
     "name": "tonone-ai",
     "url": "https://tonone.ai"
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["agents", "ai-ops-team", "ai-ops", "llm"],
-  "agents": [
-    {
-      "name": "Token",
-      "path": "agents/token.md"
-    }
-  ],
-  "skills": [
-    {
-      "name": "token-budget",
-      "path": "skills/token-budget/SKILL.md"
-    },
-    {
-      "name": "token-chunk",
-      "path": "skills/token-chunk/SKILL.md"
-    },
-    {
-      "name": "token-recon",
-      "path": "skills/token-recon/SKILL.md"
-    }
+  "keywords": [
+    "agents",
+    "ai-ops-team",
+    "ai-ops",
+    "llm"
   ]
 }

--- a/team/trace/.claude-plugin/plugin.json
+++ b/team/trace/.claude-plugin/plugin.json
@@ -1,32 +1,17 @@
 {
   "name": "trace",
   "version": "1.13.0",
-  "description": "AI Operations Team \u2014 Trace: LLM tracing, span capture, prompt/completion logging, cost attribution, and AI system debugging.",
+  "description": "AI Operations Team — Trace: LLM tracing, span capture, prompt/completion logging, cost attribution, and AI system debugging.",
   "author": {
     "name": "tonone-ai",
     "url": "https://tonone.ai"
   },
   "repository": "https://github.com/tonone-ai/tonone",
   "license": "MIT",
-  "keywords": ["agents", "ai-ops-team", "ai-ops", "llm"],
-  "agents": [
-    {
-      "name": "Trace",
-      "path": "agents/trace.md"
-    }
-  ],
-  "skills": [
-    {
-      "name": "trace-instrument",
-      "path": "skills/trace-instrument/SKILL.md"
-    },
-    {
-      "name": "trace-debug",
-      "path": "skills/trace-debug/SKILL.md"
-    },
-    {
-      "name": "trace-recon",
-      "path": "skills/trace-recon/SKILL.md"
-    }
+  "keywords": [
+    "agents",
+    "ai-ops-team",
+    "ai-ops",
+    "llm"
   ]
 }

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -62,6 +62,30 @@ def test_plugin_json_required_fields():
             assert field in data, f"{agent}/plugin.json: missing '{field}'"
 
 
+def test_plugin_json_skills_and_agents_are_not_stale_arrays():
+    """
+    plugin.json must not carry 'skills' or 'agents' as an array of {name, path}
+    objects — that shape belongs to the per-skill-plugin generator removed in
+    1.13.0 and fails install-time schema validation outright (confirmed via
+    `claude plugin install`, not just `claude plugin validate`). The other 89
+    agents omit both keys and rely on auto-discovery; that's the only shape
+    that installs. 11 agents (budget, deploy, embed, evals, form, guard,
+    prompt, proof, rank, token, trace) shipped with the stale array shape in
+    1.13.0 and could not be installed standalone — exactly the granularity
+    apex-profile depends on.
+    """
+    for agent in AGENTS:
+        p = REPO / "team" / agent / ".claude-plugin" / "plugin.json"
+        data = json.loads(p.read_text())
+        for key in ("skills", "agents"):
+            value = data.get(key)
+            assert not isinstance(value, list), (
+                f"{agent}/plugin.json: '{key}' is a stale array of "
+                f"{{name, path}} objects — this fails `claude plugin install "
+                f"{agent}@tonone-ai`. Remove the key; auto-discovery covers it."
+            )
+
+
 def test_agent_definitions_not_empty():
     """Agent definitions must be substantive (>= 50 lines) — not placeholder stubs."""
     for agent_file in sorted((REPO / "agents").glob("*.md")):


### PR DESCRIPTION
## What's broken

`claude plugin install form@tonone-ai` (and 10 others) fails:

```
✘ Failed to install plugin "form@tonone-ai": invalid manifest file
   Validation errors: skills: Invalid input
```

11 of the 100 `team/*/.claude-plugin/plugin.json` manifests declare `skills`
(and, for 9 of them, `agents`) as an array of `{name, path}` objects. That's
leftover shape from the per-skill-plugin generator `scripts/gen-skill-plugins.py`
removed in 1.13.0 — the other 89 agents omit both keys entirely and rely on
auto-discovery, which is the only shape that actually installs.

Affected: `budget` `deploy` `embed` `evals` `form` `guard` `prompt` `proof`
`rank` `token` `trace`.

This directly undermines #118/apex-profile — the whole point of scoping down
to a curated agent subset breaks for up to 11% of the roster, including
`form`, the design agent and (by a fair bit) the heaviest single agent in the
repo.

## The fix

Removed the stale `skills`/`agents` keys from all 11 manifests, matching the
shape every working agent already uses.

**Verified against a live install, not just `claude plugin validate`** — I
registered the fixed tree as a local marketplace and ran
`claude plugin install form@tonone-ai` for real: fails on `main`, installs
clean with this branch.

I also checked `hooks/hooks.json`'s array shape, which `claude plugin validate`
separately flags on `form` and `proof` (`hooks: Invalid input: expected
record, received array`). `flux` and `spine` ship the identical array shape
and install fine, so that one isn't an actual blocker — left it alone rather
than bundling an unverified change into this PR.

## Regression test

`tests/test_structure.py` already tracks "plugin.json schema violations →
HIGH impact (plugin registry won't parse)" in its own risk-map docstring, but
had no test for this specific shape. Added
`test_plugin_json_skills_and_agents_are_not_stale_arrays`. Confirmed red
against the pre-fix manifests (isolated via `git stash push` on just the
`plugin.json` files, keeping the new test), green after.

## Test plan

- [x] Full suite: `pytest tests/` — 53 passed (52 on `main`, +1 new test)
- [x] New test fails against pre-fix manifests, passes against the fix
      (verified both directions)
- [x] `claude plugin install form@tonone-ai` fails on `main`, succeeds on this
      branch (tested against a local marketplace override, not just schema
      validation)
- [x] `claude plugin validate team/<agent>` passes for all 11 fixed manifests

🤖 Generated with [Claude Code](https://claude.com/code)